### PR TITLE
Add a "Фурі-томбой" alternative job name to a Captain

### DIFF
--- a/Resources/Locale/uk-UA/_Pirate/job/alternative-jobs.ftl
+++ b/Resources/Locale/uk-UA/_Pirate/job/alternative-jobs.ftl
@@ -48,6 +48,7 @@ job-description-monolith-preacher = Несамовитий голос Волі �
 
 # Command
 job-alternative-name-furry-femboy = Фурі-фембой
+job-alternative-name-furry-tomboy = Фурі-томбой
 job-alternative-name-command-officer = Офіцер командування
 job-alternative-name-station-director = Директор станції
 job-alternative-name-notarius = Нотаріус

--- a/Resources/Prototypes/_Pirate/Roles/Jobs/AlternativeJobs.yml
+++ b/Resources/Prototypes/_Pirate/Roles/Jobs/AlternativeJobs.yml
@@ -127,7 +127,14 @@
   jobDescription: job-description-captain
   jobIconProtoId: JobIconFurryFemboy
   parentJobId: Captain
-
+  
+- type: alternativeJob
+  id: AlternativeJobFurryTomboy
+  jobName: job-alternative-name-furry-tomboy
+  jobDescription: job-description-captain
+  jobIconProtoId: JobIconFurryFemboy
+  parentJobId: Captain
+  
 - type: alternativeJob
   id: AlternativeJobCommandOfficer
   jobName: job-alternative-name-command-officer


### PR DESCRIPTION
Because of [this](https://discord.com/channels/1158407971936677960/1412368808924024842), now we, hopefully, will have not only a "фурі-**фем**бой" but also a "фурі-**том**бой".

We are MRP. We are MRP. We are MRP. We are MRP. We are MRP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new alternative job option “Furry Tomboy” under the Command role set, available alongside existing alternatives.
  - Included localized naming for Ukrainian (Pirate) locale, ensuring the new option appears correctly in that language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->