### PR TITLE
Порт редагування опису персонажа під час раунду

### DIFF
--- a/Content.Client/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Client/CharacterInfo/CharacterInfoSystem.cs
@@ -47,10 +47,18 @@ public sealed class CharacterInfoSystem : EntitySystem
         RaiseNetworkEvent(new RequestCharacterInfoEvent(GetNetEntity(entity.Value)));
     }
 
+    // Pirate: in-round flavor text edits
+    public void UpdateDetailExaminable(string content)
+    {
+        RaiseNetworkEvent(new UpdateDetailExaminableEvent(content));
+    }
+
     private void OnCharacterInfoEvent(CharacterInfoEvent msg, EntitySessionEventArgs args)
     {
-        var entity = GetEntity(msg.NetEntity);
-        var data = new CharacterData(entity, msg.JobTitle, msg.Objectives, msg.Briefing, Name(entity), msg.Memory); // Pirate banking
+        if (!TryGetEntity(msg.NetEntity, out var entity))
+            return;
+
+        var data = new CharacterData(entity.Value, msg.JobTitle, msg.Objectives, msg.Briefing, msg.DetailExaminable, Name(entity.Value), msg.Memory); // Pirate banking
 
         OnCharacterUpdate?.Invoke(data);
     }
@@ -67,6 +75,7 @@ public sealed class CharacterInfoSystem : EntitySystem
         string Job,
         Dictionary<string, List<ObjectiveInfo>> Objectives,
         string? Briefing,
+        string? DetailExaminable, // Pirate: in-round flavor text edits
         string EntityName,
         Dictionary<string, string> Memory //Pirate Banking
     );

--- a/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
+++ b/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
@@ -79,6 +79,10 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
 
         _window.OnClose += DeactivateButton;
         _window.OnOpen += ActivateButton;
+        _window.DetailExaminableContainer.Visible = false; // Pirate: in-round flavor text edits
+        _window.DetailExaminableTextEdit.Placeholder = new Rope.Leaf(Loc.GetString("flavor-text-placeholder"));
+        _window.DetailExaminableTextEdit.OnTextChanged += OnDetailExaminableChanged; // Pirate: in-round flavor text edits
+        _window.DetailExaminableSubmitButton.OnPressed += OnDetailExaminableSubmit; // Pirate: in-round flavor text edits
 
         CommandBinds.Builder
             .Bind(ContentKeyFunctions.OpenCharacterMenu,
@@ -90,6 +94,10 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
     {
         if (_window != null)
         {
+            _window.OnClose -= DeactivateButton;
+            _window.OnOpen -= ActivateButton;
+            _window.DetailExaminableTextEdit.OnTextChanged -= OnDetailExaminableChanged; // Pirate: in-round flavor text edits
+            _window.DetailExaminableSubmitButton.OnPressed -= OnDetailExaminableSubmit; // Pirate: in-round flavor text edits
             _window.Close();
             _window = null;
         }
@@ -137,6 +145,7 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
         }
 
         CharacterButton.Pressed = false;
+        _window?.DetailExaminableSubmitButton.Disabled = true; // Pirate: in-round flavor text edits
     }
 
     private void ActivateButton()
@@ -156,7 +165,7 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
             return;
         }
 
-        var (entity, job, objectives, briefing, entityName, memories) = data; // Pirate banking
+        var (entity, job, objectives, briefing, detailExaminable, entityName, memories) = data; // Pirate banking
 
         _window.SpriteView.SetEntity(entity);
 
@@ -167,6 +176,13 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
         _window.Objectives.RemoveAllChildren();
         _window.ObjectivesLabel.Visible = objectives.Any();
         _window.Memories.RemoveAllChildren(); //Pirate banking
+        _window.DetailExaminableContainer.Visible = detailExaminable != null; // Pirate: in-round flavor text edits
+
+        if (detailExaminable != null)
+        {
+            _window.DetailExaminableTextEdit.TextRope = new Rope.Leaf(detailExaminable);
+            _window.DetailExaminableSubmitButton.Disabled = true;
+        }
 
         foreach (var (groupId, conditions) in objectives)
         {
@@ -301,5 +317,25 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
             _characterInfo.RequestCharacterInfo();
             _window.Open();
         }
+    }
+
+    // Pirate: in-round flavor text edits
+    private void OnDetailExaminableSubmit(ButtonEventArgs args)
+    {
+        if (_window == null)
+            return;
+
+        var text = Rope.Collapse(_window.DetailExaminableTextEdit.TextRope).Trim();
+        _window.DetailExaminableSubmitButton.Disabled = true;
+        _characterInfo.UpdateDetailExaminable(text);
+    }
+
+    // Pirate: in-round flavor text edits
+    private void OnDetailExaminableChanged(TextEdit.TextEditEventArgs args)
+    {
+        if (_window == null)
+            return;
+
+        _window.DetailExaminableSubmitButton.Disabled = false;
     }
 }

--- a/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
+++ b/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
@@ -145,7 +145,8 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
         }
 
         CharacterButton.Pressed = false;
-        _window?.DetailExaminableSubmitButton.Disabled = true; // Pirate: in-round flavor text edits
+        if (_window != null)
+            _window.DetailExaminableSubmitButton.Disabled = true; // Pirate: in-round flavor text edits
     }
 
     private void ActivateButton()

--- a/Content.Client/UserInterface/Systems/Character/Windows/CharacterWindow.xaml
+++ b/Content.Client/UserInterface/Systems/Character/Windows/CharacterWindow.xaml
@@ -35,6 +35,19 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             <Label Name="ObjectivesLabel" Access="Public" Text="{Loc 'character-info-objectives-label'}" HorizontalAlignment="Center"/>
             <BoxContainer Orientation="Vertical" Name="Objectives" Access="Public"/>
             <cc:Placeholder Name="RolePlaceholder" Access="Public" PlaceholderText="{Loc 'character-info-roles-antagonist-text'}"/>
+            <PanelContainer Name="DetailExaminableContainer" Access="Public" StyleClasses="PanelLight" Margin="0 4 0 0">
+                <!-- Pirate: in-round flavor text edits -->
+                <BoxContainer Orientation="Vertical" Margin="10 2 10 0">
+                    <Label Text="{Loc 'character-info-detail-examinable-label'}" StyleClasses="LabelKeyText" VerticalAlignment="Bottom"/>
+                    <PanelContainer StyleClasses="PanelDark" Margin="0 0 0 6">
+                        <TextEdit Name="DetailExaminableTextEdit" Access="Public" MinHeight="160" Margin="5 5" VerticalExpand="True"/>
+                    </PanelContainer>
+                    <BoxContainer Orientation="Horizontal">
+                        <Control HorizontalExpand="True"/>
+                        <Button Name="DetailExaminableSubmitButton" Text="{Loc 'character-info-detail-examinable-submit'}" Disabled="True" Access="Public" HorizontalAlignment="Right"/>
+                    </BoxContainer>
+                </BoxContainer>
+            </PanelContainer>
         </BoxContainer>
     </ScrollContainer>
 </windows:CharacterWindow>

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -166,7 +166,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         if (!_charInfoIsAttach)
             return;
 
-        var (_, job, _, _, entityName, _) = data;
+        var (_, job, _, _, _, entityName, _) = data; // Pirate: in-round flavor text edits
 
         // Mark this entity's name as our character name for the "UpdateHighlights" function.
         var newHighlights = "@" + entityName;

--- a/Content.Server/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Server/CharacterInfo/CharacterInfoSystem.cs
@@ -110,7 +110,7 @@ public sealed class CharacterInfoSystem : EntitySystem
             return;
 
         var maxFlavorTextLength = _cfg.GetCVar(CCVars.MaxFlavorTextLength);
-        var newContent = FormattedMessage.RemoveMarkupOrThrow(msg.Content);
+        var newContent = FormattedMessage.RemoveMarkupPermissive(msg.Content);
         if (newContent.Length > maxFlavorTextLength)
             newContent = newContent[..maxFlavorTextLength];
 

--- a/Content.Server/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Server/CharacterInfo/CharacterInfoSystem.cs
@@ -16,20 +16,31 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Server.Administration.Logs;
 using Content.Server.Mind;
+using Content.Server.Preferences.Managers;
 using Content.Server.Roles;
 using Content.Server.Roles.Jobs;
+using Content.Shared.CCVar;
 using Content.Shared.CharacterInfo;
+using Content.Shared.Database;
+using Content.Shared.DetailExaminable;
 using Content.Shared.Objectives;
 using Content.Shared.Objectives.Components;
 using Content.Shared.Objectives.Systems;
+using Content.Shared.Preferences;
+using Robust.Shared.Configuration;
+using Robust.Shared.Utility;
 
 namespace Content.Server.CharacterInfo;
 
 public sealed class CharacterInfoSystem : EntitySystem
 {
+    [Dependency] private readonly IAdminLogManager _log = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly JobSystem _jobs = default!;
     [Dependency] private readonly MindSystem _minds = default!;
+    [Dependency] private readonly IServerPreferencesManager _preferencesManager = default!;
     [Dependency] private readonly RoleSystem _roles = default!;
     [Dependency] private readonly SharedObjectivesSystem _objectives = default!;
 
@@ -38,6 +49,7 @@ public sealed class CharacterInfoSystem : EntitySystem
         base.Initialize();
 
         SubscribeNetworkEvent<RequestCharacterInfoEvent>(OnRequestCharacterInfoEvent);
+        SubscribeNetworkEvent<UpdateDetailExaminableEvent>(OnUpdateDetailExaminableEvent);
     }
 
     private void OnRequestCharacterInfoEvent(RequestCharacterInfoEvent msg, EntitySessionEventArgs args)
@@ -83,6 +95,36 @@ public sealed class CharacterInfoSystem : EntitySystem
             //Pirate banking end
         }
 
-        RaiseNetworkEvent(new CharacterInfoEvent(GetNetEntity(entity), jobTitle, objectives, briefing, memories), args.SenderSession); //Pirate banking
+        string? detailExaminable = null; // Pirate: in-round flavor text edits
+        if (_cfg.GetCVar(CCVars.FlavorText))
+            detailExaminable = TryComp<DetailExaminableComponent>(entity, out var detail) ? detail.Content : string.Empty;
+
+        RaiseNetworkEvent(new CharacterInfoEvent(GetNetEntity(entity), jobTitle, objectives, briefing, detailExaminable, memories), args.SenderSession); //Pirate banking
+    }
+
+    // Pirate: in-round flavor text edits
+    private void OnUpdateDetailExaminableEvent(UpdateDetailExaminableEvent msg, EntitySessionEventArgs args)
+    {
+        if (!_cfg.GetCVar(CCVars.FlavorText)
+            || args.SenderSession.AttachedEntity is not { } entity)
+            return;
+
+        var maxFlavorTextLength = _cfg.GetCVar(CCVars.MaxFlavorTextLength);
+        var newContent = FormattedMessage.RemoveMarkupOrThrow(msg.Content);
+        if (newContent.Length > maxFlavorTextLength)
+            newContent = newContent[..maxFlavorTextLength];
+
+        var detail = EnsureComp<DetailExaminableComponent>(entity);
+        detail.Content = newContent;
+        Dirty(entity, detail);
+
+        var preferences = _preferencesManager.GetPreferences(args.SenderSession.UserId);
+        if (preferences.SelectedCharacter is HumanoidCharacterProfile profile)
+        {
+            var updatedProfile = profile.WithFlavorText(newContent);
+            _ = _preferencesManager.SetProfile(args.SenderSession.UserId, preferences.SelectedCharacterIndex, updatedProfile);
+        }
+
+        _log.Add(LogType.Identity, LogImpact.Medium, $"{ToPrettyString(entity):user} updated their flavor text");
     }
 }

--- a/Content.Shared/CharacterInfo/SharedCharacterInfoSystem.cs
+++ b/Content.Shared/CharacterInfo/SharedCharacterInfoSystem.cs
@@ -32,14 +32,28 @@ public sealed class CharacterInfoEvent : EntityEventArgs
     public readonly string JobTitle;
     public readonly Dictionary<string, List<ObjectiveInfo>> Objectives;
     public readonly string? Briefing;
+    public readonly string? DetailExaminable; // Pirate: in-round flavor text edits
     public readonly Dictionary<string, string> Memory; //Pirate banking
 
-    public CharacterInfoEvent(NetEntity netEntity, string jobTitle, Dictionary<string, List<ObjectiveInfo>> objectives, string? briefing, Dictionary<string, string> memory) //Pirate banking
+    public CharacterInfoEvent(NetEntity netEntity, string jobTitle, Dictionary<string, List<ObjectiveInfo>> objectives, string? briefing, string? detailExaminable, Dictionary<string, string> memory) //Pirate banking
     {
         NetEntity = netEntity;
         JobTitle = jobTitle;
         Objectives = objectives;
         Briefing = briefing;
+        DetailExaminable = detailExaminable; // Pirate: in-round flavor text edits
         Memory = memory; //Pirate banking
+    }
+}
+
+// Pirate: in-round flavor text edits
+[Serializable, NetSerializable]
+public sealed class UpdateDetailExaminableEvent : EntityEventArgs
+{
+    public readonly string Content;
+
+    public UpdateDetailExaminableEvent(string content)
+    {
+        Content = content;
     }
 }

--- a/Resources/Locale/en-US/character-info/components/character-info-component.ftl
+++ b/Resources/Locale/en-US/character-info/components/character-info-component.ftl
@@ -11,3 +11,5 @@ character-info-title = Character
 character-info-roles-antagonist-text = You have no special Roles
 character-info-objectives-label = Objectives
 character-info-no-profession = No Profession
+character-info-detail-examinable-label = Description
+character-info-detail-examinable-submit = Update Description

--- a/Resources/Locale/uk-UA/character-info/components/character-info-component.ftl
+++ b/Resources/Locale/uk-UA/character-info/components/character-info-component.ftl
@@ -3,3 +3,5 @@ character-info-roles-antagonist-text = Ролі антагоніста
 character-info-objectives-label = Завдання
 
 character-info-no-profession = Без професії
+character-info-detail-examinable-label = Опис
+character-info-detail-examinable-submit = Оновити опис


### PR DESCRIPTION
Портовано редагування опису персонажа під час раунду.

Джерело: https://github.com/lagrange14/substations/pull/531

:cl:
- add: Додано можливість змінювати опис персонажа під час раунду через меню персонажа.