### PR TITLE
Порт реактивації сканера здоров'я

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
@@ -220,10 +220,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                             </PanelContainer>
                             <TextureRect Name="NoDataTex"
                                         Access="Public"
-                                        SetSize="64 64"
+                                        SetSize="96 96"
                                         Visible="false"
                                         Stretch="KeepAspectCentered"
-                                        TexturePath="/Textures/Interface/Misc/health_analyzer_out_of_range.png"/>
+                                        TexturePath="/Textures/Interface/Misc/health_analyzer_out_of_range.png"/> <!-- Pirate: Match Shitmed preview size. -->
                             <BoxContainer Margin="5 0 0 0"
                                         Orientation="Vertical"
                                         VerticalAlignment="Top">

--- a/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
+++ b/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
@@ -88,6 +88,12 @@ public sealed partial class HealthAnalyzerComponent : Component
     public SoundSpecifier ScanningEndSound = new SoundPathSpecifier("/Audio/Items/Medical/healthscanner.ogg");
 
     /// <summary>
+    /// Pirate: Whether the analyzer last sent an active scan update.
+    /// </summary>
+    [DataField]
+    public bool IsAnalyzerActive;
+
+    /// <summary>
     /// Whether to show up the popup
     /// </summary>
     [DataField]

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -215,11 +215,12 @@ public sealed class HealthAnalyzerSystem : EntitySystem
             var patientCoordinates = Transform(patient).Coordinates;
             if (component.MaxScanRange != null && !_transformSystem.InRange(patientCoordinates, transform.Coordinates, component.MaxScanRange.Value))
             {
-                //Range too far, disable updates
-                StopAnalyzingEntity((uid, component), patient);
+                // Pirate: Pause the scanner UI until the target returns to range.
+                PauseAnalyzingEntity((uid, component), patient);
                 continue;
             }
 
+            component.IsAnalyzerActive = true; // Pirate: Analyzer reactivation.
             UpdateScannedUser(uid, patient, true, component.CurrentMode, component.CurrentBodyPart); // Shitmed Change
         }
     }
@@ -306,6 +307,7 @@ public sealed class HealthAnalyzerSystem : EntitySystem
         //Link the health analyzer to the scanned entity
         healthAnalyzer.Comp.ScannedEntity = target;
         healthAnalyzer.Comp.CurrentBodyPart = part; // Shitmed Change
+        healthAnalyzer.Comp.IsAnalyzerActive = true; // Pirate: Analyzer reactivation.
 
         _toggle.TryActivate(healthAnalyzer.Owner);
 
@@ -322,9 +324,24 @@ public sealed class HealthAnalyzerSystem : EntitySystem
         //Unlink the analyzer
         healthAnalyzer.Comp.ScannedEntity = null;
         healthAnalyzer.Comp.CurrentBodyPart = null; // Shitmed Change
+        healthAnalyzer.Comp.IsAnalyzerActive = false; // Pirate: Analyzer reactivation.
         _toggle.TryDeactivate(healthAnalyzer.Owner);
 
         UpdateScannedUser(healthAnalyzer, target, false, healthAnalyzer.Comp.CurrentMode);
+    }
+
+    /// <summary>
+    /// Pirate: Send one inactive update while keeping the scan linked so it can resume when back in range.
+    /// </summary>
+    /// <param name="healthAnalyzer">The health analyzer that's receiving the updates</param>
+    /// <param name="target">The entity to analyze</param>
+    private void PauseAnalyzingEntity(Entity<HealthAnalyzerComponent> healthAnalyzer, EntityUid target)
+    {
+        if (!healthAnalyzer.Comp.IsAnalyzerActive)
+            return;
+
+        UpdateScannedUser(healthAnalyzer, target, false, healthAnalyzer.Comp.CurrentMode, healthAnalyzer.Comp.CurrentBodyPart);
+        healthAnalyzer.Comp.IsAnalyzerActive = false;
     }
 
     // Shitmed Change Start


### PR DESCRIPTION
Портує реактивацію сканера здоров'я після повернення в радіус сканування.

Джерело: https://github.com/teamstarcup/starcup/pull/84
Оригінал: https://github.com/DeltaV-Station/Delta-v/pull/3521

:cl:
- fix: Сканер здоров'я знову активується після повернення до пацієнта в радіус сканування.