### PR TITLE
Фікс прогнозування магнітного підбору руди

### DIFF
--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -42,6 +42,11 @@ public sealed class MagnetPickupSystem : EntitySystem
 
     private static readonly TimeSpan ScanDelay = TimeSpan.FromSeconds(1);
 
+    /// <summary>
+    /// Reused list of nearby pickup candidates so we can sort them deterministically without allocating every scan.
+    /// </summary>
+    private readonly List<EntityUid> _nearby = [];
+
     private EntityQuery<PhysicsComponent> _physicsQuery;
 
     public override void Initialize()
@@ -88,12 +93,12 @@ public sealed class MagnetPickupSystem : EntitySystem
                 continue;
             // WD EDIT END
 
-             if (comp.NextScan > currentTime)
+            if (comp.NextScan > currentTime)
                 continue;
 
             comp.NextScan += ScanDelay;
 
-                        // WD EDIT START. Added ForcePickup.
+            // WD EDIT START. Added ForcePickup.
             if (!comp.ForcePickup && !_inventory.TryGetContainingSlot((uid, xform, meta), out _))
                 continue;
 
@@ -105,8 +110,11 @@ public sealed class MagnetPickupSystem : EntitySystem
             var playedSound = false;
             var finalCoords = xform.Coordinates;
             var moverCoords = _transform.GetMoverCoordinates(uid, xform);
+            _nearby.Clear();
+            _nearby.AddRange(_lookup.GetEntitiesInRange(uid, comp.Range, LookupFlags.Dynamic | LookupFlags.Sundries));
+            _nearby.Sort((a, b) => GetNetEntity(a).CompareTo(GetNetEntity(b)));
 
-            foreach (var near in _lookup.GetEntitiesInRange(uid, comp.Range, LookupFlags.Dynamic | LookupFlags.Sundries))
+            foreach (var near in _nearby)
             {
                 if (_whitelistSystem.IsWhitelistFail(storage.Whitelist, near))
                     continue;
@@ -125,11 +133,11 @@ public sealed class MagnetPickupSystem : EntitySystem
                 var nearMap = _transform.GetMapCoordinates(near, xform: nearXform);
                 var nearCoords = _transform.ToCoordinates(moverCoords.EntityId, nearMap);
 
-                if (!_storage.Insert(uid, near, out var stacked, storageComp: storage, playSound: !playedSound))
+                if (!_storage.Insert(uid, near, out var stacked, user: parentUid, storageComp: storage, playSound: !playedSound))
                     continue;
 
                 // Play pickup animation for either the stack entity or the original entity.
-                                _storage.PlayPickupAnimation(stacked ?? near, nearCoords, finalCoords, nearXform.LocalRotation);
+                _storage.PlayPickupAnimation(stacked ?? near, nearCoords, finalCoords, nearXform.LocalRotation, parentUid);
 
                 playedSound = true;
             }


### PR DESCRIPTION
Порт фіксу прогнозування магнітного підбору для рудних сумок.

Джерело: https://github.com/space-wizards/space-station-14/pull/43998

:cl:
- fix: Виправлено ривки й помилки прогнозування під час магнітного підбору руди в сумку.
