### PR TITLE
Literally 1984

### DIFF
--- a/Resources/Prototypes/_Pirate/Entities/Clothing/ee_generic.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Clothing/ee_generic.yml
@@ -47,6 +47,23 @@
   abstract: true
 
 - type: entity
+  parent: ClothingHeadEyeBaseFlippable
+  id: ClothingEyesEyepatchFake
+  name: eyepatch
+  description: Yarr.
+  suffix: fake
+  components:
+  - type: Sprite
+    sprite: Clothing/Eyes/Misc/eyepatch.rsi
+  - type: Clothing
+    sprite: Clothing/Eyes/Misc/eyepatch.rsi
+
+- type: entity
+  parent: [ClothingEyesEyepatchFake, ClothingHeadEyeBaseFlipped]
+  id: ClothingEyesEyepatchFakeFlipped
+  suffix: fake, flipped
+
+- type: entity
   parent: ClothingEyesEyepatch
   id: ClothingEyesEyepatchColor
   name: eyepatch
@@ -63,6 +80,23 @@
 - type: entity
   parent: [ClothingEyesEyepatchColor, ClothingHeadEyeBaseFlipped]
   id: ClothingEyesEyepatchColorFlipped
+
+- type: entity
+  parent: ClothingHeadEyeBaseFlippable
+  id: ClothingEyesEyepatchColorFake
+  name: eyepatch
+  description: Yarr.
+  suffix: colorable, fake
+  components:
+  - type: Sprite
+    sprite: _Pirate/Loadouts/EEGeneric/Clothing/Eyes/Misc/eyepatch_color.rsi
+  - type: Clothing
+    sprite: _Pirate/Loadouts/EEGeneric/Clothing/Eyes/Misc/eyepatch_color.rsi
+
+- type: entity
+  parent: [ClothingEyesEyepatchColorFake, ClothingHeadEyeBaseFlipped]
+  id: ClothingEyesEyepatchColorFakeFlipped
+  suffix: colorable, fake, flipped
 
 
 - type: entity
@@ -224,7 +258,7 @@
 
 
 - type: entity
-  parent: ClothingHandsGlovesSyntheticBase
+  parent: ClothingHandsButcherable
   id: ClothingHandsGlovesEvening
   name: evening gloves
   description: Gloves that reach past the elbow. Serving elegance and serving looks!
@@ -236,17 +270,15 @@
 
 
 - type: entity
-  parent: ClothingHandsGlovesSyntheticBase
-  id: ClothingHandsTacticalMaidGlovesLoadout
+  parent: ClothingHandsButcherable
+  id: ClothingHandsTacticalMaidGlovesCivilian
   name: tactical maid gloves
-  description: Tactical maid gloves, every self-respecting maid should be able to discreetly eliminate the stains the passengers leave.
+  description: Tactical maid gloves, every self-respecting maid should be able to discreetly eliminate her goals.
   components:
   - type: Sprite
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Hands/Gloves/tacticalmaidgloves.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Hands/Gloves/tacticalmaidgloves.rsi
-  - type: Fiber
-    fiberColor: fibers-black
 
 - type: entity
   parent: ClothingHandsGlovesEnviroglovesBase
@@ -402,6 +434,9 @@
     sprite: _Pirate/Loadouts/EEGeneric/_EE/Clothing/BieselRepublic/Belt/TCAF_webbing.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/_EE/Clothing/BieselRepublic/Belt/TCAF_webbing.rsi
+  - type: Storage
+    grid:
+    - 0,0,3,1
 
 - type: entity
   parent: [ClothingBackpackSatchel, BaseFoldable]
@@ -772,7 +807,7 @@
 
 
 - type: entity
-  parent: ClothingHandsGlovesCombat
+  parent: ClothingHandsButcherable
   id: ClothingHandsGlovesCombatTCAF
   name: TCAF combat gloves
   description: A pair of tactical gloves of an ancient Solarian design, which see common use in the Biesel Republic's armed forces.
@@ -1091,7 +1126,18 @@
 
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  abstract: true
+  parent: ClothingOuterStorageBase
+  id: ClothingOuterLoadoutWinterCoat
+  components:
+  - type: TemperatureProtection
+    heatingCoefficient: 1.1
+    coolingCoefficient: 0.1
+  - type: Item
+    size: Normal
+
+- type: entity
+  parent: ClothingOuterLoadoutWinterCoat
   id: ClothingOuterCorporateJacket
   name: Nanotrasen Corporate Jacket
   description: A cozy jacket with the Nanotrasen logo printed on the back. Merchandise rewarded to stations with a safety factor of uhh... seven.
@@ -1103,7 +1149,7 @@
     
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: ClothingOuterLoadoutWinterCoat
   id: ClothingOuterDenimJacket
   name: Denim jacket
   description: A jean jacket with a warm inner lining.
@@ -1127,11 +1173,6 @@
   - type: TemperatureProtection
     heatingCoefficient: 0.1
     coolingCoefficient: 0.1
-  - type: Armor
-    modifiers:
-      coefficients:
-        Slash: 0.9
-        Heat: 0.75
 
 
 - type: entity
@@ -1156,11 +1197,6 @@
   - type: TemperatureProtection
     heatingCoefficient: 0.1
     coolingCoefficient: 0.1
-  - type: Armor
-    modifiers:
-      coefficients:
-        Slash: 0.9
-        Heat: 0.75
 
 
 - type: entity
@@ -1516,7 +1552,7 @@
 
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: ClothingOuterLoadoutWinterCoat
   id: ClothingOuterWinterCoatLong
   name: long winter coat
   description: Even your legs will be warm with this stylish coat.
@@ -1528,7 +1564,7 @@
 
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: ClothingOuterLoadoutWinterCoat
   id: ClothingOuterWinterCoatPlaid
   name: plaid winter coat
   description: It might be made out of actual wool.
@@ -2766,6 +2802,82 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Shoes/Sandals/flipflops_alt.rsi
 
 - type: entity
+  abstract: true
+  parent: Clothing
+  id: ClothingShoesLoadoutCivilianBase
+  components:
+  - type: Clothing
+    slots:
+    - FEET
+    equipSound:
+      collection: GenericEquip
+      params:
+        volume: -5
+    equipDelay: 0.5
+    unequipDelay: 0.3
+  - type: Sprite
+    state: icon
+  - type: Item
+    size: Normal
+  - type: Food
+    requiresSpecialDigestion: true
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10
+        reagents:
+        - ReagentId: Fiber
+          Quantity: 10
+  - type: Tag
+    tags:
+    - ClothMade
+    - Recyclable
+    - WhitelistChameleon
+  - type: ProtectedFromStepTriggers
+  - type: Butcherable
+    butcheringType: Knife
+    spawned:
+    - id: MaterialCloth1
+      amount: 1
+  - type: PhysicalComposition
+    materialComposition:
+      Cloth: 50
+
+- type: entity
+  parent: ClothingShoesLoadoutCivilianBase
+  id: ClothingShoesBootsCowboyFancyLoadout
+  name: fancy cowboy boots
+  description: They got spurs that jingle and/or jangle.
+  components:
+  - type: Sprite
+    sprite: Clothing/Shoes/Boots/cowboybootsfancy.rsi
+  - type: Clothing
+    sprite: Clothing/Shoes/Boots/cowboybootsfancy.rsi
+  - type: FootstepModifier
+    footstepSoundCollection:
+      collection: FootstepSpurs
+      params:
+        variation: 0.09
+        volume: -6
+
+- type: entity
+  parent: ClothingShoesLoadoutCivilianBase
+  id: ClothingShoesBootsCowboyWhiteLoadout
+  name: white cowboy boots
+  description: They got spurs that jingle and/or jangle.
+  components:
+  - type: Sprite
+    sprite: Clothing/Shoes/Boots/cowboybootswhite.rsi
+  - type: Clothing
+    sprite: Clothing/Shoes/Boots/cowboybootswhite.rsi
+  - type: FootstepModifier
+    footstepSoundCollection:
+      collection: FootstepSpurs
+      params:
+        variation: 0.09
+        volume: -6
+
+- type: entity
   parent: ClothingShoesBaseButcherable
   id: ClothingShoesBootsWorkColor
   name: workboots
@@ -2778,7 +2890,7 @@
 
 
 - type: entity
-  parent: ClothingShoesMilitaryBase
+  parent: ClothingShoesLoadoutCivilianBase
   id: ClothingShoesBootsJackFake
   name: jackboots
   description: Civilian-grade replica of Nanotrasen Security combat boots. Looks the part but lacks the performanceвЂ”ideal for the heated situations.
@@ -2790,7 +2902,7 @@
 
 
 - type: entity
-  parent: ClothingShoesMilitaryBase
+  parent: ClothingShoesLoadoutCivilianBase
   id: ClothingShoesBootsJackColor
   name: fashion jackboots
   description: Civilian-grade replica of Nanotrasen Security combat boots, impractical but fashionable.
@@ -2799,8 +2911,6 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Shoes/Boots/jackboots_color.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Shoes/Boots/jackboots_color.rsi
-  - type: ClothingModifyStunTime # Goobstation
-    modifier: 0.8
 
 
 - type: entity
@@ -2863,7 +2973,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Shoes/Boots/thighboots.rsi
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: ClothingOuterLoadoutWinterCoat
   id: ClothingOuterCsCorporateJacket
   name: Cybersun Corporate Jacket
   description: A cozy jacket with the Cybersun logo printed on the back. Merchandise rewarded to stations with a safety factor of uhh... seven.
@@ -2875,7 +2985,7 @@
 
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: ClothingOuterLoadoutWinterCoat
   id: ClothingOuterEeCorporateJacket
   name: Einstein Engines Corporate Jacket
   description: A cozy jacket with the Einstein Engines logo printed on the back. Merchandise rewarded to stations with a safety factor of uhh... seven.
@@ -2887,7 +2997,7 @@
 
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: ClothingOuterLoadoutWinterCoat
   id: ClothingOuterHiCorporateJacket
   name: Hephaestus Industries Corporate Jacket
   description: A cozy jacket with the Hephaestus Industries logo printed on the back. Merchandise rewarded to stations with a safety factor of uhh... seven.
@@ -2899,7 +3009,7 @@
 
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: ClothingOuterLoadoutWinterCoat
   id: ClothingOuterHmCorporateJacket
   name: Hawkmoon Acquisitions Corporate Jacket
   description: A cozy jacket with the Hawkmoon Acquisitions logo printed on the back. Merchandise rewarded to stations with a safety factor of uhh... seven.
@@ -2911,7 +3021,7 @@
 
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: ClothingOuterLoadoutWinterCoat
   id: ClothingOuterIdCorporateJacket
   name: Interdyne Corporate Jacket
   description: A cozy jacket with the Interdyne logo printed on the back. Merchandise rewarded to stations with a safety factor of uhh... seven.
@@ -2923,7 +3033,7 @@
 
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: ClothingOuterLoadoutWinterCoat
   id: ClothingOuterBcCorporateJacket
   name: Bishop Cybernetics Corporate Jacket
   description: A cozy jacket with the Bishop Cybernetics logo printed on the back. Merchandise rewarded to stations with a safety factor of uhh... seven.
@@ -2935,7 +3045,7 @@
 
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: ClothingOuterLoadoutWinterCoat
   id: ClothingOuterDdCorporateJacket
   name: Discount Dan's Corporate Jacket
   description: A cozy jacket with the Discount Dan's logo printed on the back. Merchandise rewarded to stations with a safety factor of uhh... seven.
@@ -2947,7 +3057,7 @@
 
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: ClothingOuterLoadoutWinterCoat
   id: ClothingOuterFaCorporateJacket
   name: Five Points Armory Corporate Jacket
   description: A cozy jacket with the Five Points Armory logo printed on the back. Merchandise rewarded to stations with a safety factor of uhh... seven.
@@ -2959,7 +3069,7 @@
 
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: ClothingOuterLoadoutWinterCoat
   id: ClothingOuterGeCorporateJacket
   name: Gilthari Exports Corporate Jacket
   description: A cozy jacket with the Gilthari Exports logo printed on the back. Merchandise rewarded to stations with a safety factor of uhh... seven.
@@ -2971,7 +3081,7 @@
 
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: ClothingOuterLoadoutWinterCoat
   id: ClothingOuterZhCorporateJacket
   name: Zeng-Hu Pharmaceuticals Corporate Jacket
   description: A cozy jacket with the Zeng-Hu Pharmaceuticals logo printed on the back. Merchandise rewarded to stations with a safety factor of uhh... seven.
@@ -2983,7 +3093,7 @@
 
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: ClothingOuterLoadoutWinterCoat
   id: ClothingOuterIiCorporateJacket
   name: Idris Incorporated Corporate Jacket
   description: A cozy jacket with the Idris Incorporated logo printed on the back. Merchandise rewarded to stations with a safety factor of uhh... seven.
@@ -2995,7 +3105,7 @@
 
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: ClothingOuterLoadoutWinterCoat
   id: ClothingOuterOeCorporateJacket
   name: Orion Express Corporate Jacket
 
@@ -3793,16 +3903,24 @@
       sprite: _Pirate/Loadouts/EEGeneric/_EE/Clothing/BieselRepublic/OuterClothing/TCAF_jacket.rsi
     - type: Clothing
       sprite: _Pirate/Loadouts/EEGeneric/_EE/Clothing/BieselRepublic/OuterClothing/TCAF_jacket.rsi
-    - type: Armor
-      modifiers:
-        coefficients:
-          Blunt: 0.95
-          Slash: 0.95
-          Piercing: 0.95
-          Heat: 0.85
     - type: TemperatureProtection
       heatingCoefficient: 0.1
       coolingCoefficient: 0.1
+
+- type: entity
+  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing]
+  id: ClothingOuterCoatDetectiveLoadoutCivilian
+  name: detective trenchcoat
+  description: An 18th-century multi-purpose trenchcoat. Someone who wears this means serious business.
+  components:
+  - type: Sprite
+    sprite: Clothing/OuterClothing/Coats/detective.rsi
+  - type: Clothing
+    sprite: Clothing/OuterClothing/Coats/detective.rsi
+  - type: StorageFill
+    contents:
+    - id: SmokingPipeFilledTobacco
+    - id: FlippoLighter
 
 - type: entity
   parent: ClothingNeckBase

--- a/Resources/Prototypes/_Pirate/Entities/Clothing/ee_generic.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Clothing/ee_generic.yml
@@ -2803,7 +2803,7 @@
 
 - type: entity
   abstract: true
-  parent: Clothing
+  parent: [Clothing, ClothingSlotBase]
   id: ClothingShoesLoadoutCivilianBase
   components:
   - type: Clothing
@@ -2842,6 +2842,14 @@
   - type: PhysicalComposition
     materialComposition:
       Cloth: 50
+  - type: ItemSlots
+    slots:
+      item:
+        name: clothing-boots-sidearm
+        whitelist:
+          tags:
+          - Knife
+          - Sidearm
 
 - type: entity
   parent: ClothingShoesLoadoutCivilianBase

--- a/Resources/Prototypes/_Pirate/Entities/Clothing/ee_generic.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Clothing/ee_generic.yml
@@ -2901,7 +2901,7 @@
   parent: ClothingShoesLoadoutCivilianBase
   id: ClothingShoesBootsJackFake
   name: jackboots
-  description: Civilian-grade replica of Nanotrasen Security combat boots. Looks the part but lacks the performanceвЂ”ideal for the heated situations.
+  description: Civilian-grade replica of Nanotrasen Security combat boots. Looks the part but lacks the performance - ideal for the heated situations.
   components:
   - type: Sprite
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Shoes/Boots/jackboots.rsi

--- a/Resources/Prototypes/_Pirate/Loadouts/Generic/ee_generic.yml
+++ b/Resources/Prototypes/_Pirate/Loadouts/Generic/ee_generic.yml
@@ -243,13 +243,13 @@
 - type: loadout
   id: LoadoutEyesEyepatch
   equipment:
-    eyes: ClothingEyesEyepatch
+    eyes: ClothingEyesEyepatchFake
 
 - type: loadout
   id: LoadoutEyesEyepatchColor
   customColorTint: true
   equipment:
-    eyes: ClothingEyesEyepatchColor
+    eyes: ClothingEyesEyepatchColorFake
 
 - type: loadout
   id: LoadoutEyesGlasses3D
@@ -317,7 +317,7 @@
 - type: loadout
   id: ClothingOuterCoatDetectiveLoadout
   equipment:
-    outerClothing: ClothingOuterCoatDetectiveLoadout
+    outerClothing: ClothingOuterCoatDetectiveLoadoutCivilian
 
 - type: loadout
   id: ClothingOuterCoatExpensive
@@ -440,7 +440,7 @@
 - type: loadout
   id: ClothingHandsTacticalMaidGlovesLoadout
   equipment:
-    gloves: ClothingHandsTacticalMaidGlovesLoadout
+    gloves: ClothingHandsTacticalMaidGlovesCivilian
 
 - type: loadout
   id: ClothingHandsGlovesCombatTCAF
@@ -465,13 +465,13 @@
   id: LoadoutShoesBootsCowboyFancy
   customColorTint: true
   equipment:
-    shoes: ClothingShoesBootsCowboyFancy
+    shoes: ClothingShoesBootsCowboyFancyLoadout
 
 - type: loadout
   id: LoadoutShoesBootsCowboyWhite
   customColorTint: true
   equipment:
-    shoes: ClothingShoesBootsCowboyWhite
+    shoes: ClothingShoesBootsCowboyWhiteLoadout
 
 - type: loadout
   id: LoadoutShoesBootsLaceup

--- a/Resources/Prototypes/_Pirate/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Pirate/Loadouts/loadout_groups.yml
@@ -104,7 +104,7 @@
   - LoadoutBeltWaist
   - LoadoutBeltWaistThin
   - LoadoutBeltWaistbagColor
-  # - ClothingBeltTCAFWebbing
+  - ClothingBeltTCAFWebbing
 
 - type: loadoutGroup
   id: PirateEEGenericHands


### PR DESCRIPTION

## Про запит на злиття
Нерфи раундстар доступного спорядження з бонусами

<img width="640" height="347" alt="image" src="https://github.com/user-attachments/assets/cf5a68bb-efe1-4efa-8aa8-e0f61f769035" />



**Журнал змін**
- tweak: у рукавичок TCAF, evening та tactical maid прибрано бойову броню, електроізоляцію і маскування відбитків.
- tweak: детективний тренч замінено на цивільну версію без броні
- tweak: cowboy boots, fake jackboots і fashion jackboots прибрано броню, бонуси вставання та стан-модифікатор
- tweak: у TCAF jacket, winter/corporate/denim jacket, overcoat та Idris windbreaker прибрано броню
- tweak: пов'язки на очі замінено на косметичні версії без захисту від флешок
- tweak: TCAF розгрузка повернулась у спорядженням зі зменшеним сховищем 8x2 => 4x2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Замітки про випуск

* **Нові можливості**
  * Додані поддільні варіанти пов'язок для очей з кольоровими версіями
  * Доступні нові варіанти ковбойського взуття
  * Новий детективний тренчкот з місцем для зберігання
  * Розширена функціональність тактичного поясу TCAF

<!-- end of auto-generated comment: release notes by coderabbit.ai -->