### PR TITLE
Вогнетривкі фотографії

### DIFF
--- a/Content.Server/_Pirate/RoundEnd/PhotoAlbum/PhotoAlbumProtectionComponent.cs
+++ b/Content.Server/_Pirate/RoundEnd/PhotoAlbum/PhotoAlbumProtectionComponent.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Corvax Team Contributors
+// SPDX-FileCopyrightText: 2026 CyberLanos <cyber.lanos00@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+namespace Content.Server._Pirate.RoundEnd.PhotoAlbum;
+
+/// <summary>
+/// Marks an item while it is protected by a photo album.
+/// </summary>
+[RegisterComponent]
+public sealed partial class PhotoAlbumProtectionComponent : Component;

--- a/Content.Server/_Pirate/RoundEnd/PhotoAlbum/PhotoAlbumSystem.cs
+++ b/Content.Server/_Pirate/RoundEnd/PhotoAlbum/PhotoAlbumSystem.cs
@@ -6,9 +6,13 @@
 using System;
 using System.Linq;
 using Content.Server._Pirate.Photo;
+using Content.Server.Atmos.EntitySystems;
 using Content.Server.GameTicking;
 using Content.Server.Popups;
 using Content.Shared._Pirate.RoundEnd;
+using Content.Shared.Atmos;
+using Content.Shared.Damage;
+using Content.Shared.Destructible;
 using Content.Shared.Examine;
 using Content.Shared.GameTicking;
 using Content.Shared.Tag;
@@ -29,6 +33,7 @@ public sealed class PhotoAlbumSystem : EntitySystem
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly TagSystem _tags = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
+    [Dependency] private readonly FlammableSystem _flammable = default!;
     private readonly HashSet<EntityUid> _unsignedAutoSignAlbums = new();
     private readonly Dictionary<Guid, byte[]> _roundEndImageData = new();
 
@@ -47,6 +52,10 @@ public sealed class PhotoAlbumSystem : EntitySystem
         SubscribeLocalEvent<PhotoAlbumComponent, ComponentShutdown>(OnPhotoAlbumShutdown);
         SubscribeLocalEvent<PhotoAlbumComponent, EntInsertedIntoContainerMessage>(OnPhotoAlbumInserted);
         SubscribeLocalEvent<PhotoAlbumComponent, EntRemovedFromContainerMessage>(OnPhotoAlbumRemoved);
+
+        SubscribeLocalEvent<PhotoAlbumProtectionComponent, BeforeDamageChangedEvent>(OnProtectedPhotoDamaged);
+        SubscribeLocalEvent<PhotoAlbumProtectionComponent, DestructionAttemptEvent>(OnProtectedPhotoDestruction);
+        SubscribeLocalEvent<PhotoAlbumProtectionComponent, IgnitedEvent>(OnProtectedPhotoIgnited);
     }
 
     private void OnPhotoAlbumImageRequest(PhotoAlbumImageRequestEvent ev, EntitySessionEventArgs args)
@@ -62,6 +71,7 @@ public sealed class PhotoAlbumSystem : EntitySystem
     private void OnPhotoAlbumStartup(Entity<PhotoAlbumComponent> entity, ref ComponentStartup args)
     {
         RefreshUnsignedAutoSignTracking(entity.Owner);
+        ProtectStoredPhotos(entity);
 
         if (entity.Comp.IsSigned)
             UpdateSignedAlbumName(entity);
@@ -84,12 +94,59 @@ public sealed class PhotoAlbumSystem : EntitySystem
 
     private void OnPhotoAlbumInserted(EntityUid uid, PhotoAlbumComponent component, EntInsertedIntoContainerMessage args)
     {
+        if (args.Container.ID == component.ContainerId)
+            ProtectStoredPhoto(args.Entity);
+
         RefreshUnsignedAutoSignTracking(uid, component);
     }
 
     private void OnPhotoAlbumRemoved(EntityUid uid, PhotoAlbumComponent component, EntRemovedFromContainerMessage args)
     {
+        if (args.Container.ID == component.ContainerId)
+            ReleaseStoredPhoto(args.Entity);
+
         RefreshUnsignedAutoSignTracking(uid, component);
+    }
+
+    private void OnProtectedPhotoDamaged(Entity<PhotoAlbumProtectionComponent> entity, ref BeforeDamageChangedEvent args)
+    {
+        args.Cancelled = true;
+    }
+
+    private void OnProtectedPhotoDestruction(Entity<PhotoAlbumProtectionComponent> entity, ref DestructionAttemptEvent args)
+    {
+        args.Cancel();
+    }
+
+    private void OnProtectedPhotoIgnited(Entity<PhotoAlbumProtectionComponent> entity, ref IgnitedEvent args)
+    {
+        _flammable.Extinguish(entity.Owner);
+    }
+
+    private void ProtectStoredPhotos(Entity<PhotoAlbumComponent> entity)
+    {
+        if (!_container.TryGetContainer(entity.Owner, entity.Comp.ContainerId, out var container))
+            return;
+
+        foreach (var photo in container.ContainedEntities)
+        {
+            ProtectStoredPhoto(photo);
+        }
+    }
+
+    private void ProtectStoredPhoto(EntityUid photo)
+    {
+        _flammable.Extinguish(photo);
+        EnsureComp<PhotoAlbumProtectionComponent>(photo);
+    }
+
+    private void ReleaseStoredPhoto(EntityUid photo)
+    {
+        if (!HasComp<PhotoAlbumProtectionComponent>(photo))
+            return;
+
+        _flammable.Extinguish(photo);
+        RemComp<PhotoAlbumProtectionComponent>(photo);
     }
 
     private void RefreshUnsignedAutoSignTracking(EntityUid uid, PhotoAlbumComponent? photoAlbum = null)


### PR DESCRIPTION
## Чому / Баланс
Фотки, які горять від петард клоуна, це ненормально; нюка, яка підпалює й обнуляє фотографії в усіх шафах голів, це теж ненормально. Захист пропадає після вилучення з альбому.

## Вимоги
<!-- Підтвердіть наступне, записавши X у квадратні дужки [X]: -->
- [x] Я прочитав та дотримуюсь [Правил запитів на злиття та журналу змін](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я додав медіа, **АБО** цей запит на злиття не потребує медіа.
<!-- Ви повинні розуміти, що недотримування пунктів вище може бути підставою для закриття вашого запиту. -->

**Журнал змін**
:cl:
- tweak: фотографії всередині альбомів не горять від вогню
- tweak: фотографії всередині альбомів не руйнуються від вибухів
