### PR TITLE
Feature/adjustments

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -121,7 +121,7 @@
   - type: RequireProjectileTarget
     active: False
   - type: AnimatedEmotes
-  - type: Fart
+  # - type: Fart
   - type: CollectiveMind # Goobstation - Starlight collective mind port
   - type: Penetratable # Goobstation - Better snipers
     penetrateDamage: 15 # Kill million mices

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -311,11 +311,11 @@
 - type: entity
   parent: PosterBase
   id: PosterContrabandCommunistState
-  name: "Communist State"
-  description: "All hail the Communist party!"
+  name: "Fun Police"
+  description: "A poster condemning the station's security forces."
   components:
   - type: Sprite
-    state: poster18_contraband
+    state: poster3_contraband
 
 - type: entity
   parent: PosterBase

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -243,7 +243,7 @@
   id: Nukeops
   components:
   - type: GameRule
-    minPlayers: 8
+    minPlayers: 20
   - type: LoadMapRule
     mapPath: /Maps/_Goobstation/Nonstations/nukieplanet.yml # goob edit
   - type: AntagSelection
@@ -334,7 +334,7 @@
     maxDifficulty: 5
 
 # Goobstation - order swapped since admin verbs use .Last() for some reason
-# TODO: Fix that
+# TODO: Fix that 
 - type: entity
   id: TraitorReinforcement
   parent: BaseTraitorRuleNoObjectives # Goobstation
@@ -375,7 +375,7 @@
   parent: BaseGameRule
   components:
   - type: GameRule
-    minPlayers: 8
+    minPlayers: 15
     chaosScore: 1000 # Goobstation
   - type: RevolutionaryRule
   - type: AntagSelection
@@ -463,7 +463,7 @@
   parent: BaseGameRule
   components:
   - type: GameRule
-    minPlayers: 8
+    minPlayers: 20
     delay:
       min: 600
       max: 900

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -90,7 +90,7 @@
   id: Box
   mapName: 'Бокс'
   mapPath: /Maps/_Goobstation/box.yml # Goobstation
-  minPlayers: 20 # Goobstation return minPlayers requirement for maps
+  minPlayers: 15 # Goobstation return minPlayers requirement for maps
   maxPlayers: 85 # Goobstation - Limit mappool to highpop versions of maps only
   stations:
     Boxstation:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -85,10 +85,10 @@
   icon: "JobIconPassenger"
   supervisors: job-supervisors-everyone
   goobcoins: 0 #Goob content
-  requirements:
-    - !type:OverallPlaytimeRequirement
-      time: 36000 #10 hrs
-      inverted: true # get a job you bum  
+#  requirements:
+#    - !type:OverallPlaytimeRequirement
+#      time: 36000 #10 hrs
+#      inverted: true # get a job you bum
 #  access:
 #  - Maintenance
 

--- a/Resources/Prototypes/_DV/CosmicCult/roundstart.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/roundstart.yml
@@ -12,7 +12,7 @@
   components:
   - type: CosmicCultRule
   - type: GameRule
-    minPlayers: 8
+    minPlayers: 25
     chaosScore: 1200
     delay:
       min: 60

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Fun/immovable_rod.yml
@@ -6,18 +6,20 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #Goobstation - add a skibidi toilet as an immovable rod sprite
-- type: entity
-  parent: ImmovableRodKeepTilesStill
-  id: ImmovableRodSkibidi
-  name: immovable Skibidi
-  description: skibidi dob dob yes yes
-  components:
-  - type: Sprite
-    sprite: _Goobstation/Mobs/Demons/skibidi.rsi
-    drawdepth: Mobs
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-    state: icon
-    rotation: 0
-    noRot: false
+# Pirate V
+#- type: entity
+#  parent: ImmovableRodKeepTilesStill
+#  id: ImmovableRodSkibidi
+#  name: immovable Skibidi
+#  description: skibidi dob dob yes yes
+#  components:
+#  - type: Sprite
+#    sprite: _Goobstation/Mobs/Demons/skibidi.rsi
+#    drawdepth: Mobs
+#    layers:
+#      - map: [ "enum.DamageStateVisualLayers.Base" ]
+#        state: alive
+#    state: icon
+#    rotation: 0
+#    noRot: false
+# Pirate ^

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -33,7 +33,7 @@
   components:
   - type: ChangelingRule
   - type: GameRule
-    minPlayers: 8
+    minPlayers: 15
     chaosScore: 800
   - type: AntagRandomObjectives
     sets:
@@ -65,7 +65,7 @@
   id: CalmTraitor # For Dual Antag Gamemodes
   components:
   - type: GameRule
-    minPlayers: 10
+    minPlayers: 30
     chaosScore: 700
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
@@ -89,7 +89,7 @@
   id: CalmLing # For Dual Antag Gamemodes
   components:
   - type: GameRule
-    minPlayers: 10
+    minPlayers: 30
     chaosScore: 450
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
@@ -110,7 +110,7 @@
   id: Calmops # For Dual Antag Gamemodes
   components:
   - type: GameRule
-    minPlayers: 10
+    minPlayers: 30
     chaosScore: 1000
   - type: LoadMapRule
     mapPath: /Maps/_Goobstation/Nonstations/nukieplanet.yml
@@ -180,7 +180,7 @@
   parent: BaseGameRule
   components:
   - type: GameRule
-    minPlayers: 10
+    minPlayers: 30
     chaosScore: 700
   - type: RevolutionaryRule
   - type: AntagSelection
@@ -219,7 +219,7 @@
   components:
   - type: BlobRule
   - type: GameRule
-    minPlayers: 8
+    minPlayers: 15
     chaosScore: 1000
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
@@ -343,7 +343,7 @@
   - type: DevilRule
   - type: GameRule
     chaosScore: 350 # low since they tend to revive people and stuff
-    minPlayers: 8
+    minPlayers: 15
   - type: AntagObjectives
     objectives:
     - DevilContractObjective

--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -20,7 +20,7 @@
   components:
   - type: HereticRule
   - type: GameRule
-    minPlayers: 5
+    minPlayers: 15
     chaosScore: 800
   - type: AntagObjectives
     objectives:
@@ -51,7 +51,7 @@
   components:
   - type: HereticRule
   - type: GameRule
-    minPlayers: 8
+    minPlayers: 15
   - type: AntagObjectives
     objectives:
     - HereticKnowledgeObjective

--- a/Resources/Prototypes/_Goobstation/SoundCollections/emotes.yml
+++ b/Resources/Prototypes/_Goobstation/SoundCollections/emotes.yml
@@ -7,12 +7,12 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-- type: soundCollection
-  id: Fart
-  files:
-    - /Audio/_Goobstation/Voice/Human/fart2.ogg
-    - /Audio/_Goobstation/Voice/Human/fart3.ogg
-    - /Audio/_Goobstation/Voice/Human/fart4.ogg
+# - type: soundCollection
+#   id: Fart
+#   files:
+#     - /Audio/_Goobstation/Voice/Human/fart2.ogg
+#     - /Audio/_Goobstation/Voice/Human/fart3.ogg
+#     - /Audio/_Goobstation/Voice/Human/fart4.ogg
 
 - type: soundCollection
   id: Jump

--- a/Resources/Prototypes/_Goobstation/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/_Goobstation/Voice/speech_emotes.yml
@@ -9,134 +9,134 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-- type: emote
-  id: Fart
-  name: chat-emote-name-fart
-  category: Farts
-  icon: _Goobstation/Interface/Emotes/fart.png
-  whitelist:
-    components:
-    - Vocal
-  blacklist:
-    components:
-    - BorgChassis
-    - Silicon
-  chatMessages: ["chat-emote-msg-fart"]
-  chatTriggers:
-    - fart
-    - farts
-    - farting
-    - farted
-    - toot
-    - toots
-    - tooted
-    - tooting
-    - pass gas
-    - passes gas
-    - passing gas
-    - passed gas
-    - break wind
-    - breaks wind
-    - breaking wind
-    - broke wind
-    - flatulate
-    - flatulates
-    - flatulating
-    - flatulated
-    - let one rip
-    - lets one rip
-    - letting one rip
-    - cut cheese
-    - cuts cheese
-    - cutting cheese
-    - cut the cheese
-    - cuts the cheese
-    - cutting the cheese
-    - let out a stinker
-    - lets out a stinker
-    - letting out a stinker
-    - exhales anally
-    - burps from the rear
-    - burps from the butt
-    - bowel howl
-    - bowel howls
-    - bowel howling
-    - bowel howled
-    - accelerates climate change
+# - type: emote
+#   id: Fart
+#   name: chat-emote-name-fart
+#   category: Farts
+#   icon: _Goobstation/Interface/Emotes/fart.png
+#   whitelist:
+#     components:
+#     - Vocal
+#   blacklist:
+#     components:
+#     - BorgChassis
+#     - Silicon
+#   chatMessages: ["chat-emote-msg-fart"]
+#   chatTriggers:
+#     - fart
+#     - farts
+#     - farting
+#     - farted
+#     - toot
+#     - toots
+#     - tooted
+#     - tooting
+#     - pass gas
+#     - passes gas
+#     - passing gas
+#     - passed gas
+#     - break wind
+#     - breaks wind
+#     - breaking wind
+#     - broke wind
+#     - flatulate
+#     - flatulates
+#     - flatulating
+#     - flatulated
+#     - let one rip
+#     - lets one rip
+#     - letting one rip
+#     - cut cheese
+#     - cuts cheese
+#     - cutting cheese
+#     - cut the cheese
+#     - cuts the cheese
+#     - cutting the cheese
+#     - let out a stinker
+#     - lets out a stinker
+#     - letting out a stinker
+#     - exhales anally
+#     - burps from the rear
+#     - burps from the butt
+#     - bowel howl
+#     - bowel howls
+#     - bowel howling
+#     - bowel howled
+#     - accelerates climate change
+#
+# - type: emote
+#   id: FartInhale
+#   name: chat-emote-name-fart-inhale
+#   category: Farts
+#   icon: _Goobstation/Interface/Emotes/fart-in.png
+#   whitelist:
+#     components:
+#     - Vocal
+#   blacklist:
+#     components:
+#     - BorgChassis
+#     - Silicon
+#   chatMessages: ["chat-emote-msg-fart-inhale"]
+#   chatTriggers:
+#     - inhale anally
+#     - inhales anally
+#     - inhaling anally
+#     - inhaled anally
+#     - anally inhale
+#     - anally inhales
+#     - anally inhaling
+#     - anally inhaled
+#     - farts backward
+#     - fart backward
+#     - fart in
+#     - farts in
+#     - farting in
+#     - farted in
+#     - inhales through the rear
+#     - inhales through rear
+#     - inhales through the butt
+#     - inhales through butt
+#     - inhales through the anus
+#     - inhales through anus
+#     - inhales through the rectum
+#     - inhales through rectum
+#     - inhales through the ass
+#     - inhales through ass
+#     - buttreathes in
+#     - breathes in through butt
+#
+# - type: emote
+#   id: FartSuper
+#   name: chat-emote-name-fart-super
+#   category: Farts
+#   icon: _Goobstation/Interface/Emotes/fart-super.png
+#   whitelist:
+#     components:
+#     - Vocal
+#   blacklist:
+#     components:
+#     - BorgChassis
+#     - Silicon
+#   chatMessages: ["chat-emote-msg-fart-super"]
+#   chatTriggers:
+#     - superfart
+#     - superfarts
+#     - superfarted
+#     - superfarting
+#     - super fart
+#     - super farts
+#     - super farted
+#     - super farting
+#     - ultrafart
+#     - ultrafarts
+#     - ultrafarted
+#     - ultrafarting
+#     - ultra fart
+#     - ultra farts
+#     - ultra farted
+#     - ultra farting
 
 - type: emote
-  id: FartInhale
-  name: chat-emote-name-fart-inhale
-  category: Farts
-  icon: _Goobstation/Interface/Emotes/fart-in.png
-  whitelist:
-    components:
-    - Vocal
-  blacklist:
-    components:
-    - BorgChassis
-    - Silicon
-  chatMessages: ["chat-emote-msg-fart-inhale"]
-  chatTriggers:
-    - inhale anally
-    - inhales anally
-    - inhaling anally
-    - inhaled anally
-    - anally inhale
-    - anally inhales
-    - anally inhaling
-    - anally inhaled
-    - farts backward
-    - fart backward
-    - fart in
-    - farts in
-    - farting in
-    - farted in
-    - inhales through the rear
-    - inhales through rear
-    - inhales through the butt
-    - inhales through butt
-    - inhales through the anus
-    - inhales through anus
-    - inhales through the rectum
-    - inhales through rectum
-    - inhales through the ass
-    - inhales through ass
-    - buttreathes in
-    - breathes in through butt
-
-- type: emote
-  id: FartSuper
-  name: chat-emote-name-fart-super
-  category: Farts
-  icon: _Goobstation/Interface/Emotes/fart-super.png
-  whitelist:
-    components:
-    - Vocal
-  blacklist:
-    components:
-    - BorgChassis
-    - Silicon
-  chatMessages: ["chat-emote-msg-fart-super"]
-  chatTriggers:
-    - superfart
-    - superfarts
-    - superfarted
-    - superfarting
-    - super fart
-    - super farts
-    - super farted
-    - super farting
-    - ultrafart
-    - ultrafarts
-    - ultrafarted
-    - ultrafarting
-    - ultra fart
-    - ultra farts
-    - ultra farted
-    - ultra farting
-
-- type: emote 
   id: Flap
   name: chat-emote-name-flap
   category: Vocal

--- a/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
@@ -20,7 +20,7 @@
   components:
   - type: WizardRule
   - type: GameRule
-    minPlayers: 8
+    minPlayers: 30
     chaosScore: 900
   - type: AntagObjectives
     objectives:

--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -239,7 +239,7 @@
     - survivalnew
   name: survivalplus-title
   description: survivalplus-description
-  showInVot: true
+  showInVote: true
   minPlayers: 30 # Pirate
   rules:
     - SecretPlusRampingMid

--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -239,7 +239,8 @@
     - survivalnew
   name: survivalplus-title
   description: survivalplus-description
-  showInVote: true
+  showInVot: true
+  minPlayers: 30 # Pirate
   rules:
     - SecretPlusRampingMid
     - LavalandStormScheduler

--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -183,7 +183,7 @@
   name: guide-title
   description: guide-description
   showInVote: false
-  minPlayers: 8
+  minPlayers: 25
   rules:
     - CombatDynamic
     - LavalandStormScheduler

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -245,7 +245,7 @@
   name: death-match-title
   description: death-match-description
   maxPlayers: 15
-  showInVote: true
+  showInVote: false # Pirate
   supportedMaps: DeathMatchMapPool
   rules:
     - DeathMatch31

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -214,7 +214,7 @@
     - sandbox
   name: sandbox-title
   description: sandbox-description
-  showInVote: false # Not suitable for use without admin intervention, since entity spamming can quickly crash a server
+  showInVote: true # Not suitable for use without admin intervention, since entity spamming can quickly crash a server
   maxPlayers: 5
   rules:
     - Sandbox
@@ -277,7 +277,7 @@
   description: rev-description
   showInVote: false
   rules:
-  - DummyNonAntagChance  
+  - DummyNonAntagChance
   - Revolutionary
   - SubGamemodesRule
   - BasicStationEventScheduler


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
This PR introduces balance changes by increasing the minimum player count (`minPlayers`) for most antagonist roles. It also removes some "meme" content, specifically fart-related emotes and sounds, and updates some posters and role requirements.

## Why / Balance
Increasing the `minPlayers` for antagonist modes like Nukeops, Traitor, Cult, and Wizard is an important balancing change. It ensures that intense and potentially round-disruptive roles only appear when there are enough players on the server to create an interesting and balanced gameplay experience. On low-population servers, these modes often lead to a quick and uninteresting end to the round.

The removal of the fart-related content is an effort to clean up and adjust the overall tone of the game.

## Technical details
- Changed the `minPlayers` value in many `.yml` files in `Resources/Prototypes/GameRules/`, `Resources/Prototypes/_Goobstation/GameRules/`, and others.
- Commented out or removed the `Fart` component and related definitions in `Resources/Prototypes/Entities/Mobs/base.yml`, `Resources/Prototypes/_Goobstation/SoundCollections/emotes.yml`, and `Resources/Prototypes/_Goobstation/Voice/speech_emotes.yml`.
- Updated a poster definition in `Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml`.
- Commented out the requirements for the Passenger role in `Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml`.
- Commented out the `ImmovableRodSkibidi` variant in `Resources/Prototypes/_Goobstation/Entities/Objects/Fun/immovable_rod.yml`.

## Media
This PR does not require media as the changes are mostly related to configuration and content removal.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

**Changelog**

:cl:
- tweak: Increased the minimum player requirements for most antagonist roles to improve game balance on low-population servers.
- remove: Removed the fart emote and its associated sounds.
- tweak: Replaced the "Communist State" poster with a "Fun Police" poster.
- tweak: The Passenger role no longer has a playtime requirement.
- tweak: The Sandbox and Deathmatch presets have had their visibility in the voting menu swapped.
