### PR TITLE
Fixed psionic records missing some keys

### DIFF
--- a/Resources/Locale/uk-UA/psionics-records/psionics-records.ftl
+++ b/Resources/Locale/uk-UA/psionics-records/psionics-records.ftl
@@ -27,5 +27,7 @@ psionics-records-console-unknown-officer = <невідомий офіцер>
 
 psionics-records-filter-placeholder = Введіть текст і натисніть "Enter"
 psionics-records-name-filter = Ім'я
-psionics-records-prints-filter = Відбитки пальців
+psionics-records-job-filter = Робота
+psionics-records-species-filter = Вид
+psionics-records-prints-filter = Відбитки
 psionics-records-dna-filter = ДНК


### PR DESCRIPTION
Додано (не перенесений) переклад двох ключів для фільтрів для псіонічного комп'ютера.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Додано нові фільтри в українській локалізації: «Робота» та «Вид» у розділі записів псіоніки.
  * Оновлено назву фільтра «Відбитки пальців» до «Відбитки» для більш лаконічного відображення.

* **Виправлення**
  * Уточнено та впорядковано перекладені значення фільтрів, щоб забезпечити узгоджене відображення в інтерфейсі (значення для ДНК без змін).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->