### PR TITLE
вичищаю екран спорядження вилкою

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -195,10 +195,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                     <pirate:TraitsTab Name="TraitsTab" />
                     <!-- Pirate end: port and modified DV traits UI -->
                 <!-- Pirate: loadout -->
-                <BoxContainer Name="LoadoutsTab" Orientation="Horizontal" Margin="10">
-                    <TabContainer Name="LoadoutSlotTabs" HorizontalExpand="True" VerticalExpand="True" SizeFlagsStretchRatio="4" />
-                    <ScrollContainer HorizontalExpand="True" VerticalExpand="True" SizeFlagsStretchRatio="1" Margin="8 0 0 0" HScrollEnabled="False">
-                        <BoxContainer Name="SelectedLoadoutsList" Orientation="Vertical" HorizontalExpand="True" />
+                <BoxContainer Name="LoadoutsTab" Orientation="Vertical" Margin="10">
+                    <TabContainer Name="LoadoutSlotTabs" HorizontalExpand="True" VerticalExpand="True" />
+                    <ScrollContainer Name="LoadoutSidebarScroll" HorizontalExpand="True" VerticalExpand="True" HScrollEnabled="False">
+                        <BoxContainer Name="SelectedLoadoutsList" Orientation="Vertical" HorizontalExpand="True" Margin="5" />
                     </ScrollContainer>
                 </BoxContainer>
                 <!-- Pirate: loadout -->

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -229,6 +229,7 @@ namespace Content.Client.Lobby.UI
         private LoadoutWindow? _loadoutWindow;
         private bool _showUnavailableLoadouts; // Pirate: loadout
         private readonly Dictionary<(ProtoId<LoadoutGroupPrototype> Group, ProtoId<LoadoutPrototype> Loadout), List<LoadoutIconButton>> _loadoutIconButtons = new(); // Pirate: loadout
+        private readonly Dictionary<int, BoxContainer> _loadoutSidebarSlots = new(); // Pirate: loadout
 
         private bool _exporting;
         private bool _imaging;
@@ -307,6 +308,8 @@ namespace Content.Client.Lobby.UI
             _requirements = requirements;
             _controller = UserInterfaceManager.GetUIController<LobbyUIController>();
             _sprite = _entManager.System<SpriteSystem>();
+
+            LoadoutSlotTabs.OnTabChanged += MoveLoadoutSidebarToTab; // Pirate: loadout
 
             _maxNameLength = _cfgManager.GetCVar(CCVars.MaxNameLength);
             _allowFlavorText = _cfgManager.GetCVar(CCVars.FlavorText);
@@ -1011,6 +1014,8 @@ namespace Content.Client.Lobby.UI
         {
             _loadoutWindow?.Dispose();
             #region Pirate: loadout
+            LoadoutSidebarScroll.Orphan();
+            _loadoutSidebarSlots.Clear();
             LoadoutSlotTabs.DisposeAllChildren();
             SelectedLoadoutsList.DisposeAllChildren();
             _loadoutIconButtons.Clear();
@@ -1389,9 +1394,9 @@ namespace Content.Client.Lobby.UI
 
             var showUnavailable = new CheckBox
             {
-                Text = Loc.GetString("humanoid-profile-editor-show-unavailable"), // Pirate: loadout
+                Text = Loc.GetString("humanoid-profile-editor-show-unavailable"),
                 Pressed = _showUnavailableLoadouts,
-                Margin = new Thickness(0, 0, 0, 8),
+                Margin = new Thickness(0, 6, 0, 8),
             };
 
             showUnavailable.OnToggled += args =>
@@ -1449,6 +1454,7 @@ namespace Content.Client.Lobby.UI
             var categories = CreateLoadoutCategoryNames();
 
             var result = new Dictionary<string, BoxContainer>();
+            _loadoutSidebarSlots.Clear();
 
             foreach (var category in categories)
             {
@@ -1464,18 +1470,50 @@ namespace Content.Client.Lobby.UI
                     HScrollEnabled = false,
                     HorizontalExpand = true,
                     VerticalExpand = true,
+                    SizeFlagsStretchRatio = 4,
                     Children =
                     {
                         body,
                     },
                 };
 
-                LoadoutSlotTabs.AddChild(scroll);
+                var sidebarSlot = new BoxContainer
+                {
+                    Orientation = BoxContainer.LayoutOrientation.Vertical,
+                    HorizontalExpand = true,
+                    VerticalExpand = true,
+                    SizeFlagsStretchRatio = 1,
+                };
+
+                var row = new BoxContainer
+                {
+                    Orientation = BoxContainer.LayoutOrientation.Horizontal,
+                    HorizontalExpand = true,
+                    VerticalExpand = true,
+                    Children =
+                    {
+                        scroll,
+                        sidebarSlot,
+                    },
+                };
+
+                LoadoutSlotTabs.AddChild(row);
                 LoadoutSlotTabs.SetTabTitle(LoadoutSlotTabs.ChildCount - 1, GetLoadoutCategoryTitle(category));
+                _loadoutSidebarSlots[LoadoutSlotTabs.ChildCount - 1] = sidebarSlot;
                 result[category] = body;
             }
 
+            MoveLoadoutSidebarToTab(LoadoutSlotTabs.CurrentTab);
             return result;
+        }
+
+        private void MoveLoadoutSidebarToTab(int tab)
+        {
+            if (!_loadoutSidebarSlots.TryGetValue(tab, out var slot) || LoadoutSidebarScroll.Parent == slot)
+                return;
+
+            LoadoutSidebarScroll.Orphan();
+            slot.AddChild(LoadoutSidebarScroll);
         }
 
         private string GetLoadoutCategoryTitle(string category)

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1465,7 +1465,7 @@ namespace Content.Client.Lobby.UI
 
             foreach (var choice in choices.Values
                 .Where(choice => choice.Selected)
-                .OrderBy(choice => loadoutSystem.GetName(choice.Prototype)))
+                .OrderBy(choice => choice.CustomName ?? loadoutSystem.GetName(choice.Prototype))) // Pirate: loadout
             {
                 var remove = new ContainerButton
                 {
@@ -1495,7 +1495,7 @@ namespace Content.Client.Lobby.UI
                         remove,
                         new Label
                         {
-                            Text = loadoutSystem.GetName(choice.Prototype),
+                            Text = choice.CustomName ?? loadoutSystem.GetName(choice.Prototype), // Pirate: loadout
                             ClipText = true,
                             HorizontalExpand = true,
                             Margin = new Thickness(5, 0, 0, 0),
@@ -1669,6 +1669,12 @@ namespace Content.Client.Lobby.UI
             }
 
             #region Pirate: loadout
+            /// <summary>
+            /// The custom name from any active location, if one was set. Used for the selected-loadouts list
+            /// which has no specific group context.
+            /// </summary>
+            public string? CustomName => Locations.FirstOrDefault(location => location.Active && location.CustomName != null).CustomName;
+
             public string? CustomNameForGroup(ProtoId<LoadoutGroupPrototype> group)
             {
                 return Locations.FirstOrDefault(location => location.Active && location.Group == group && location.CustomName != null).CustomName;

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1112,7 +1112,7 @@ namespace Content.Client.Lobby.UI
                         var enabled = roleLoadout.IsValid(Profile, _playerManager.LocalSession, loadoutId, collection, out var reason);
                         var selectedLoadout = selected?.FirstOrDefault(loadout => loadout.Prototype == loadoutId); // Pirate: loadout
                         var selectedInGroup = active && selectedLoadout != null; // Pirate: loadout
-                        choice.Locations.Add(new CombinedLoadoutLocation(roleId, groupId, active, enabled, selectedInGroup, generic, reason, selectedLoadout?.CustomColorTint)); // Pirate: loadout
+                        choice.Locations.Add(new CombinedLoadoutLocation(roleId, groupId, active, enabled, selectedInGroup, generic, reason, selectedLoadout?.CustomColorTint, selectedLoadout?.CustomName, selectedLoadout?.CustomDescription)); // Pirate: loadout
                         choice.Selected |= selectedInGroup;
                     }
                 }
@@ -1217,7 +1217,7 @@ namespace Content.Client.Lobby.UI
                 };
 
                 icon.OnPressed += args => SetCombinedLoadout(choice, args.Button.Pressed, section.Group);
-                icon.OnCustomizePressed += () => OpenLoadoutColorPicker(choice, section.Group, loadoutSystem.GetName(choice.Prototype)); // Pirate: loadout
+                icon.OnCustomizePressed += (defName, defDesc) => OpenLoadoutCustomize(choice, section.Group, loadoutSystem.GetName(choice.Prototype), defName, defDesc); // Pirate: loadout
                 iconRows.AddChild(icon);
                 RegisterLoadoutIconButton(section.Group, choice.Prototype.ID, icon);
             }
@@ -1320,17 +1320,59 @@ namespace Content.Client.Lobby.UI
             ReloadPreview();
         }
 
-        private void OpenLoadoutColorPicker(CombinedLoadoutChoice choice, ProtoId<LoadoutGroupPrototype> group, string loadoutName)
+        #region Pirate: loadout
+        private void OpenLoadoutCustomize(CombinedLoadoutChoice choice, ProtoId<LoadoutGroupPrototype> group, string loadoutTitle, string defaultName, string defaultDescription)
         {
-            var initialColor = Color.FromHex(choice.CustomColorForGroup(group), Color.White);
-            var window = new LoadoutColorPickerWindow(loadoutName, initialColor);
-            window.OnColorSubmitted += color => SetCombinedLoadoutColor(choice, group, color.ToHex());
+            var currentName = choice.CustomNameForGroup(group) ?? defaultName;
+            var currentDescription = choice.CustomDescriptionForGroup(group) ?? defaultDescription;
+
+            // Only offer the color picker for items that support tinting.
+            Color? color = choice.Prototype.CustomColorTint
+                ? Color.FromHex(choice.CustomColorForGroup(group), Color.White)
+                : null;
+
+            var window = new LoadoutCustomizeWindow(loadoutTitle, currentName, currentDescription, color);
+            window.OnSubmitted += (name, description, pickedColor) =>
+                SetCombinedLoadoutCustomization(choice, group, name, description, pickedColor, defaultName, defaultDescription);
+
+            if (color != null)
+            {
+                var savedColor = color.Value;
+                // Live preview while dragging; revert to the saved color if the dialog is closed without applying.
+                window.OnColorPreview += previewColor => PreviewLoadoutColor(choice, group, previewColor);
+                window.OnReverted += () => PreviewLoadoutColor(choice, group, savedColor);
+            }
+
             window.OpenCentered();
         }
 
-        private void SetCombinedLoadoutColor(CombinedLoadoutChoice choice, ProtoId<LoadoutGroupPrototype> group, string customColorTint)
+        // Re-tints the loadout's icon and its equipped item on the character preview in place, without
+        // touching the profile. Used for immediate color feedback; the value is only persisted on apply.
+        private void PreviewLoadoutColor(CombinedLoadoutChoice choice, ProtoId<LoadoutGroupPrototype> group, Color color)
         {
-            if (Profile == null || _playerManager.LocalSession == null || !choice.Prototype.CustomColorTint)
+            if (_loadoutIconButtons.TryGetValue((group, choice.Prototype.ID), out var buttons))
+            {
+                var hex = color.ToHex();
+                foreach (var button in buttons)
+                    button.SetCustomColor(hex);
+            }
+
+            // Only tint the character when this loadout is actually equipped on the preview.
+            if (!choice.IsSelectedInGroup(group) || !_entManager.EntityExists(PreviewDummy))
+                return;
+
+            var inventory = _entManager.System<Content.Shared.Inventory.InventorySystem>();
+            var tint = _entManager.System<Content.Client._Pirate.Loadouts.LoadoutTintSystem>();
+            foreach (var slot in choice.Prototype.Equipment.Keys)
+            {
+                if (inventory.TryGetSlotEntity(PreviewDummy, slot, out var equipped))
+                    tint.SetTint(equipped.Value, color);
+            }
+        }
+
+        private void SetCombinedLoadoutCustomization(CombinedLoadoutChoice choice, ProtoId<LoadoutGroupPrototype> group, string name, string description, Color? color, string defaultName, string defaultDescription)
+        {
+            if (Profile == null || _playerManager.LocalSession == null)
                 return;
 
             var collection = IoCManager.Instance;
@@ -1340,6 +1382,11 @@ namespace Content.Client.Lobby.UI
             var location = choice.Locations.FirstOrDefault(location => location.Active && location.Group == group && location.Enabled);
             if (!location.Active)
                 return;
+
+            // Store null when a value matches the item's default so it falls back gracefully.
+            var customName = NormalizeCustomText(name, defaultName);
+            var customDescription = NormalizeCustomText(description, defaultDescription);
+            var customColorTint = choice.Prototype.CustomColorTint && color.HasValue ? color.Value.ToHex() : null;
 
             var roleLoadout = Profile.Loadouts.TryGetValue(location.Role, out var existing)
                 ? existing.Clone()
@@ -1355,11 +1402,13 @@ namespace Content.Client.Lobby.UI
             if (selected == null)
             {
                 RemoveConflictingLoadouts(roleLoadout, choice.Prototype);
-                roleLoadout.AddLoadout(location.Group, choice.Prototype.ID, _prototypeManager, customColorTint);
+                roleLoadout.AddLoadout(location.Group, choice.Prototype.ID, _prototypeManager, customColorTint, customName, customDescription);
             }
             else
             {
                 selected.CustomColorTint = customColorTint;
+                selected.CustomName = customName;
+                selected.CustomDescription = customDescription;
             }
 
             Profile = Profile.WithLoadout(roleLoadout);
@@ -1367,6 +1416,13 @@ namespace Content.Client.Lobby.UI
             RefreshLoadouts();
             ReloadPreview();
         }
+
+        private static string? NormalizeCustomText(string value, string defaultValue)
+        {
+            var trimmed = value.Trim();
+            return string.IsNullOrEmpty(trimmed) || trimmed == defaultValue.Trim() ? null : trimmed;
+        }
+        #endregion
 
         private void RemoveConflictingLoadouts(RoleLoadout roleLoadout, LoadoutPrototype selectedPrototype)
         {
@@ -1611,6 +1667,18 @@ namespace Content.Client.Lobby.UI
             {
                 return Locations.FirstOrDefault(location => location.Active && location.Group == group && location.CustomColorTint != null).CustomColorTint;
             }
+
+            #region Pirate: loadout
+            public string? CustomNameForGroup(ProtoId<LoadoutGroupPrototype> group)
+            {
+                return Locations.FirstOrDefault(location => location.Active && location.Group == group && location.CustomName != null).CustomName;
+            }
+
+            public string? CustomDescriptionForGroup(ProtoId<LoadoutGroupPrototype> group)
+            {
+                return Locations.FirstOrDefault(location => location.Active && location.Group == group && location.CustomDescription != null).CustomDescription;
+            }
+            #endregion
         }
 
         private enum CombinedLoadoutKind
@@ -1627,7 +1695,9 @@ namespace Content.Client.Lobby.UI
             bool Selected,
             bool IsGeneric,
             FormattedMessage? Reason,
-            string? CustomColorTint)
+            string? CustomColorTint,
+            string? CustomName, // Pirate: loadout
+            string? CustomDescription) // Pirate: loadout
         {
             public CombinedLoadoutKind Kind => IsGeneric
                 ? CombinedLoadoutKind.Generic

--- a/Content.Client/_Pirate/Lobby/UI/Loadouts/LoadoutCustomizeWindow.cs
+++ b/Content.Client/_Pirate/Lobby/UI/Loadouts/LoadoutCustomizeWindow.cs
@@ -1,0 +1,131 @@
+using System.Numerics;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.Utility;
+
+namespace Content.Client._Pirate.Lobby.UI.Loadouts;
+
+/// <summary>
+/// Combined dialog for customizing a loadout item: display name, description, and (when the
+/// item supports tinting) a color picker. Prefilled with the current custom values or the
+/// item's defaults.
+/// </summary>
+public sealed class LoadoutCustomizeWindow : DefaultWindow
+{
+    /// <summary>
+    /// Raised on apply. The color argument is null when the item does not support tinting.
+    /// </summary>
+    public event Action<string, string, Color?>? OnSubmitted;
+
+    /// <summary>
+    /// Raised live as the color slider moves, for immediate preview (not persisted).
+    /// </summary>
+    public event Action<Color>? OnColorPreview;
+
+    /// <summary>
+    /// Raised when the window closes without applying, so the live preview can be reverted.
+    /// </summary>
+    public event Action? OnReverted;
+
+    private bool _applied;
+
+    private readonly LineEdit _nameEdit = new()
+    {
+        HorizontalExpand = true,
+    };
+
+    private readonly TextEdit _descriptionEdit = new()
+    {
+        HorizontalExpand = true,
+        VerticalExpand = true,
+        Margin = new Thickness(3),
+    };
+
+    private readonly ColorSelectorSliders? _colorSelector;
+
+    public LoadoutCustomizeWindow(string loadoutName, string name, string description, Color? color)
+    {
+        Title = loadoutName;
+        MinSize = new Vector2(360, color != null ? 560 : 320);
+
+        _nameEdit.Text = name;
+        _descriptionEdit.TextRope = new Rope.Leaf(description);
+
+        var body = new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Vertical,
+            Margin = new Thickness(8),
+            Children =
+            {
+                new Label { Text = Loc.GetString("loadout-name-desc-name-label") },
+                _nameEdit,
+                new Label
+                {
+                    Text = Loc.GetString("loadout-name-desc-description-label"),
+                    Margin = new Thickness(0, 8, 0, 0),
+                },
+                new PanelContainer
+                {
+                    VerticalExpand = true,
+                    Children =
+                    {
+                        _descriptionEdit,
+                    },
+                },
+            },
+        };
+
+        if (color != null)
+        {
+            _colorSelector = new ColorSelectorSliders
+            {
+                SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv,
+                IsAlphaVisible = false,
+                HorizontalExpand = true,
+                Color = color.Value,
+            };
+
+            _colorSelector.OnColorChanged += _ => OnColorPreview?.Invoke(_colorSelector.Color);
+
+            body.AddChild(new Label
+            {
+                Text = Loc.GetString("loadout-name-desc-color-label"),
+                Margin = new Thickness(0, 8, 0, 0),
+            });
+            body.AddChild(_colorSelector);
+        }
+
+        var apply = new Button
+        {
+            Text = Loc.GetString("loadout-name-desc-apply"),
+            HorizontalAlignment = HAlignment.Right,
+            MinWidth = 96,
+        };
+        apply.OnPressed += _ =>
+        {
+            _applied = true;
+            OnSubmitted?.Invoke(_nameEdit.Text, Rope.Collapse(_descriptionEdit.TextRope), _colorSelector?.Color);
+            Close();
+        };
+
+        // Closing without applying reverts the live preview to the saved color.
+        OnClose += () =>
+        {
+            if (!_applied)
+                OnReverted?.Invoke();
+        };
+
+        body.AddChild(new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Horizontal,
+            HorizontalAlignment = HAlignment.Right,
+            Margin = new Thickness(0, 8, 0, 0),
+            Children =
+            {
+                apply,
+            },
+        });
+
+        Contents.AddChild(body);
+    }
+}

--- a/Content.Client/_Pirate/Lobby/UI/Loadouts/LoadoutIconButton.cs
+++ b/Content.Client/_Pirate/Lobby/UI/Loadouts/LoadoutIconButton.cs
@@ -17,7 +17,10 @@ public sealed class LoadoutIconButton : Button
 {
     [Dependency] private readonly IEntityManager _entManager = default!;
 
-    public event Action? OnCustomizePressed;
+    public event Action<string, string>? OnCustomizePressed;
+
+    private string _defaultName = string.Empty;
+    private string _defaultDescription = string.Empty;
 
     private static readonly StyleBoxFlat NormalStyle = CreateStyle("#2a2a35", "#32323e");
     private static readonly StyleBoxFlat HoverStyle = CreateStyle("#2a3a4a", "#32323e");
@@ -67,6 +70,9 @@ public sealed class LoadoutIconButton : Button
         if (string.IsNullOrWhiteSpace(displayName))
             displayName = loadout.ID;
 
+        _defaultName = displayName;
+        _defaultDescription = description;
+
         TooltipSupplier = _ =>
         {
             var tooltip = new Tooltip();
@@ -81,8 +87,7 @@ public sealed class LoadoutIconButton : Button
             return tooltip;
         };
 
-        if (loadout.CustomColorTint)
-            AddCustomizeButton();
+        AddCustomizeButton();
     }
 
     private EntProtoId? ResolveDisplayEntity(LoadoutPrototype loadout)
@@ -116,17 +121,18 @@ public sealed class LoadoutIconButton : Button
 
     private void AddCustomizeButton()
     {
-        var customize = new ContainerButton
+        // Single gear button in the top-left corner; opens the combined customize dialog.
+        var button = new ContainerButton
         {
             StyleBoxOverride = new StyleBoxEmpty(),
             MinSize = new Vector2(24, 24),
             SetSize = new Vector2(24, 24),
             HorizontalAlignment = HAlignment.Left,
             VerticalAlignment = VAlignment.Top,
-            ToolTip = Loc.GetString("loadout-customize-color-tooltip"),
+            ToolTip = Loc.GetString("loadout-customize-tooltip"),
         };
 
-        customize.AddChild(new TextureRect
+        button.AddChild(new TextureRect
         {
             TexturePath = "/Textures/Interface/Nano/gear.svg.192dpi.png",
             SetSize = new Vector2(16, 16),
@@ -135,8 +141,8 @@ public sealed class LoadoutIconButton : Button
             Stretch = TextureRect.StretchMode.KeepAspectCentered,
         });
 
-        customize.OnPressed += _ => OnCustomizePressed?.Invoke();
-        AddChild(customize);
+        button.OnPressed += _ => OnCustomizePressed?.Invoke(_defaultName, _defaultDescription);
+        AddChild(button);
     }
 
     protected override void DrawModeChanged()

--- a/Content.Server.Database/Migrations/Postgres/20260613120001_PirateLoadoutNameDesc.cs
+++ b/Content.Server.Database/Migrations/Postgres/20260613120001_PirateLoadoutNameDesc.cs
@@ -1,0 +1,42 @@
+using Content.Server.Database;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Content.Server.Database.Migrations.Postgres
+{
+    /// <inheritdoc />
+    [DbContext(typeof(PostgresServerDbContext))]
+    [Migration("20260613120001_PirateLoadoutNameDesc")]
+    public partial class PirateLoadoutNameDesc : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "custom_name",
+                table: "profile_loadout",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "custom_description",
+                table: "profile_loadout",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "custom_name",
+                table: "profile_loadout");
+
+            migrationBuilder.DropColumn(
+                name: "custom_description",
+                table: "profile_loadout");
+        }
+    }
+}

--- a/Content.Server.Database/Migrations/Postgres/PostgresServerDbContextModelSnapshot.cs
+++ b/Content.Server.Database/Migrations/Postgres/PostgresServerDbContextModelSnapshot.cs
@@ -1319,6 +1319,16 @@ namespace Content.Server.Database.Migrations.Postgres
                         .HasColumnType("character varying(16)")
                         .HasColumnName("custom_color_tint");
 
+                    #region Pirate: loadout
+                    b.Property<string>("CustomDescription")
+                        .HasColumnType("text")
+                        .HasColumnName("custom_description");
+
+                    b.Property<string>("CustomName")
+                        .HasColumnType("text")
+                        .HasColumnName("custom_name");
+                    #endregion
+
                     b.Property<int>("ProfileLoadoutGroupId")
                         .HasColumnType("integer")
                         .HasColumnName("profile_loadout_group_id");

--- a/Content.Server.Database/Migrations/Sqlite/20260613120000_PirateLoadoutNameDesc.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20260613120000_PirateLoadoutNameDesc.cs
@@ -1,0 +1,42 @@
+using Content.Server.Database;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Content.Server.Database.Migrations.Sqlite
+{
+    /// <inheritdoc />
+    [DbContext(typeof(SqliteServerDbContext))]
+    [Migration("20260613120000_PirateLoadoutNameDesc")]
+    public partial class PirateLoadoutNameDesc : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "custom_name",
+                table: "profile_loadout",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "custom_description",
+                table: "profile_loadout",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "custom_name",
+                table: "profile_loadout");
+
+            migrationBuilder.DropColumn(
+                name: "custom_description",
+                table: "profile_loadout");
+        }
+    }
+}

--- a/Content.Server.Database/Migrations/Sqlite/SqliteServerDbContextModelSnapshot.cs
+++ b/Content.Server.Database/Migrations/Sqlite/SqliteServerDbContextModelSnapshot.cs
@@ -1254,6 +1254,16 @@ namespace Content.Server.Database.Migrations.Sqlite
                         .HasColumnType("TEXT")
                         .HasColumnName("custom_color_tint");
 
+                    #region Pirate: loadout
+                    b.Property<string>("CustomDescription")
+                        .HasColumnType("TEXT")
+                        .HasColumnName("custom_description");
+
+                    b.Property<string>("CustomName")
+                        .HasColumnType("TEXT")
+                        .HasColumnName("custom_name");
+                    #endregion
+
                     b.Property<int>("ProfileLoadoutGroupId")
                         .HasColumnType("INTEGER")
                         .HasColumnName("profile_loadout_group_id");

--- a/Content.Server.Database/Model.cs
+++ b/Content.Server.Database/Model.cs
@@ -827,6 +827,16 @@ namespace Content.Server.Database
         /// </remarks>
         [MaxLength(16)]
         public string? CustomColorTint { get; set; }
+
+        /// <summary>
+        /// Optional custom display name overriding the item's default.
+        /// </summary>
+        public string? CustomName { get; set; }
+
+        /// <summary>
+        /// Optional custom description overriding the item's default.
+        /// </summary>
+        public string? CustomDescription { get; set; }
         #endregion
 
         /*

--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -387,6 +387,8 @@ namespace Content.Server.Database
                         {
                             Prototype = profLoadout.LoadoutName,
                             CustomColorTint = profLoadout.CustomColorTint, // Pirate: loadout
+                            CustomName = profLoadout.CustomName, // Pirate: loadout
+                            CustomDescription = profLoadout.CustomDescription, // Pirate: loadout
                         });
                     }
                 }
@@ -504,6 +506,8 @@ namespace Content.Server.Database
                         {
                             LoadoutName = loadout.Prototype,
                             CustomColorTint = loadout.CustomColorTint, // Pirate: loadout
+                            CustomName = loadout.CustomName, // Pirate: loadout
+                            CustomDescription = loadout.CustomDescription, // Pirate: loadout
                         });
                     }
 

--- a/Content.Shared/Clothing/Components/HideLayerClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/HideLayerClothingComponent.cs
@@ -45,4 +45,13 @@ public sealed partial class HideLayerClothingComponent : Component
     /// </summary>
     [DataField]
     public bool HideOnToggle = false;
+
+    #region Pirate: loadout
+    /// <summary>
+    /// If true, the layer will always be hidden even if the layer
+    /// is not present in the equipee's HumanoidAppearanceComponent.HideLayersOnEquip field.
+    /// </summary>
+    [DataField]
+    public bool Force = false;
+    #endregion
 }

--- a/Content.Shared/Clothing/EntitySystems/HideLayerClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/HideLayerClothingSystem.cs
@@ -66,7 +66,7 @@ public sealed class HideLayerClothingSystem : EntitySystem
         // the clothing is (or was)equipped in a matching slot.
         foreach (var (layer, validSlots) in clothing.Comp1.Layers)
         {
-            if (!hideable.Contains(layer))
+            if (!clothing.Comp1.Force && !hideable.Contains(layer)) // Pirate: loadout
                 continue;
 
             // Only update this layer if we are currently equipped to the relevant slot.
@@ -82,7 +82,7 @@ public sealed class HideLayerClothingSystem : EntitySystem
         {
             foreach (var layer in slots)
             {
-                if (hideable.Contains(layer))
+                if (clothing.Comp1.Force || hideable.Contains(layer)) // Pirate: loadout
                     _humanoid.SetLayerVisibility(user!, layer, !hideLayers, inSlot, ref dirty);
             }
         }

--- a/Content.Shared/Preferences/Loadouts/Loadout.cs
+++ b/Content.Shared/Preferences/Loadouts/Loadout.cs
@@ -31,6 +31,18 @@ public sealed partial class Loadout : IEquatable<Loadout>
     public string? CustomColorTint;
 
     /// <summary>
+    /// Optional custom display name overriding the item's default. Null means use the default.
+    /// </summary>
+    [DataField]
+    public string? CustomName;
+
+    /// <summary>
+    /// Optional custom description overriding the item's default. Null means use the default.
+    /// </summary>
+    [DataField]
+    public string? CustomDescription;
+
+    /// <summary>
     /// Checks whether the custom tint is empty or a persisted parser-valid hex color string.
     /// </summary>
     public bool IsValidColorTint()
@@ -45,6 +57,8 @@ public sealed partial class Loadout : IEquatable<Loadout>
         {
             Prototype = Prototype,
             CustomColorTint = CustomColorTint,
+            CustomName = CustomName,
+            CustomDescription = CustomDescription,
         };
     }
     #endregion
@@ -53,7 +67,10 @@ public sealed partial class Loadout : IEquatable<Loadout>
     {
         if (ReferenceEquals(null, other)) return false;
         if (ReferenceEquals(this, other)) return true;
-        return Prototype.Equals(other.Prototype) && CustomColorTint == other.CustomColorTint; // Pirate: loadout
+        return Prototype.Equals(other.Prototype)
+               && CustomColorTint == other.CustomColorTint
+               && CustomName == other.CustomName
+               && CustomDescription == other.CustomDescription; // Pirate: loadout
     }
 
     public override bool Equals(object? obj)
@@ -63,6 +80,6 @@ public sealed partial class Loadout : IEquatable<Loadout>
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(Prototype, CustomColorTint); // Pirate: loadout
+        return HashCode.Combine(Prototype, CustomColorTint, CustomName, CustomDescription); // Pirate: loadout
     }
 }

--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -229,6 +229,11 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
                 if (!loadoutProto.CustomColorTint || string.IsNullOrEmpty(loadout.CustomColorTint) || !loadout.IsValidColorTint()) // Pirate: loadout
                     loadout.CustomColorTint = null; // Pirate: loadout
 
+                #region Pirate: loadout
+                loadout.CustomName = SanitizeCustomText(loadout.CustomName, configManager.GetCVar(CCVars.MaxNameLength));
+                loadout.CustomDescription = SanitizeCustomText(loadout.CustomDescription, configManager.GetCVar(CCVars.MaxFlavorTextLength));
+                #endregion
+
                 Apply(loadoutProto);
             }
 
@@ -274,6 +279,22 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
     }
 
     #region Pirate: loadout
+    /// <summary>
+    /// Trims a player-supplied custom name/description and clamps it to <paramref name="maxLength"/>.
+    /// Returns null when the result is empty so the item falls back to its default.
+    /// </summary>
+    private static string? SanitizeCustomText(string? text, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return null;
+
+        var trimmed = text.Trim();
+        if (trimmed.Length > maxLength)
+            trimmed = trimmed[..maxLength];
+
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+
     private bool PirateHasLoadoutForGroupSlot(
         ProtoId<LoadoutGroupPrototype> currentGroup,
         LoadoutGroupPrototype currentGroupProto,
@@ -418,7 +439,7 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
     /// <summary>
     /// Applies the specified loadout to this group.
     /// </summary>
-    public bool AddLoadout(ProtoId<LoadoutGroupPrototype> selectedGroup, ProtoId<LoadoutPrototype> selectedLoadout, IPrototypeManager protoManager, string? customColorTint = null) // Pirate: loadout
+    public bool AddLoadout(ProtoId<LoadoutGroupPrototype> selectedGroup, ProtoId<LoadoutPrototype> selectedLoadout, IPrototypeManager protoManager, string? customColorTint = null, string? customName = null, string? customDescription = null) // Pirate: loadout
     {
         var groupLoadouts = SelectedLoadouts[selectedGroup];
 
@@ -450,6 +471,8 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
         {
             Prototype = selectedLoadout,
             CustomColorTint = customColorTint, // Pirate: loadout
+            CustomName = customName, // Pirate: loadout
+            CustomDescription = customDescription, // Pirate: loadout
         });
 
         return true;

--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -231,7 +231,7 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
 
                 #region Pirate: loadout
                 loadout.CustomName = SanitizeCustomText(loadout.CustomName, configManager.GetCVar(CCVars.MaxNameLength));
-                loadout.CustomDescription = SanitizeCustomText(loadout.CustomDescription, configManager.GetCVar(CCVars.MaxFlavorTextLength));
+                loadout.CustomDescription = SanitizeCustomText(loadout.CustomDescription, MaxLoadoutDescriptionLength);
                 #endregion
 
                 Apply(loadoutProto);
@@ -279,6 +279,11 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
     }
 
     #region Pirate: loadout
+    /// <summary>
+    /// Maximum length for a loadout item's custom description.
+    /// </summary>
+    private const int MaxLoadoutDescriptionLength = 256;
+
     /// <summary>
     /// Trims a player-supplied custom name/description and clamps it to <paramref name="maxLength"/>.
     /// Returns null when the result is empty so the item falls back to its default.

--- a/Content.Shared/Station/SharedStationSpawningSystem.cs
+++ b/Content.Shared/Station/SharedStationSpawningSystem.cs
@@ -156,7 +156,7 @@ public abstract class SharedStationSpawningSystem : EntitySystem
         foreach (var (items, loadoutProto) in selectedLoadouts.OrderByDescending(selected => HasEquipment(selected.Prototype)))
         {
             // Pirate: cameras (photo persistence)
-            EquipStartingGear(entity, loadoutProto, raiseEvent: false, pirateFromSelectedLoadout: true, pirateLoadoutTint: items.CustomColorTint); // Pirate: loadout
+            EquipStartingGear(entity, loadoutProto, raiseEvent: false, pirateFromSelectedLoadout: true, pirateLoadoutTint: items.CustomColorTint, pirateLoadoutName: items.CustomName, pirateLoadoutDescription: items.CustomDescription); // Pirate: loadout
         }
         #endregion
 
@@ -185,6 +185,15 @@ public abstract class SharedStationSpawningSystem : EntitySystem
         var component = EnsureComp<LoadoutTintComponent>(entity);
         component.Color = parsed.Value;
         Dirty(entity, component);
+    }
+
+    private void ApplyLoadoutMetadata(EntityUid entity, string? name, string? description)
+    {
+        if (!string.IsNullOrWhiteSpace(name))
+            _metadata.SetEntityName(entity, name);
+
+        if (!string.IsNullOrWhiteSpace(description))
+            _metadata.SetEntityDescription(entity, description);
     }
     #endregion
 
@@ -216,12 +225,14 @@ public abstract class SharedStationSpawningSystem : EntitySystem
         LoadoutPrototype loadout,
         bool raiseEvent = true,
         bool pirateFromSelectedLoadout = false, // Pirate: cameras (photo persistence)
-        string? pirateLoadoutTint = null) // Pirate: loadout
+        string? pirateLoadoutTint = null, // Pirate: loadout
+        string? pirateLoadoutName = null, // Pirate: loadout
+        string? pirateLoadoutDescription = null) // Pirate: loadout
     {
         // Pirate: cameras (photo persistence)
-        EquipStartingGear(entity, loadout.StartingGear, raiseEvent, pirateFromSelectedLoadout, pirateLoadoutTint); // Pirate: loadout
+        EquipStartingGear(entity, loadout.StartingGear, raiseEvent, pirateFromSelectedLoadout, pirateLoadoutTint, pirateLoadoutName, pirateLoadoutDescription); // Pirate: loadout
         // Pirate: cameras (photo persistence)
-        EquipStartingGear(entity, (IEquipmentLoadout) loadout, raiseEvent, pirateFromSelectedLoadout, pirateLoadoutTint); // Pirate: loadout
+        EquipStartingGear(entity, (IEquipmentLoadout) loadout, raiseEvent, pirateFromSelectedLoadout, pirateLoadoutTint, pirateLoadoutName, pirateLoadoutDescription); // Pirate: loadout
     }
 
     /// <summary>
@@ -232,11 +243,13 @@ public abstract class SharedStationSpawningSystem : EntitySystem
         ProtoId<StartingGearPrototype>? startingGear,
         bool raiseEvent = true,
         bool pirateFromSelectedLoadout = false, // Pirate: cameras (photo persistence)
-        string? pirateLoadoutTint = null) // Pirate: loadout
+        string? pirateLoadoutTint = null, // Pirate: loadout
+        string? pirateLoadoutName = null, // Pirate: loadout
+        string? pirateLoadoutDescription = null) // Pirate: loadout
     {
         PrototypeManager.TryIndex(startingGear, out var gearProto);
         // Pirate: cameras (photo persistence)
-        EquipStartingGear(entity, gearProto, raiseEvent, pirateFromSelectedLoadout, pirateLoadoutTint); // Pirate: loadout
+        EquipStartingGear(entity, gearProto, raiseEvent, pirateFromSelectedLoadout, pirateLoadoutTint, pirateLoadoutName, pirateLoadoutDescription); // Pirate: loadout
     }
 
     /// <summary>
@@ -247,7 +260,9 @@ public abstract class SharedStationSpawningSystem : EntitySystem
         StartingGearPrototype? startingGear,
         bool raiseEvent = true,
         bool pirateFromSelectedLoadout = false, // Pirate: cameras (photo persistence)
-        string? pirateLoadoutTint = null) // Pirate: loadout
+        string? pirateLoadoutTint = null, // Pirate: loadout
+        string? pirateLoadoutName = null, // Pirate: loadout
+        string? pirateLoadoutDescription = null) // Pirate: loadout
     {
         // Begin DeltaV Additions: Fix nukie IPCs not having comms
         if (startingGear is not { } proto)
@@ -256,7 +271,7 @@ public abstract class SharedStationSpawningSystem : EntitySystem
         _internalEncryption.TryInsertEncryptionKey(entity, proto);
         // End DeltaV Additions
         // Pirate: cameras (photo persistence)
-        EquipStartingGear(entity, (IEquipmentLoadout?) startingGear, raiseEvent, pirateFromSelectedLoadout, pirateLoadoutTint); // Pirate: loadout
+        EquipStartingGear(entity, (IEquipmentLoadout?) startingGear, raiseEvent, pirateFromSelectedLoadout, pirateLoadoutTint, pirateLoadoutName, pirateLoadoutDescription); // Pirate: loadout
     }
 
     /// <summary>
@@ -270,7 +285,9 @@ public abstract class SharedStationSpawningSystem : EntitySystem
         IEquipmentLoadout? startingGear,
         bool raiseEvent = true,
         bool pirateFromSelectedLoadout = false, // Pirate: cameras (photo persistence)
-        string? pirateLoadoutTint = null) // Pirate: loadout
+        string? pirateLoadoutTint = null, // Pirate: loadout
+        string? pirateLoadoutName = null, // Pirate: loadout
+        string? pirateLoadoutDescription = null) // Pirate: loadout
     {
         if (startingGear == null)
             return;
@@ -288,6 +305,7 @@ public abstract class SharedStationSpawningSystem : EntitySystem
                     // Pirate: cameras (photo persistence)
                     RaiseSelectedLoadoutEntitySpawned(equipmentEntity, entity, pirateFromSelectedLoadout);
                     ApplyLoadoutTint(equipmentEntity, pirateLoadoutTint); // Pirate: loadout
+                    ApplyLoadoutMetadata(equipmentEntity, pirateLoadoutName, pirateLoadoutDescription); // Pirate: loadout
                     if (slot.Whitelist != null && !_whitelist.IsWhitelistPass(slot.Whitelist, equipmentEntity)) // Goob Change - Plasmamen
                     {
                         QueueDel(equipmentEntity);
@@ -308,6 +326,7 @@ public abstract class SharedStationSpawningSystem : EntitySystem
                 // Pirate: cameras (photo persistence)
                 RaiseSelectedLoadoutEntitySpawned(inhandEntity, entity, pirateFromSelectedLoadout);
                 ApplyLoadoutTint(inhandEntity, pirateLoadoutTint); // Pirate: loadout
+                ApplyLoadoutMetadata(inhandEntity, pirateLoadoutName, pirateLoadoutDescription); // Pirate: loadout
 
                 if (_handsSystem.TryGetEmptyHand((entity, handsComponent), out var emptyHand))
                 {

--- a/Content.Shared/_Pirate/Clothing/ClothingLayerRemapComponent.cs
+++ b/Content.Shared/_Pirate/Clothing/ClothingLayerRemapComponent.cs
@@ -1,0 +1,24 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Pirate.Clothing;
+
+/// <summary>
+/// Always redirects a clothing item's sprite map layer from one bookmark to another while equipped.
+/// Used so floor-length garments draw over the wearer's feet/shoes instead of behind them.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ClothingLayerRemapComponent : Component
+{
+    /// <summary>
+    /// The slot bookmark the clothing would normally be inserted at.
+    /// </summary>
+    [DataField]
+    public string FromLayer = "jumpsuit";
+
+    /// <summary>
+    /// The bookmark to insert at instead. Must exist on the wearer's sprite, otherwise the
+    /// clothing falls back to <see cref="FromLayer"/>.
+    /// </summary>
+    [DataField]
+    public string ToLayer = "jumpsuitOverShoes";
+}

--- a/Content.Shared/_Pirate/Clothing/ClothingLayerRemapSystem.cs
+++ b/Content.Shared/_Pirate/Clothing/ClothingLayerRemapSystem.cs
@@ -1,0 +1,19 @@
+using Content.Goobstation.Common.Clothing;
+
+namespace Content.Shared._Pirate.Clothing;
+
+public sealed class ClothingLayerRemapSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ClothingLayerRemapComponent, GetActualMapLayerEvent>(OnGetActualMapLayer);
+    }
+
+    private void OnGetActualMapLayer(Entity<ClothingLayerRemapComponent> ent, ref GetActualMapLayerEvent args)
+    {
+        if (args.MapLayer == ent.Comp.FromLayer)
+            args.MapLayer = ent.Comp.ToLayer;
+    }
+}

--- a/Resources/Locale/en-US/_Pirate/loadouts/color-picker.ftl
+++ b/Resources/Locale/en-US/_Pirate/loadouts/color-picker.ftl
@@ -1,3 +1,9 @@
 loadout-color-picker-apply = Apply
 loadout-customize-color-tooltip = Customize color
+loadout-customize-name-tooltip = Customize name and description
+loadout-customize-tooltip = Customize
+loadout-name-desc-apply = Apply
+loadout-name-desc-name-label = Name
+loadout-name-desc-description-label = Description
+loadout-name-desc-color-label = Color
 humanoid-profile-editor-show-unavailable = Show unavailable

--- a/Resources/Locale/uk-UA/_Pirate/loadouts/color-picker.ftl
+++ b/Resources/Locale/uk-UA/_Pirate/loadouts/color-picker.ftl
@@ -1,3 +1,9 @@
 loadout-color-picker-apply = Застосувати
 loadout-customize-color-tooltip = Налаштувати колір
+loadout-customize-name-tooltip = Налаштувати назву та опис
+loadout-customize-tooltip = Налаштувати
+loadout-name-desc-apply = Застосувати
+loadout-name-desc-name-label = Назва
+loadout-name-desc-description-label = Опис
+loadout-name-desc-color-label = Колір
 humanoid-profile-editor-show-unavailable = Показати недоступні

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -151,6 +151,13 @@
     sprite: Clothing/Shoes/Boots/performer.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Boots/performer.rsi
+  # region Pirate: loadout
+  - type: HideLayerClothing
+    force: true
+    slots:
+    - LFoot
+    - RFoot
+  # endregion Pirate: loadout
 
 - type: entity
   parent: [ClothingShoesMilitaryBase, BaseSecurityContraband]
@@ -177,6 +184,13 @@
     sprite: Clothing/Shoes/Boots/highheelboots.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Boots/highheelboots.rsi
+  # region Pirate: loadout
+  - type: HideLayerClothing
+    force: true
+    slots:
+    - LFoot
+    - RFoot
+  # endregion Pirate: loadout
   - type: FootstepModifier
     footstepSoundCollection:
       collection: FootstepHighHeels

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -281,6 +281,7 @@
     - map: ["enum.HumanoidVisualLayers.Face"] #Goob 120 - why did we have face on dummy but not basespecies
     - map: [ "gloves" ]
     - map: [ "shoes" ]
+    - map: [ "jumpsuitOverShoes" ] # Pirate: loadout - bookmark for floor-length garments to draw over feet/shoes
     - map: [ "ears" ]
     - map: [ "eyes" ]
     - map: [ "id" ]
@@ -637,6 +638,7 @@
     - map: [ "enum.HumanoidVisualLayers.Face" ] # Goob 3370
     - map: [ "gloves" ]
     - map: [ "shoes" ]
+    - map: [ "jumpsuitOverShoes" ] # Pirate: loadout - bookmark for floor-length garments to draw over feet/shoes
     - map: [ "ears" ]
     - map: [ "eyes" ]
     - map: [ "id" ]

--- a/Resources/Prototypes/_Pirate/Entities/Clothing/ee_generic.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Clothing/ee_generic.yml
@@ -2174,6 +2174,14 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/evening_gown.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/evening_gown.rsi
+  - type: HideLayerClothing
+    force: true
+    slots:
+    - LFoot
+    - RFoot
+  - type: HideClothingLayerClothing
+    hiddenSlots:
+    - shoes
 
 
 - type: entity
@@ -2198,6 +2206,14 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/tea_dress.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/tea_dress.rsi
+  - type: HideLayerClothing
+    force: true
+    slots:
+    - LFoot
+    - RFoot
+  - type: HideClothingLayerClothing
+    hiddenSlots:
+    - shoes
 
 
 - type: entity
@@ -2437,6 +2453,14 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/fluffy.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/fluffy.rsi
+  - type: HideLayerClothing
+    force: true
+    slots:
+    - LFoot
+    - RFoot
+  - type: HideClothingLayerClothing
+    hiddenSlots:
+    - shoes
 
 
 - type: entity
@@ -2449,6 +2473,14 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/formalred.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/formalred.rsi
+  - type: HideLayerClothing
+    force: true
+    slots:
+    - LFoot
+    - RFoot
+  - type: HideClothingLayerClothing
+    hiddenSlots:
+    - shoes
 
 
 - type: entity
@@ -2461,6 +2493,14 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/gothic.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/gothic.rsi
+  - type: HideLayerClothing
+    force: true
+    slots:
+    - LFoot
+    - RFoot
+  - type: HideClothingLayerClothing
+    hiddenSlots:
+    - shoes
 
 
 - type: entity
@@ -2497,6 +2537,14 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/long_dress.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/long_dress.rsi
+  - type: HideLayerClothing
+    force: true
+    slots:
+    - LFoot
+    - RFoot
+  - type: HideClothingLayerClothing
+    hiddenSlots:
+    - shoes
 
 
 - type: entity
@@ -2509,6 +2557,14 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/long_flared_dress.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/long_flared_dress.rsi
+  - type: HideLayerClothing
+    force: true
+    slots:
+    - LFoot
+    - RFoot
+  - type: HideClothingLayerClothing
+    hiddenSlots:
+    - shoes
 
 
 - type: entity
@@ -2569,6 +2625,14 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/puffydress.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/puffydress.rsi
+  - type: HideLayerClothing
+    force: true
+    slots:
+    - LFoot
+    - RFoot
+  - type: HideClothingLayerClothing
+    hiddenSlots:
+    - shoes
 
 
 - type: entity
@@ -2593,6 +2657,14 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/sari_green.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/sari_green.rsi
+  - type: HideLayerClothing
+    force: true
+    slots:
+    - LFoot
+    - RFoot
+  - type: HideClothingLayerClothing
+    hiddenSlots:
+    - shoes
 
 
 - type: entity
@@ -2605,6 +2677,14 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/sari_red.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/sari_red.rsi
+  - type: HideLayerClothing
+    force: true
+    slots:
+    - LFoot
+    - RFoot
+  - type: HideClothingLayerClothing
+    hiddenSlots:
+    - shoes
 
 
 - type: entity
@@ -2677,6 +2757,14 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/victorian_black_dress.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/victorian_black_dress.rsi
+  - type: HideLayerClothing
+    force: true
+    slots:
+    - LFoot
+    - RFoot
+  - type: HideClothingLayerClothing
+    hiddenSlots:
+    - shoes
 
 
 - type: entity
@@ -2689,6 +2777,14 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/victorian_red_dress.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/victorian_red_dress.rsi
+  - type: HideLayerClothing
+    force: true
+    slots:
+    - LFoot
+    - RFoot
+  - type: HideClothingLayerClothing
+    hiddenSlots:
+    - shoes
 
 
 - type: entity
@@ -2725,6 +2821,7 @@
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Shoes/Misc/high_heels.rsi
   - type: HideLayerClothing
+    force: true
     slots:
     - LFoot
     - RFoot
@@ -2744,6 +2841,7 @@
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Shoes/Misc/long_high_heels.rsi
   - type: HideLayerClothing
+    force: true
     slots:
     - LFoot
     - RFoot

--- a/Resources/Prototypes/_Pirate/Entities/Clothing/ee_generic.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Clothing/ee_generic.yml
@@ -2174,14 +2174,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/evening_gown.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/evening_gown.rsi
-  - type: HideLayerClothing
-    force: true
-    slots:
-    - LFoot
-    - RFoot
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2206,14 +2199,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/tea_dress.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/tea_dress.rsi
-  - type: HideLayerClothing
-    force: true
-    slots:
-    - LFoot
-    - RFoot
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2262,6 +2248,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/black_tango.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/black_tango.rsi
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2273,6 +2260,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/black_tango_alt.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/black_tango_alt.rsi
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2285,6 +2273,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/cheongsamblue.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/cheongsamblue.rsi
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2297,6 +2286,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/cheongsamgreen.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/cheongsamgreen.rsi
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2309,6 +2299,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/cheongsampurple.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/cheongsampurple.rsi
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2321,6 +2312,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/cheongsamred.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/cheongsamred.rsi
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2333,6 +2325,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/cheongsamwhite.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/cheongsamwhite.rsi
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2393,6 +2386,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/flamenco.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/flamenco.rsi
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2417,6 +2411,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/dress_orange.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/dress_orange.rsi
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2453,14 +2448,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/fluffy.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/fluffy.rsi
-  - type: HideLayerClothing
-    force: true
-    slots:
-    - LFoot
-    - RFoot
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2473,14 +2461,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/formalred.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/formalred.rsi
-  - type: HideLayerClothing
-    force: true
-    slots:
-    - LFoot
-    - RFoot
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2493,14 +2474,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/gothic.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/gothic.rsi
-  - type: HideLayerClothing
-    force: true
-    slots:
-    - LFoot
-    - RFoot
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2513,6 +2487,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/kimono_color.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/kimono_color.rsi
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2525,6 +2500,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/lacy_gown.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/lacy_gown.rsi
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2537,14 +2513,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/long_dress.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/long_dress.rsi
-  - type: HideLayerClothing
-    force: true
-    slots:
-    - LFoot
-    - RFoot
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2557,14 +2526,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/long_flared_dress.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/long_flared_dress.rsi
-  - type: HideLayerClothing
-    force: true
-    slots:
-    - LFoot
-    - RFoot
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2589,6 +2551,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/qipao_slim.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/qipao_slim.rsi
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2625,14 +2588,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/puffydress.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/puffydress.rsi
-  - type: HideLayerClothing
-    force: true
-    slots:
-    - LFoot
-    - RFoot
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2657,14 +2613,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/sari_green.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/sari_green.rsi
-  - type: HideLayerClothing
-    force: true
-    slots:
-    - LFoot
-    - RFoot
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2677,14 +2626,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/sari_red.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/sari_red.rsi
-  - type: HideLayerClothing
-    force: true
-    slots:
-    - LFoot
-    - RFoot
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2709,6 +2651,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/spider.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/spider.rsi
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2757,14 +2700,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/victorian_black_dress.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/victorian_black_dress.rsi
-  - type: HideLayerClothing
-    force: true
-    slots:
-    - LFoot
-    - RFoot
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 
 - type: entity
@@ -2777,14 +2713,7 @@
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/victorian_red_dress.rsi
   - type: Clothing
     sprite: _Pirate/Loadouts/EEGeneric/Clothing/Uniforms/Jumpskirt/victorian_red_dress.rsi
-  - type: HideLayerClothing
-    force: true
-    slots:
-    - LFoot
-    - RFoot
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 
 - type: entity


### PR DESCRIPTION
## Вимоги
<!-- Підтвердіть наступне, записавши X у квадратні дужки [X]: -->
- [x] Я прочитав та дотримуюсь [Правил запитів на злиття та журналу змін](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я додав медіа, **АБО** цей запит на злиття не потребує медіа.
<!-- Ви повинні розуміти, що недотримування пунктів вище може бути підставою для закриття вашого запиту. -->


**Журнал змін**

:cl:
- fix: поломане відображення категорій в лоадауті для екранів на холодильниках (на малому розширенні)
- fix: підбори не показуюь спрайти ніг
- fix: довгий одяг з лоадауту перекриває взуття, а не показується під ним
- feat: кастомізація імен та описів предметів у лоадауті
- tweak: перекраска одягу в спорядженні показує превью кольору без збереження



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примітки до випуску

* **New Features**
  * Користувачі тепер можуть налаштовувати власні назви й описи для завантажень (у додачу до кольору)
  * Новий інтерфейс кастомізації з функцією попереднього перегляду змін
  * Покращена система відображення шарів одягу й спорядження

* **Refactor**
  * Переорганізована розмітка вкладки завантажень для краще зручності

<!-- end of auto-generated comment: release notes by coderabbit.ai -->