### PR TITLE
нерфлю катану до (не)юзабельності

### DIFF
--- a/Content.Client/_Pirate/Weapons/Ranged/Systems/GunSystem.HitscanPrediction.cs
+++ b/Content.Client/_Pirate/Weapons/Ranged/Systems/GunSystem.HitscanPrediction.cs
@@ -76,7 +76,7 @@ public sealed partial class GunSystem
 
                 if (!ev.Reflected)
                 {
-                    blocked = TryAttemptHitscanBlock(user, gunUid, hit);
+                    blocked = TryAttemptHitscanBlock(user, gunUid, hit, hitscan);
                     FirePredictedHitscanEffects(effectCoordinates, result.Distance, dir.Normalized().ToAngle(), hitscan, blocked);
                     break;
                 }

--- a/Content.Server/_Pirate/Weapons/Ranged/Systems/GunSystem.Hitscan.cs
+++ b/Content.Server/_Pirate/Weapons/Ranged/Systems/GunSystem.Hitscan.cs
@@ -76,7 +76,7 @@ public sealed partial class GunSystem
 
                 if (!ev.Reflected)
                 {
-                    blocked = TryAttemptHitscanBlock(user, gunUid, hit);
+                    blocked = TryAttemptHitscanBlock(user, gunUid, hit, hitscan);
                     FireHitscanEffects(effectCoordinates, result.Distance, dir.Normalized().ToAngle(), hitscan, user, blocked);
                     break;
                 }

--- a/Content.Shared/Weapons/Melee/Events/AttackEvent.cs
+++ b/Content.Shared/Weapons/Melee/Events/AttackEvent.cs
@@ -68,11 +68,12 @@ namespace Content.Shared.Weapons.Melee.Events
     }
 
     // Goobstation start
-    public sealed class BeforeHarmfulActionEvent(EntityUid user, HarmfulActionType type) : CancellableEntityEventArgs
+    public sealed class BeforeHarmfulActionEvent(EntityUid user, HarmfulActionType type, DamageSpecifier? damage = null) : CancellableEntityEventArgs // Pirate: katana
     {
         public EntityUid User { get; } = user;
 
         public HarmfulActionType Type { get; } = type;
+        public DamageSpecifier? Damage { get; } = damage; // Pirate: katana
     }
 
     public enum HarmfulActionType : byte

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -893,7 +893,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                 continue;
 
             // Goobstation start
-            var beforeEvent = new BeforeHarmfulActionEvent(user, HarmfulActionType.Harm, damage); // Pirate: multiz
+            var beforeEvent = new BeforeHarmfulActionEvent(user, HarmfulActionType.Harm, damage); // Pirate: katana
             RaiseLocalEvent(entity, beforeEvent);
             if (beforeEvent.Cancelled)
                 continue;

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -735,7 +735,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         }
 
         // Goobstation start
-        var beforeEvent = new BeforeHarmfulActionEvent(user, HarmfulActionType.Harm);
+        var beforeEvent = new BeforeHarmfulActionEvent(user, HarmfulActionType.Harm, damage); // Pirate: katana
         RaiseLocalEvent(target.Value, beforeEvent);
         if (beforeEvent.Cancelled)
             return;
@@ -893,7 +893,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                 continue;
 
             // Goobstation start
-            var beforeEvent = new BeforeHarmfulActionEvent(user, HarmfulActionType.Harm);
+            var beforeEvent = new BeforeHarmfulActionEvent(user, HarmfulActionType.Harm, damage); // Pirate: multiz
             RaiseLocalEvent(entity, beforeEvent);
             if (beforeEvent.Cancelled)
                 continue;

--- a/Content.Shared/_Pirate/Weapons/Melee/Components/TimedDeflectBlockComponent.cs
+++ b/Content.Shared/_Pirate/Weapons/Melee/Components/TimedDeflectBlockComponent.cs
@@ -62,7 +62,7 @@ public sealed partial class TimedDeflectBlockComponent : Component
     public float StaminaReferenceDamage = 12f;
 
     [DataField]
-    public float DeflectWindowBonusPerLevel = 0.9f;
+    public float DeflectWindowBonusPerLevel = 0.09f;
 
     [DataField]
     public float DeflectLagCompensationMultiplier = 1.5f;

--- a/Content.Shared/_Pirate/Weapons/Melee/Components/TimedDeflectBlockComponent.cs
+++ b/Content.Shared/_Pirate/Weapons/Melee/Components/TimedDeflectBlockComponent.cs
@@ -59,7 +59,7 @@ public sealed partial class TimedDeflectBlockComponent : Component
     public float DeflectStaminaMultiplier = 1.2f;
 
     [DataField]
-    public float StaminaReferenceDamage = 10f;
+    public float StaminaReferenceDamage = 12f;
 
     [DataField]
     public float DeflectWindowBonusPerLevel = 0.9f;

--- a/Content.Shared/_Pirate/Weapons/Melee/Components/TimedDeflectBlockComponent.cs
+++ b/Content.Shared/_Pirate/Weapons/Melee/Components/TimedDeflectBlockComponent.cs
@@ -53,10 +53,10 @@ public sealed partial class TimedDeflectBlockComponent : Component
     public float BlockStaminaDamageReductionPerLevel = 0.005f;
 
     [DataField]
-    public float BlockStaminaMultiplier = 1.5f;
+    public float BlockStaminaMultiplier = 2;
 
     [DataField]
-    public float DeflectStaminaMultiplier = 0.5f;
+    public float DeflectStaminaMultiplier = 0.9f;
 
     [DataField]
     public float DeflectWindowBonusPerLevel = 0.15f;

--- a/Content.Shared/_Pirate/Weapons/Melee/Components/TimedDeflectBlockComponent.cs
+++ b/Content.Shared/_Pirate/Weapons/Melee/Components/TimedDeflectBlockComponent.cs
@@ -56,7 +56,10 @@ public sealed partial class TimedDeflectBlockComponent : Component
     public float BlockStaminaMultiplier = 2;
 
     [DataField]
-    public float DeflectStaminaMultiplier = 0.9f;
+    public float DeflectStaminaMultiplier = 1.2f;
+
+    [DataField]
+    public float StaminaReferenceDamage = 12f;
 
     [DataField]
     public float DeflectWindowBonusPerLevel = 0.15f;

--- a/Content.Shared/_Pirate/Weapons/Melee/Components/TimedDeflectBlockComponent.cs
+++ b/Content.Shared/_Pirate/Weapons/Melee/Components/TimedDeflectBlockComponent.cs
@@ -59,10 +59,10 @@ public sealed partial class TimedDeflectBlockComponent : Component
     public float DeflectStaminaMultiplier = 1.2f;
 
     [DataField]
-    public float StaminaReferenceDamage = 12f;
+    public float StaminaReferenceDamage = 10f;
 
     [DataField]
-    public float DeflectWindowBonusPerLevel = 0.15f;
+    public float DeflectWindowBonusPerLevel = 0.9f;
 
     [DataField]
     public float DeflectLagCompensationMultiplier = 1.5f;

--- a/Content.Shared/_Pirate/Weapons/Melee/TimedDeflectBlockSystem.cs
+++ b/Content.Shared/_Pirate/Weapons/Melee/TimedDeflectBlockSystem.cs
@@ -177,7 +177,7 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
         if (!TryGetActiveDeflectWeapon(ent, out var weapon, out var block) || block == null)
             return;
 
-        if (!ApplyDefense(ent.Owner, weapon, block, args.User, projectile: null, out _))
+        if (!ApplyDefense(ent.Owner, weapon, block, args.User, GetDamageTotal(args.Damage), projectile: null, out _))
             return;
 
         args.Cancel();
@@ -208,13 +208,13 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
 
         if (ent.Comp.DeflectToSource &&
             args.Args.Component.Shooter is { } shooter &&
-            TryDeflectProjectileToSource(args.Args.Target, ent.Owner, ent.Comp, shooter, args.Args.ProjUid, args.Args.Component))
+            TryDeflectProjectileToSource(args.Args.Target, ent.Owner, ent.Comp, shooter, GetDamageTotal(args.Args.Component.Damage), args.Args.ProjUid, args.Args.Component))
         {
             args.Args.Cancelled = true;
             return;
         }
 
-        if (!ApplyDefense(args.Args.Target, ent.Owner, ent.Comp, args.Args.Component.Shooter, args.Args.ProjUid, out _))
+        if (!ApplyDefense(args.Args.Target, ent.Owner, ent.Comp, args.Args.Component.Shooter, GetDamageTotal(args.Args.Component.Damage), args.Args.ProjUid, out _))
             return;
 
         args.Args.Cancelled = true;
@@ -229,7 +229,7 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
             args.Args.Shooter == null ||
             !TryComp<WieldableComponent>(ent, out var wieldable) ||
             !wieldable.Wielded ||
-            !TryApplyDirectedDeflect(args.Args.Target, ent.Owner, ent.Comp, args.Args.Shooter.Value))
+            !TryApplyDirectedDeflect(args.Args.Target, ent.Owner, ent.Comp, args.Args.Shooter.Value, GetDamageTotal(args.Args.Damage)))
         {
             return;
         }
@@ -252,7 +252,7 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
             return;
         }
 
-        if (!ApplyDefense(args.Args.Target, ent.Owner, ent.Comp, args.Args.Shooter, projectile: null, out _))
+        if (!ApplyDefense(args.Args.Target, ent.Owner, ent.Comp, args.Args.Shooter, GetDamageTotal(args.Args.Damage), projectile: null, out _))
             return;
 
         args.Args.Cancelled = true;
@@ -334,13 +334,14 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
         EntityUid defender,
         EntityUid weapon,
         TimedDeflectBlockComponent block,
-        EntityUid attacker)
+        EntityUid attacker,
+        float incomingDamage)
     {
         if (!CanDefendAgainst(defender, attacker) ||
             !IsWithinDeflectWindow(defender, block))
             return false;
 
-        ApplySuccessfulDeflect(defender, weapon, block, attacker);
+        ApplySuccessfulDeflect(defender, weapon, block, attacker, incomingDamage);
         RevealDefender(defender);
         return true;
     }
@@ -350,6 +351,7 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
         EntityUid weapon,
         TimedDeflectBlockComponent block,
         EntityUid attacker,
+        float incomingDamage,
         EntityUid projectileUid,
         ProjectileComponent projectile)
     {
@@ -373,7 +375,7 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
             return false;
 
         // All checks passed — apply deflect side effects (power gain, stamina, sound, stealth reveal).
-        if (!TryApplyDirectedDeflect(defender, weapon, block, attacker))
+        if (!TryApplyDirectedDeflect(defender, weapon, block, attacker, incomingDamage))
             return false;
 
         var desiredVelocity = direction * speed;
@@ -407,6 +409,7 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
         EntityUid weapon,
         TimedDeflectBlockComponent block,
         EntityUid? attacker,
+        float incomingDamage,
         EntityUid? projectile,
         out bool deflected)
     {
@@ -418,10 +421,10 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
         deflected = IsWithinDeflectWindow(defender, block);
 
         if (deflected)
-            ApplySuccessfulDeflect(defender, weapon, block, attacker);
+            ApplySuccessfulDeflect(defender, weapon, block, attacker, incomingDamage);
         else
         {
-            AdjustStamina(defender, GetBlockStaminaDamage(block), attacker, weapon);
+            AdjustStamina(defender, ScaleStaminaFraction(GetBlockStaminaDamage(block), block, incomingDamage), attacker, weapon);
             _audio.PlayPredicted(block.BlockSound, weapon, attacker);
         }
 
@@ -447,7 +450,8 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
         EntityUid defender,
         EntityUid weapon,
         TimedDeflectBlockComponent block,
-        EntityUid? attacker)
+        EntityUid? attacker,
+        float incomingDamage)
     {
         AddDeflectPower(weapon, block);
         block.DeflectWindowEnd = _timing.CurTime + TimeSpan.FromSeconds(GetDeflectWindow(block));
@@ -455,7 +459,7 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
         if (_net.IsServer)
             Dirty(weapon, block);
 
-        AdjustStamina(defender, GetDeflectStaminaCost(block), attacker, weapon);
+        AdjustStamina(defender, ScaleStaminaFraction(GetDeflectStaminaCost(block), block, incomingDamage), attacker, weapon);
         _sparks.DoSparks(Transform(weapon).Coordinates, minSparks: 1, maxSparks: 2, playSound: false);
         _audio.PlayPredicted(block.DeflectSound, weapon, attacker);
         TryBackflip(defender, block);
@@ -606,6 +610,18 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
         return GetBaseStaminaDamage(block) * block.DeflectStaminaMultiplier;
     }
 
+    private float ScaleStaminaFraction(float fraction, TimedDeflectBlockComponent block, float incomingDamage)
+    {
+        if (fraction <= 0f ||
+            incomingDamage <= 0f ||
+            block.StaminaReferenceDamage <= 0f)
+        {
+            return fraction;
+        }
+
+        return fraction * incomingDamage / block.StaminaReferenceDamage;
+    }
+
     private float GetBaseStaminaDamage(TimedDeflectBlockComponent block)
     {
         return MathF.Max(0f, block.BlockStaminaDamageFraction - GetLevel(block) * block.BlockStaminaDamageReductionPerLevel);
@@ -735,5 +751,10 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
     private string GetWieldedInhandState(string state)
     {
         return $"{state}-wielded";
+    }
+
+    private static float GetDamageTotal(DamageSpecifier? damage)
+    {
+        return damage?.GetTotal().Float() ?? 0f;
     }
 }

--- a/Content.Shared/_Pirate/Weapons/Melee/TimedDeflectBlockSystem.cs
+++ b/Content.Shared/_Pirate/Weapons/Melee/TimedDeflectBlockSystem.cs
@@ -177,7 +177,9 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
         if (!TryGetActiveDeflectWeapon(ent, out var weapon, out var block) || block == null)
             return;
 
-        ApplyDefense(ent.Owner, weapon, block, args.User, projectile: null, out var deflected);
+        if (!ApplyDefense(ent.Owner, weapon, block, args.User, projectile: null, out _))
+            return;
+
         args.Cancel();
 
         // If the attacker was wielding a TimedDeflectBlock weapon, break their grip —
@@ -212,7 +214,9 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
             return;
         }
 
-        ApplyDefense(args.Args.Target, ent.Owner, ent.Comp, args.Args.Component.Shooter, args.Args.ProjUid, out _);
+        if (!ApplyDefense(args.Args.Target, ent.Owner, ent.Comp, args.Args.Component.Shooter, args.Args.ProjUid, out _))
+            return;
+
         args.Args.Cancelled = true;
     }
 
@@ -248,7 +252,9 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
             return;
         }
 
-        ApplyDefense(args.Args.Target, ent.Owner, ent.Comp, args.Args.Shooter, projectile: null, out _);
+        if (!ApplyDefense(args.Args.Target, ent.Owner, ent.Comp, args.Args.Shooter, projectile: null, out _))
+            return;
+
         args.Args.Cancelled = true;
     }
 
@@ -330,7 +336,8 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
         TimedDeflectBlockComponent block,
         EntityUid attacker)
     {
-        if (!IsWithinDeflectWindow(defender, block))
+        if (!CanDefendAgainst(defender, attacker) ||
+            !IsWithinDeflectWindow(defender, block))
             return false;
 
         ApplySuccessfulDeflect(defender, weapon, block, attacker);
@@ -346,6 +353,9 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
         EntityUid projectileUid,
         ProjectileComponent projectile)
     {
+        if (!CanDefendAgainst(defender, attacker))
+            return false;
+
         // Validate all redirect prerequisites before committing any side effects.
         if (!TryComp<PhysicsComponent>(projectileUid, out var physics))
             return false;
@@ -392,7 +402,7 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
         return true;
     }
 
-    private void ApplyDefense(
+    private bool ApplyDefense(
         EntityUid defender,
         EntityUid weapon,
         TimedDeflectBlockComponent block,
@@ -400,6 +410,11 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
         EntityUid? projectile,
         out bool deflected)
     {
+        deflected = false;
+
+        if (!CanDefendAgainst(defender, attacker))
+            return false;
+
         deflected = IsWithinDeflectWindow(defender, block);
 
         if (deflected)
@@ -419,6 +434,13 @@ public sealed class TimedDeflectBlockSystem : EntitySystem
             RaiseLocalEvent(ref deleteEv);
             PredictedQueueDel(projectileUid);
         }
+
+        return true;
+    }
+
+    private static bool CanDefendAgainst(EntityUid defender, EntityUid? attacker)
+    {
+        return attacker == null || attacker != defender;
     }
 
     private void ApplySuccessfulDeflect(

--- a/Content.Shared/_Pirate/Weapons/Ranged/Events/HitScanBlockAttemptEvent.cs
+++ b/Content.Shared/_Pirate/Weapons/Ranged/Events/HitScanBlockAttemptEvent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Damage;
 using Robust.Shared.GameObjects;
 
 namespace Content.Shared._Pirate.Weapons.Ranged.Events;
@@ -7,4 +8,5 @@ public record struct HitScanBlockAttemptEvent(
     EntityUid? Shooter,
     EntityUid SourceItem,
     EntityUid Target,
+    DamageSpecifier? Damage = null,
     bool Cancelled = false);

--- a/Content.Shared/_Pirate/Weapons/Ranged/Systems/SharedGunSystem.Gunplay.cs
+++ b/Content.Shared/_Pirate/Weapons/Ranged/Systems/SharedGunSystem.Gunplay.cs
@@ -34,9 +34,9 @@ public abstract partial class SharedGunSystem
             Audio.PlayPredicted(gun.SoundGunshotModified, gunUid, user);
     }
 
-    protected bool TryAttemptHitscanBlock(EntityUid? user, EntityUid gunUid, EntityUid hitEntity)
+    protected bool TryAttemptHitscanBlock(EntityUid? user, EntityUid gunUid, EntityUid hitEntity, HitscanPrototype hitscan)
     {
-        var blockEv = new HitScanBlockAttemptEvent(user, gunUid, hitEntity);
+        var blockEv = new HitScanBlockAttemptEvent(user, gunUid, hitEntity, hitscan.Damage);
         RaiseLocalEvent(hitEntity, ref blockEv);
         return blockEv.Cancelled;
     }

--- a/Resources/Prototypes/_Goobstation/Entities/Thunderdome/thunderdome_gear.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Thunderdome/thunderdome_gear.yml
@@ -110,8 +110,8 @@
     belt: ClothingBeltDarkKatanaSheathUchigatanaFilled
   storage:
     back:
-      - Stimpack
-      - Stimpack
+      - StimpackMini
+      - StimpackMini
 #endregion Pirate: katana
 
 - type: startingGear


### PR DESCRIPTION
## Вимоги

- [x] Я прочитав та дотримуюсь [Правил запитів на злиття та журналу змін](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] цей запит на **злиття не потребує медіа**.


**Журнал змін**

:cl:
- fix: катана більше не блокує/відбиває удари по собі
- tweak: катана рахує скільки стаміни витратити відносно пошкоджень атаки (лвл 0 може заблочити максимум 72 дамага до стамкріта або відбити 132. лвл 6 - 132 і 216 відповідно)
- tweak: катана витрачає більше стаміни на блок і дефлект
- tweak: зменшив бонуси для вікна дефлектів (максимальне 1.4c  => 1.04с)
- tweak: набір з катаною на тандердромі має міні стімпаки замість звичайних



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Поточний реліз

* **Нові можливості**
  * Блокування та відбиття атак тепер враховують силу вхідних пошкоджень.

* **Баланс**
  * Налаштовано витрати витривалості для рукопашного бою та відбиття атак.
  * Оновлено стартове спорядження в Thunderdome арені.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->