### PR TITLE
Виправити шепіт для короткозорості

### DIFF
--- a/Content.Goobstation.Server/Chat/DeafnessBlindnessSystem.cs
+++ b/Content.Goobstation.Server/Chat/DeafnessBlindnessSystem.cs
@@ -52,7 +52,8 @@ public sealed class DeafnessBlindnessSystem : EntitySystem
     }
     private void OnBlindnessOverrideInRange(Entity<PermanentBlindnessComponent> ent, ref ChatMessageOverrideInRange args)
     {
-        if (!args.RequiresSight)
+        // Pirate: PoorVision also uses PermanentBlindnessComponent, but only full blindness should block sight-only chat.
+        if (!args.RequiresSight || ent.Comp.Blindness != 0)
             return;
         args.Cancel();
     }

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -146,7 +146,6 @@ using Content.Shared.Radio;
 using Content.Shared.Station.Components;
 using Content.Shared.Whitelist;
 using Content.Goobstation.Common.Chat;
-using Content.Goobstation.Common.Traits;
 using Robust.Server.Player;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
@@ -160,11 +159,6 @@ using Robust.Shared.Replays;
 using Robust.Shared.Utility;
 using Content.Pirate.Common._EinsteinEngines.Chat;
 using Content.Shared._RMC14.CCVar;
-
-// Goob start - the blind dont see
-using Content.Shared.Eye.Blinding.Components;
-using Content.Shared.Traits.Assorted;
-// Goob end
 
 namespace Content.Server.Chat.Systems;
 
@@ -849,10 +843,12 @@ public sealed partial class ChatSystem : SharedChatSystem
                 continue; // Won't get logged to chat, and ghosts are too far away to see the pop-up, so we just won't send it to them.
 
             // Goob edit start
-            if (TryComp<DeafComponent>(listener, out var modifier) && language.SpeechOverride.RequireSpeech)
-                continue; // blocks anyone with the deaf component from hearing.
-            if (HasComp<PermanentBlindnessComponent>(listener) || HasComp<TemporaryBlindnessComponent>(listener))
-                continue; // block blind people from seeing subtle sign language gestures
+            // Raises an event for deaf and blind components.
+            // Pirate: use the same override path as spoken chat so PoorVision is not treated as full blindness.
+            var overrideEv = new ChatMessageOverrideInRange(language.SpeechOverride.RequireSpeech, language.SpeechOverride.RequireSight);
+            RaiseLocalEvent(listener, ref overrideEv);
+            if (overrideEv.Cancelled)
+                continue;
             // Goob edit end
 
             // Einstein Engines - Language begin


### PR DESCRIPTION
Виправляє блокування шепоту для персонажів із короткозорістю.

:cl:
- fix: Короткозорість більше не заважає чути шепіт.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Шепіт тепер коректніше враховує слух і зір: повідомлення не надсилатимуться тим, хто не відповідає вимогам для сприйняття.
  * Виправлено блокування чат-повідомлень, що потребують зору: вони тепер не блокуються для часткового погіршення зору, а лише за повної сліпоти.
  * Зроблено обробку чат-повідомлень більш узгодженою для персонажів із вадами слуху або зору.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->