### PR TITLE
Auto vote system

### DIFF
--- a/Content.Pirate.Common/Voting/LobbyReadyUpEvent.cs
+++ b/Content.Pirate.Common/Voting/LobbyReadyUpEvent.cs
@@ -1,0 +1,6 @@
+namespace Content.Pirate.Common.Voting
+{
+    public sealed class LobbyReadyUpEvent : EntityEventArgs
+    {
+    }
+}

--- a/Content.Pirate.Server/Voting/AutoVoteSystem.cs
+++ b/Content.Pirate.Server/Voting/AutoVoteSystem.cs
@@ -1,0 +1,48 @@
+using Content.Server.GameTicking;
+using Content.Server.Voting.Managers;
+using Content.Pirate.Common.Voting;
+using Content.Shared.GameTicking;
+using Content.Shared.Voting;
+using Robust.Server.Player;
+using Robust.Shared.Configuration;
+
+namespace Content.Pirate.Server.Voting
+{
+    public sealed class AutoVoteSystem : EntitySystem
+    {
+        [Dependency] private readonly IConfigurationManager _cfg = default!;
+        [Dependency] private readonly IVoteManager _voteManager = default!;
+        [Dependency] private readonly IPlayerManager _playerManager = default!;
+
+        private bool _shouldVoteNextJoin = false;
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<LobbyReadyUpEvent>(OnLobbyReadyUp);
+            SubscribeLocalEvent<PlayerJoinedLobbyEvent>(OnPlayerJoinedLobby);
+        }
+
+        private void OnLobbyReadyUp(LobbyReadyUpEvent ev)
+        {
+            if (_playerManager.PlayerCount == 0)
+            {
+                _shouldVoteNextJoin = true;
+                return;
+            }
+
+            _voteManager.CreateStandardVote(null, StandardVoteType.Map);
+            _voteManager.CreateStandardVote(null, StandardVoteType.Preset);
+        }
+
+        private void OnPlayerJoinedLobby(PlayerJoinedLobbyEvent ev)
+        {
+            if (!_shouldVoteNextJoin)
+                return;
+
+            OnLobbyReadyUp(new LobbyReadyUpEvent());
+            _shouldVoteNextJoin = false;
+        }
+    }
+}

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -88,6 +88,7 @@ using Content.Server.Roles;
 using Content.Shared.CCVar;
 using Content.Shared.Database;
 using Content.Shared.GameTicking;
+using Content.Pirate.Common.Voting;
 using Content.Shared.Mind;
 using Content.Shared.Players;
 using Content.Shared.Preferences;
@@ -795,6 +796,7 @@ namespace Content.Server.GameTicking
             // Round restart cleanup event, so entity systems can reset.
             var ev = new RoundRestartCleanupEvent();
             RaiseLocalEvent(ev);
+            RaiseLocalEvent(new LobbyReadyUpEvent()); // Pirate
 
             // So clients' entity systems can clean up too...
             RaiseNetworkEvent(ev);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
This PR introduces an automatic voting system. When a round ends and the server returns to the lobby, it will now automatically start the standard votes for the next map and game preset.

## Why / Balance
This is a quality-of-life improvement that automates the round-end process. Previously, an admin had to manually start the map and preset votes. This change streamlines the flow between rounds, ensuring that voting begins promptly without manual intervention. It also includes logic to handle an empty server, initiating the vote as soon as the first player joins the lobby.

## Technical details
- A new `AutoVoteSystem` has been created in `Content.Pirate.Server` to manage the automatic initiation of votes.
- A new `LobbyReadyUpEvent` has been added to `Content.Pirate.Common` to signal that the lobby is ready for voting.
- The `GameTicker`'s `ResettingCleanup` method is modified to raise the `LobbyReadyUpEvent` after a round ends.
- The `AutoVoteSystem` listens for this event and, if players are present, creates the map and preset votes.
- If the lobby is empty when the round restarts, the system will wait for the first `PlayerJoinedLobbyEvent` to trigger the votes.

## Media
This PR contains no visual changes and does not require media.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

**Changelog**

:cl:
- add: Added an auto-vote system. Map and game preset votes will now start automatically when the round ends.
