### PR TITLE
Salvage Shuttle

### DIFF
--- a/Resources/Maps/_Pirate/Shuttles/shuttle_salvage.yml
+++ b/Resources/Maps/_Pirate/Shuttles/shuttle_salvage.yml
@@ -1,0 +1,1867 @@
+meta:
+  format: 6
+  category: Grid
+  postmapinit: false
+tilemap:
+  0: Space
+  64: FloorLino
+  66: FloorMetalDiamond
+  68: FloorMining
+  70: FloorMiningLight
+  123: FloorWoodLarge
+  125: Lattice
+  126: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: map 2215
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: PhysicsMap
+    - type: GridTree
+    - type: MovedGrids
+    - type: Broadphase
+    - type: OccluderTree
+    - type: LoadedMap
+  - uid: 2
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      pos: -0.36967927,-1.6496731
+      parent: 1
+    - type: SalvageShuttle
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: RAAAAAAARAAAAAAARAAAAAAARAAAAAAARAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAARAAAAAAARAAAAAAARAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAARAAAAAAARAAAAAAARAAAAAAARAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAARAAAAAAARAAAAAAARAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAewAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAewAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAQgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAQgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQgAAAAAAQgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARgAAAAAARgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARgAAAAAARgAAAAAARgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARgAAAAAARgAAAAAARgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAARAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAARAAAAAAARAAAAAAARAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAARAAAAAAARAAAAAAARAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAARAAAAAAARAAAAAAARAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAARAAAAAAARAAAAAAARAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAARAAAAAAARAAAAAAARAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfgAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfgAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAARgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAARgAAAAAARgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfQAAAAAAfgAAAAAARgAAAAAARgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAARAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAARAAAAAAARAAAAAAARAAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            22: -3,3
+            23: -2,3
+            24: -1,3
+            25: 3,3
+            26: 2,3
+            27: 1,3
+            28: 0,-1
+            29: 3,-1
+            37: -3,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: Box
+          decals:
+            30: 3,1
+            31: 2,1
+            32: -2,1
+            33: -3,1
+        - node:
+            color: '#0CFFFFFF'
+            id: BoxGreyscale
+          decals:
+            38: 0,1
+            39: 0,7
+            40: -2,5
+            41: -1,5
+        - node:
+            angle: 6.283185307179586 rad
+            color: '#FFFFFFFF'
+            id: Caution
+          decals:
+            44: 1.9347682,-3.823842
+        - node:
+            angle: 4.71238898038469 rad
+            color: '#FFFFFFFF'
+            id: LoadingArea
+          decals:
+            42: 3,2
+            43: 3,0
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnEndN
+          decals:
+            18: -4,2
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnEndS
+          decals:
+            19: -4,0
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineE
+          decals:
+            20: -4,1
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            11: 2,8
+            12: 2,7
+            21: -4,1
+        - node:
+            angle: 4.71238898038469 rad
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            45: 2,6
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSe
+          decals:
+            0: -1,7
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineE
+          decals:
+            1: -1,8
+            2: -1,9
+            3: -1,10
+            7: 1,7
+            8: 1,8
+            9: 1,9
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineN
+          decals:
+            16: 0,9
+            17: 1,9
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineS
+          decals:
+            4: -2,7
+        - node:
+            cleanable: True
+            color: '#0CFFFFFF'
+            id: heart
+          decals:
+            36: -0.32708877,-2.693675
+        - node:
+            cleanable: True
+            color: '#0CFFFFFF'
+            id: q
+          decals:
+            34: 1.5738986,4.7820377
+        - node:
+            cleanable: True
+            color: '#0CFFFFFF'
+            id: snake
+          decals:
+            35: -1.0770888,-4.7583256
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 65535
+          0,1:
+            0: 30591
+            1: 34944
+          0,2:
+            0: 887
+            1: 31880
+          0,-2:
+            0: 28672
+            1: 36608
+          0,-1:
+            0: 65399
+            1: 136
+          -1,0:
+            0: 61166
+            1: 4369
+          -1,1:
+            0: 52430
+            1: 8753
+          -1,2:
+            0: 3276
+            1: 49698
+          -1,-1:
+            0: 61132
+            1: 4402
+          -1,-2:
+            0: 49152
+            1: 11776
+          1,0:
+            1: 4369
+          1,1:
+            1: 17
+          1,-1:
+            1: 4368
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 22
+          - 78
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: NavMap
+    - type: RadiationGridResistance
+  - uid: 227
+    components:
+    - type: MetaData
+    - type: Transform
+      parent: 226
+    - type: Solution
+      solution:
+        maxVol: 1
+        name: food
+        reagents:
+        - ReagentId: Fiber
+          Quantity: 1
+    - type: ContainedSolution
+      containerName: food
+      container: 226
+  - uid: 235
+    components:
+    - type: MetaData
+    - type: Transform
+      parent: 234
+    - type: Solution
+      solution:
+        maxVol: 1
+        name: food
+        reagents:
+        - ReagentId: Fiber
+          Quantity: 1
+    - type: ContainedSolution
+      containerName: food
+      container: 234
+- proto: AirCanister
+  entities:
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+- proto: AirlockSalvageGlassLocked
+  entities:
+  - uid: 177
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 2
+  - uid: 178
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-1.5
+      parent: 2
+  - uid: 179
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 2
+- proto: AirlockShuttleSyndicate
+  entities:
+  - uid: 197
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 2
+  - uid: 198
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 2
+- proto: APCBasic
+  entities:
+  - uid: 77
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 2
+  - uid: 78
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 2
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 2
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 2
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 2
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 2
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 2
+- proto: Autolathe
+  entities:
+  - uid: 193
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 2
+- proto: BlastDoorWindows
+  entities:
+  - uid: 218
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 221
+      - 223
+  - uid: 219
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 221
+      - 223
+  - uid: 220
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 221
+      - 223
+- proto: BodyBagFolded
+  entities:
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 2.730495,7.1014633
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 2.2624106,7.080187
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+- proto: Bucket
+  entities:
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 3.4430563,-0.5480062
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+- proto: ButtonFrameCautionSecurity
+  entities:
+  - uid: 210
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,9.5
+      parent: 2
+- proto: CableApcExtension
+  entities:
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 2
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 2
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 2
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 2
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 2
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 2
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 2
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 2
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 2
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 2
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 2
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 2
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 2
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 2
+  - uid: 37
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 2
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 2
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 2
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 2
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 2
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 46
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 2
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 2
+  - uid: 48
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 2
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 2
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 2
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 2
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 2
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 2
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 2
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 61
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 2
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 2
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 2
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 2
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 2
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 2
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 2
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 2
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 2
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 2
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 2
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 2
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 2
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 2
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 2
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+- proto: CableHV
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 2
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+- proto: CableMV
+  entities:
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 2
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 2
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 2
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 2
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 2
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 2
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 2
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 2
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 2
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 2
+- proto: ChairPilotSeat
+  entities:
+  - uid: 189
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,9.5
+      parent: 2
+- proto: ComfyChair
+  entities:
+  - uid: 191
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 2
+  - uid: 192
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 2
+- proto: ComputerSalvageExpedition
+  entities:
+  - uid: 180
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 2
+- proto: ComputerShuttle
+  entities:
+  - uid: 182
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 2
+- proto: CrateEmptySpawner
+  entities:
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 2
+  - uid: 215
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 2
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 2
+- proto: FoodBoxDonut
+  entities:
+  - uid: 243
+    components:
+    - type: Transform
+      pos: -0.525953,9.44694
+      parent: 2
+- proto: FoodShakerSalt
+  entities:
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 2.835749,-3.0219717
+      parent: 2
+- proto: Fulton
+  entities:
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 0.44500053,1.5682487
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+- proto: FultonBeacon
+  entities:
+  - uid: 236
+    components:
+    - type: Transform
+      pos: 0.48780566,1.6021973
+      parent: 2
+- proto: GasDualPortVentPump
+  entities:
+  - uid: 83
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,1.5
+      parent: 2
+- proto: GasPipeBend
+  entities:
+  - uid: 85
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 2
+  - uid: 87
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-0.5
+      parent: 2
+- proto: GasPipeStraight
+  entities:
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 2
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 2
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 2
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 2
+- proto: GasPort
+  entities:
+  - uid: 82
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 2
+- proto: GasVentPump
+  entities:
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 2
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+- proto: GeneratorWallmountBasic
+  entities:
+  - uid: 228
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 2
+- proto: Grille
+  entities:
+  - uid: 140
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 2
+  - uid: 149
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 2
+  - uid: 150
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 2
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 2
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 2
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 2
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 2
+  - uid: 155
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 2
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 2
+  - uid: 157
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 158
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 2
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+  - uid: 160
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 2
+  - uid: 161
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 162
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 2
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 164
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+  - uid: 199
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,11.5
+      parent: 2
+  - uid: 200
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,11.5
+      parent: 2
+  - uid: 201
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,11.5
+      parent: 2
+- proto: GrilleDiagonal
+  entities:
+  - uid: 147
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,11.5
+      parent: 2
+  - uid: 148
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 2
+- proto: Gyroscope
+  entities:
+  - uid: 81
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-3.5
+      parent: 2
+- proto: HandHeldMassScanner
+  entities:
+  - uid: 217
+    components:
+    - type: Transform
+      pos: -0.28306526,10.5892725
+      parent: 2
+- proto: LockerSalvageSpecialist
+  entities:
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 2
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 2
+- proto: MaterialCloth
+  entities:
+  - uid: 232
+    components:
+    - type: Transform
+      pos: -1.7039359,8.605473
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+- proto: MedkitAdvancedFilled
+  entities:
+  - uid: 212
+    components:
+    - type: Transform
+      pos: -1.4486163,8.605473
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+- proto: MiningWindow
+  entities:
+  - uid: 119
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 2
+  - uid: 125
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 2
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 2
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 2
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 2
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 2
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 2
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 2
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 2
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 2
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 2
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 2
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 137
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 2
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 2
+  - uid: 141
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 2
+  - uid: 142
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+- proto: MopItem
+  entities:
+  - uid: 213
+    components:
+    - type: Transform
+      pos: 3.4856093,-0.61183655
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+- proto: OreBag
+  entities:
+  - uid: 194
+    components:
+    - type: Transform
+      pos: -1.5433547,3.5809207
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+  - uid: 225
+    components:
+    - type: Transform
+      pos: -1.565687,3.5550363
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+  - uid: 229
+    components:
+    - type: Transform
+      pos: -1.565687,3.5550363
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+- proto: OreProcessor
+  entities:
+  - uid: 238
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 2
+- proto: OxygenCanister
+  entities:
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 2
+- proto: Paper
+  entities:
+  - uid: 226
+    components:
+    - type: MetaData
+      name: printed paper
+    - type: Transform
+      pos: -0.375,10.201199
+      parent: 2
+    - type: Paper
+      stampState: paper_stamp-ce
+      stampedBy:
+      - stampedColor: '#C69B17FF'
+        stampedName: stamp-component-stamped-name-ce
+      - stampedColor: '#006600FF'
+        stampedName: stamp-component-stamped-name-centcom
+      content: >-
+        [color=#d0c020]███░███░░░░██░░░░[/color]
+
+        [color=#d0c020]░██░████░░░██░░░░[/color][head=3]Бланк документа[/head]
+
+        [color=#d0c020]░░█░██░██░░██░█░░[/color][head=3]NanoTrasen[/head]
+
+        [color=#d0c020]░░░░██░░██░██░██░[/color][bold]Шатл EX-908-TY[/bold]
+
+        [color=#d0c020]░░░░██░░░████░███[/color]
+
+        ====================================================[color=#d0c020][bold]      Реєстраційний локумент [/bold]   [/color]
+
+        ====================================================
+
+        1. Номер шатлу EX-908-TY
+
+        2. Категорія С1
+
+        3. Розгонні двигуни(4)
+
+        4. Маневрові двигуни(6)
+
+        5. Повздовжні габарити(18)
+
+        6. Поперечні габарити(9)
+
+        7. Клас: "кедр-в1-3"
+
+        ====================================================
+    - type: SolutionContainerManager
+      solutions: null
+      containers:
+      - food
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.25,-0.25
+            - 0.25,-0.25
+            - 0.25,0.25
+            - -0.25,0.25
+          mask:
+          - Impassable
+          - HighImpassable
+          layer: []
+          density: 20
+          hard: True
+          restitution: 0.3
+          friction: 0.2
+        flammable:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+            position: 0,0
+          mask:
+          - MidImpassable
+          - HighImpassable
+          - LowImpassable
+          - BulletImpassable
+          - InteractImpassable
+          - Opaque
+          layer: []
+          density: 1
+          hard: False
+          restitution: 0
+          friction: 0.4
+    - type: ContainerContainer
+      containers:
+        solution@food: !type:ContainerSlot
+          ent: 227
+  - uid: 234
+    components:
+    - type: MetaData
+      name: printed paper
+    - type: Transform
+      pos: -0.625,10.32633
+      parent: 2
+    - type: Paper
+      stampState: paper_stamp-centcom
+      stampedBy:
+      - stampedColor: '#006600FF'
+        stampedName: stamp-component-stamped-name-centcom
+      content: >+
+        [color=#096107]███░███░░░░██░░░░[/color]
+
+        [color=#096107]░██░████░░░██░░░░[/color]       [head=3]Бланк документа[/head]
+
+        [color=#096107]░░█░██░██░░██░█░░[/color]       [head=3]NanoTrasen[/head]
+
+        [color=#096107]░░░░██░░██░██░██░[/color]       [bold][/bold]
+
+        [color=#096107]░░░░██░░░████░███[/color]
+          ==================================================
+                                               [bold]Лист від ОЦК[/bold]
+          ==================================================
+        [bold]   |До:[/bold][italic]командування станцій[/italic]
+
+        [bold]   |Від:[/bold][italic]від Ліліан Бейкер[/italic]
+
+        [bold]   |Дата:[/bold][italic]26.03.2470[/italic]
+
+        [bold]   |Підпис:[/bold][italic]✨✨✨[/italic]
+
+        [bold]   |Тема:[/bold][italic]оновлення шатлів[/italic]
+          ==================================================
+        [italic]Вітаю шановне командування, мушу повідомити що відповідно до наказу №65437, була дозволена експлуатація шатлів типу "кедр" котрі пройшли усю сертифікацію, та перевірку у справжніх умовах видобутку та утилізації космічного сміття. Тому керуючись накозом №65437 ми надішлемо на станції оновленні шатли для утилізаторів та шахтарів, шатли старого зразка мають бути відправлені до найближчого ремонтного посту корпорації "Нанотрейсен"    [/italic]
+
+
+    - type: SolutionContainerManager
+      solutions: null
+      containers:
+      - food
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.25,-0.25
+            - 0.25,-0.25
+            - 0.25,0.25
+            - -0.25,0.25
+          mask:
+          - Impassable
+          - HighImpassable
+          layer: []
+          density: 20
+          hard: True
+          restitution: 0.3
+          friction: 0.2
+        flammable:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+            position: 0,0
+          mask:
+          - MidImpassable
+          - HighImpassable
+          - LowImpassable
+          - BulletImpassable
+          - InteractImpassable
+          - Opaque
+          layer: []
+          density: 1
+          hard: False
+          restitution: 0
+          friction: 0.4
+    - type: ContainerContainer
+      containers:
+        solution@food: !type:ContainerSlot
+          ent: 235
+- proto: Pickaxe
+  entities:
+  - uid: 185
+    components:
+    - type: Transform
+      pos: -1.5220783,3.5383677
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+  - uid: 186
+    components:
+    - type: Transform
+      pos: -1.5433547,3.5383677
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+  - uid: 224
+    components:
+    - type: Transform
+      pos: -1.4795253,3.6021972
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+- proto: PlastitaniumWindowDiagonal
+  entities:
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 2
+  - uid: 146
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,11.5
+      parent: 2
+- proto: PortableScrubber
+  entities:
+  - uid: 174
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 2
+- proto: Poweredlight
+  entities:
+  - uid: 165
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 166
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 2
+  - uid: 167
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 2
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 2
+- proto: PoweredSmallLight
+  entities:
+  - uid: 176
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-3.5
+      parent: 2
+- proto: RemoteSignaller
+  entities:
+  - uid: 223
+    components:
+    - type: Transform
+      pos: -0.12946808,9.842247
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        218:
+        - Pressed: Toggle
+        219:
+        - Pressed: Toggle
+        220:
+        - Pressed: Toggle
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+- proto: SalvageLocator
+  entities:
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+- proto: SignalButton
+  entities:
+  - uid: 221
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,9.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        220:
+        - Pressed: Toggle
+        219:
+        - Pressed: Toggle
+        218:
+        - Pressed: Toggle
+- proto: SignSalvage
+  entities:
+  - uid: 196
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 2
+- proto: SubstationBasic
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 2
+- proto: TableReinforced
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 2
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 2
+- proto: TableReinforcedGlass
+  entities:
+  - uid: 190
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,8.5
+      parent: 2
+- proto: Thruster
+  entities:
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 2
+  - uid: 203
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 2
+  - uid: 204
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,5.5
+      parent: 2
+  - uid: 205
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,5.5
+      parent: 2
+  - uid: 206
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-2.5
+      parent: 2
+  - uid: 207
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 2
+  - uid: 208
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-5.5
+      parent: 2
+  - uid: 209
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-5.5
+      parent: 2
+- proto: VendingMachineSalvage
+  entities:
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 2
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 2
+- proto: WallReinforced
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 2
+  - uid: 95
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 2
+  - uid: 96
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 2
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 2
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 2
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 2
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 2
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 2
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 2
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 2
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 2
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 2
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 2
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 2
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 2
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 2
+  - uid: 112
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 2
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 114
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 115
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 2
+  - uid: 116
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 2
+  - uid: 117
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 2
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 2
+  - uid: 121
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 2
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 2
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 2
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 2
+- proto: WaterTankFull
+  entities:
+  - uid: 175
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+...

--- a/Resources/Maps/_Pirate/box.yml
+++ b/Resources/Maps/_Pirate/box.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 260.2.0
   forkId: ""
   forkVersion: ""
-  time: 08/13/2025 00:23:27
-  entityCount: 29086
+  time: 08/13/2025 00:31:09
+  entityCount: 29088
 maps:
 - 1
 grids:
@@ -12677,7 +12677,7 @@ entities:
       pos: -13.5,18.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -25181.67
+      secondsUntilStateChange: -25313.865
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -14573,7 +14573,7 @@ entities:
       pos: 41.5,11.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -125789.89
+      secondsUntilStateChange: -125922.086
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -18330,11 +18330,6 @@ entities:
     components:
     - type: Transform
       pos: -2.5,23.5
-      parent: 2
-  - uid: 1041
-    components:
-    - type: Transform
-      pos: -6.5,31.5
       parent: 2
   - uid: 1042
     components:
@@ -72992,6 +72987,11 @@ entities:
     - type: Transform
       pos: 20.572916,-36.34928
       parent: 2
+  - uid: 29088
+    components:
+    - type: Transform
+      pos: -9.255636,30.467669
+      parent: 2
 - proto: ClothingMaskClown
   entities:
   - uid: 11238
@@ -75971,7 +75971,7 @@ entities:
       pos: 28.5,-5.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -64353.836
+      secondsUntilStateChange: -64486.03
       state: Opening
   - uid: 11643
     components:
@@ -89971,7 +89971,7 @@ entities:
       pos: -34.5,-14.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -199524.44
+      secondsUntilStateChange: -199656.64
       state: Closing
   - uid: 13875
     components:
@@ -90405,7 +90405,7 @@ entities:
       pos: -4.5,-71.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -191272.17
+      secondsUntilStateChange: -191404.38
       state: Closing
   - uid: 13961
     components:
@@ -132434,6 +132434,11 @@ entities:
       parent: 2
 - proto: MedicalBed
   entities:
+  - uid: 1041
+    components:
+    - type: Transform
+      pos: -6.5,31.5
+      parent: 2
   - uid: 19872
     components:
     - type: Transform
@@ -133197,6 +133202,11 @@ entities:
     components:
     - type: Transform
       pos: 54.482033,-24.522997
+      parent: 2
+  - uid: 29087
+    components:
+    - type: Transform
+      pos: -9.552511,30.57712
       parent: 2
 - proto: NTDefaultCircuitBoard
   entities:

--- a/Resources/Maps/_Pirate/box.yml
+++ b/Resources/Maps/_Pirate/box.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 260.2.0
   forkId: ""
   forkVersion: ""
-  time: 07/31/2025 13:59:00
+  time: 08/12/2025 23:16:25
   entityCount: 29080
 maps:
 - 1
@@ -12677,7 +12677,7 @@ entities:
       pos: -13.5,18.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -24750.637
+      secondsUntilStateChange: -24924.28
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -13646,6 +13646,14 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -67.5,-9.5
       parent: 2
+  - uid: 317
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -44.5,-30.5
+      parent: 2
+    - type: GridFill
+      path: /Maps/_Pirate/Shuttles/shuttle_salvage.yml
 - proto: AirlockExternalGlassShuttleLocked
   entities:
   - uid: 316
@@ -13653,12 +13661,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,-28.5
-      parent: 2
-  - uid: 317
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -44.5,-30.5
       parent: 2
 - proto: AirlockExternalGlassShuttleMiningFilled
   entities:
@@ -14571,7 +14573,7 @@ entities:
       pos: 41.5,11.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -125358.86
+      secondsUntilStateChange: -125532.5
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -74008,11 +74010,6 @@ entities:
     - type: Transform
       pos: -26.5,-36.5
       parent: 2
-  - uid: 11408
-    components:
-    - type: Transform
-      pos: -25.5,-36.5
-      parent: 2
 - proto: ComputerCargoBounty
   entities:
   - uid: 11409
@@ -74311,6 +74308,13 @@ entities:
     components:
     - type: Transform
       pos: 30.5,-105.5
+      parent: 2
+- proto: ComputerSalvageExpedition
+  entities:
+  - uid: 11408
+    components:
+    - type: Transform
+      pos: -25.5,-36.5
       parent: 2
 - proto: ComputerShuttleCargo
   entities:
@@ -75962,7 +75966,7 @@ entities:
       pos: 28.5,-5.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -63922.8
+      secondsUntilStateChange: -64096.445
       state: Opening
   - uid: 11643
     components:
@@ -89962,7 +89966,7 @@ entities:
       pos: -34.5,-14.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -199093.39
+      secondsUntilStateChange: -199267.05
       state: Closing
   - uid: 13875
     components:
@@ -90396,7 +90400,7 @@ entities:
       pos: -4.5,-71.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -190841.12
+      secondsUntilStateChange: -191014.78
       state: Closing
   - uid: 13961
     components:

--- a/Resources/Maps/_Pirate/box.yml
+++ b/Resources/Maps/_Pirate/box.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 260.2.0
   forkId: ""
   forkVersion: ""
-  time: 08/12/2025 23:16:25
-  entityCount: 29080
+  time: 08/13/2025 00:23:27
+  entityCount: 29086
 maps:
 - 1
 grids:
@@ -12677,7 +12677,7 @@ entities:
       pos: -13.5,18.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -24924.28
+      secondsUntilStateChange: -25181.67
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -14573,7 +14573,7 @@ entities:
       pos: 41.5,11.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -125532.5
+      secondsUntilStateChange: -125789.89
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -17977,7 +17977,7 @@ entities:
   - uid: 979
     components:
     - type: Transform
-      pos: 63.5,-7.5
+      pos: 62.506294,-7.4618998
       parent: 2
 - proto: BananaPhoneInstrument
   entities:
@@ -72739,7 +72739,12 @@ entities:
   - uid: 11196
     components:
     - type: Transform
-      pos: -6.591975,45.713867
+      pos: -7.6675434,45.40586
+      parent: 2
+  - uid: 19917
+    components:
+    - type: Transform
+      pos: -5.4644184,45.40586
       parent: 2
 - proto: ClothingHeadHatCowboyRed
   entities:
@@ -74003,13 +74008,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 42.5,-19.5
       parent: 2
-- proto: ComputerBroken
-  entities:
-  - uid: 11407
-    components:
-    - type: Transform
-      pos: -26.5,-36.5
-      parent: 2
 - proto: ComputerCargoBounty
   entities:
   - uid: 11409
@@ -74150,6 +74148,13 @@ entities:
     components:
     - type: Transform
       pos: -19.5,-29.5
+      parent: 2
+- proto: ComputerFrame
+  entities:
+  - uid: 20106
+    components:
+    - type: Transform
+      pos: -26.5,-36.5
       parent: 2
 - proto: ComputerId
   entities:
@@ -74485,10 +74490,10 @@ entities:
       parent: 2
 - proto: ConstructionBarricade
   entities:
-  - uid: 11485
+  - uid: 11407
     components:
     - type: Transform
-      pos: -7.5,45.5
+      pos: -6.5,45.5
       parent: 2
 - proto: ContainmentFieldGenerator
   entities:
@@ -75966,7 +75971,7 @@ entities:
       pos: 28.5,-5.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -64096.445
+      secondsUntilStateChange: -64353.836
       state: Opening
   - uid: 11643
     components:
@@ -89966,7 +89971,7 @@ entities:
       pos: -34.5,-14.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -199267.05
+      secondsUntilStateChange: -199524.44
       state: Closing
   - uid: 13875
     components:
@@ -90400,7 +90405,7 @@ entities:
       pos: -4.5,-71.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -191014.78
+      secondsUntilStateChange: -191272.17
       state: Closing
   - uid: 13961
     components:
@@ -132680,6 +132685,11 @@ entities:
       parent: 2
 - proto: MopBucketFull
   entities:
+  - uid: 11485
+    components:
+    - type: Transform
+      pos: 10.5,23.5
+      parent: 2
   - uid: 19914
     components:
     - type: Transform
@@ -132697,17 +132707,17 @@ entities:
       parent: 2
     - type: Pullable
       prevFixedRotation: True
-  - uid: 19917
+  - uid: 23546
     components:
     - type: Transform
-      pos: -13.5,42.5
+      pos: -14.5,40.5
       parent: 2
 - proto: MopItem
   entities:
   - uid: 19918
     components:
     - type: Transform
-      pos: -13.416729,42.36579
+      pos: -14.563323,40.6047
       parent: 2
   - uid: 19919
     components:
@@ -132748,6 +132758,11 @@ entities:
     components:
     - type: Transform
       pos: 5.5582485,-36.455353
+      parent: 2
+  - uid: 29083
+    components:
+    - type: Transform
+      pos: 10.489876,23.512457
       parent: 2
 - proto: Morgue
   entities:
@@ -133235,6 +133250,13 @@ entities:
     components:
     - type: Transform
       pos: 53.5,-22.5
+      parent: 2
+- proto: OracleSpawner
+  entities:
+  - uid: 29081
+    components:
+    - type: Transform
+      pos: 67.5,-3.5
       parent: 2
 - proto: OreProcessor
   entities:
@@ -134053,13 +134075,6 @@ entities:
              призведе до розгерметизації приміщення.
         [color=#1b487e]▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰[/color]
                                     ⠀          [italic]Місце для печаток[/italic]
-  - uid: 20106
-    components:
-    - type: Transform
-      pos: -25.484888,-36.54078
-      parent: 2
-    - type: Paper
-      content: Забіг якийсь мудак і зламав консолі. Покличте інженера.
   - uid: 20107
     components:
     - type: Transform
@@ -134095,7 +134110,7 @@ entities:
   - uid: 20113
     components:
     - type: Transform
-      pos: -7.519591,45.46369
+      pos: -6.4956684,45.452766
       parent: 2
     - type: Paper
       content: Вихід в космос був забудованний з зв'язку з будівницством доку для шатла Служби Безпеки
@@ -140397,6 +140412,28 @@ entities:
     components:
     - type: Transform
       pos: -3.5,-14.5
+      parent: 2
+    - type: TechnologyDatabase
+      supportedDisciplines:
+      - Industrial
+      - Arsenal
+      - Experimental
+      - CivilianServices
+  - uid: 29085
+    components:
+    - type: Transform
+      pos: -3.5,-14.5
+      parent: 2
+    - type: TechnologyDatabase
+      supportedDisciplines:
+      - Industrial
+      - Arsenal
+      - Experimental
+      - CivilianServices
+  - uid: 29086
+    components:
+    - type: Transform
+      pos: 63.5,-7.5
       parent: 2
     - type: TechnologyDatabase
       supportedDisciplines:
@@ -153122,6 +153159,13 @@ entities:
       parent: 13589
     - type: Physics
       canCollide: False
+- proto: SophicScribeSpawner
+  entities:
+  - uid: 29082
+    components:
+    - type: Transform
+      pos: 71.5,-3.5
+      parent: 2
 - proto: SpaceVillainArcadeComputerCircuitboard
   entities:
   - uid: 23282
@@ -154648,12 +154692,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 81.5,-1.5
-      parent: 2
-  - uid: 23546
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,23.5
       parent: 2
   - uid: 23547
     components:
@@ -161302,12 +161340,12 @@ entities:
   - uid: 24597
     components:
     - type: Transform
-      pos: -13.218813,42.230278
+      pos: -14.3055105,40.370163
       parent: 2
   - uid: 24598
     components:
     - type: Transform
-      pos: -13.375063,42.15731
+      pos: -14.188323,40.463974
       parent: 2
   - uid: 24599
     components:
@@ -161343,6 +161381,11 @@ entities:
     components:
     - type: Transform
       pos: 2.6832485,-34.158478
+      parent: 2
+  - uid: 29084
+    components:
+    - type: Transform
+      pos: 10.818001,23.442097
       parent: 2
 - proto: TrashBagBlue
   entities:

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -869,7 +869,7 @@ LightTree06: LightTree
 
 # 2024-12-22 # Lavaland Change: Migrations
 VendingMachineRestockSalvageEquipment: null
-ComputerSalvageExpedition: ComputerShuttleMiningLavaland
+#ComputerSalvageExpedition: ComputerShuttleMiningLavaland
 SalvageExpeditionsComputerCircuitboard: LavalandShuttleConsoleCircuitboard
 
 # 2025-01-06


### PR DESCRIPTION
Додав на бокс шатл шахтарів і консоль для нього.
Одним словом: "ДО РОБОТИ РАБОТЯГИ"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fully equipped Salvage Shuttle map with atmospheric, gravity, pathfinding and environmental systems plus extensive salvage gear, furnishings and signage.
  * Added new salvage-related consoles, spawners, and utility devices for expedition play.

* **Changes**
  * Integrated the shuttle into the pirate map with a new dock area, many entity repositionings and layout adjustments; several door timings tweaked.

* **Chores**
  * Disabled a legacy migration entry for the Salvage Expedition console.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->