### PR TITLE
Піднімає поріг появи блоба

### DIFF
--- a/Content.Goobstation.Server/Blob/StationEvents/BlobSpawn.cs
+++ b/Content.Goobstation.Server/Blob/StationEvents/BlobSpawn.cs
@@ -43,6 +43,13 @@ public sealed class BlobSpawnRule : StationEventSystem<BlobSpawnRuleComponent>
     {
         base.Started(uid, component, gameRule, args);
 
+        // Pirate - Blob should never appear automatically on lowpop, even if the rule is started directly.
+        if (_playerSystem.PlayerCount < gameRule.MinPlayers)
+        {
+            GameTicker.EndGameRule(uid, gameRule);
+            return;
+        }
+
         if (!TryGetRandomStation(out var station))
         {
             return;

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -90,6 +90,7 @@
       Death: 400
     eventType: HostilesSpawn
   - type: GameRule
+    minPlayers: 40 # Pirate - keep direct BlobMidround starts off lowpop.
     chaosScore: 1100
   - type: BlobSpawnRule
     carrierBlobProtos:

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -272,7 +272,7 @@
   components:
   - type: BlobRule
   - type: GameRule
-    minPlayers: 20
+    minPlayers: 40 # Pirate - keep blob off lowpop.
     chaosScore: 1000
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
@@ -300,7 +300,7 @@
     weight: 1
     duration: 1
     earliestStart: 50
-    minimumPlayers: 20
+    minimumPlayers: 40 # Pirate - keep blob off lowpop.
     maxOccurrences: 2
     chaos:
       Hostile: 200
@@ -308,6 +308,7 @@
       Medical: 200
     eventType: HostilesSpawn
   - type: GameRule
+    minPlayers: 40 # Pirate - keep direct BlobSpawn starts off lowpop.
     chaosScore: 1000
   - type: BlobSpawnRule
     carrierBlobProtos:


### PR DESCRIPTION
Блоб більше не має автоматично з’являтися, якщо онлайн нижче 40 гравців.

:cl:
- tweak: Блоб тепер потребує щонайменше 40 гравців для автоматичної появи.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blob-події та режим Blob тепер не запускаються на серверах із низькою кількістю гравців.
  * Порог запуску підвищено, тож прямі старти Blob стали рідшими та стабільнішими для малонаселених раундів.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->