### PR TITLE
Fix replay loading client requests

### DIFF
--- a/Content.Client/Administration/Systems/AdminInfoSystem.cs
+++ b/Content.Client/Administration/Systems/AdminInfoSystem.cs
@@ -18,6 +18,7 @@ public sealed class AdminInfoSystem : EntitySystem
 {
     [Dependency] private readonly IPlayerManager _u = default!;
     [Dependency] private readonly IResourceManager _k = default!;
+    [Dependency] private readonly IClientNetManager _net = default!;
 
     public override void Initialize()
     {
@@ -45,6 +46,10 @@ public sealed class AdminInfoSystem : EntitySystem
 
     private void r(EntityEventArgs z)
     {
+        // Pirate: Do not emit startup network events while loading replays.
+        if (!_net.IsConnected)
+            return;
+
         RaiseNetworkEvent(z);
     }
 

--- a/Content.Client/Guidebook/GuidebookDataSystem.cs
+++ b/Content.Client/Guidebook/GuidebookDataSystem.cs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Shared.Guidebook;
+using Robust.Shared.Network;
 
 namespace Content.Client.Guidebook;
 
@@ -15,6 +16,8 @@ namespace Content.Client.Guidebook;
 /// </summary>
 public sealed class GuidebookDataSystem : EntitySystem
 {
+    [Dependency] private readonly IClientNetManager _net = default!;
+
     private GuidebookData? _data;
 
     public override void Initialize()
@@ -24,7 +27,9 @@ public sealed class GuidebookDataSystem : EntitySystem
         SubscribeNetworkEvent<UpdateGuidebookDataEvent>(OnServerUpdated);
 
         // Request data from the server
-        RaiseNetworkEvent(new RequestGuidebookDataEvent());
+        // Pirate: Replay startup has no server connection to request guidebook data from.
+        if (_net.IsConnected)
+            RaiseNetworkEvent(new RequestGuidebookDataEvent());
     }
 
     private void OnServerUpdated(UpdateGuidebookDataEvent args)

--- a/Content.Client/Physics/Controllers/MoverController.cs
+++ b/Content.Client/Physics/Controllers/MoverController.cs
@@ -36,6 +36,7 @@ using Content.Shared.Movement.Systems;
 using Robust.Client.Physics;
 using Robust.Client.Player;
 using Robust.Shared.Configuration;
+using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
 
@@ -47,6 +48,7 @@ public sealed class MoverController : SharedMoverController
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly AlertsSystem _alerts = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IClientNetManager _net = default!;
 
     public override void Initialize()
     {
@@ -60,7 +62,16 @@ public sealed class MoverController : SharedMoverController
         SubscribeLocalEvent<MovementRelayTargetComponent, UpdateIsPredictedEvent>(OnUpdateRelayTargetPredicted);
         SubscribeLocalEvent<PullableComponent, UpdateIsPredictedEvent>(OnUpdatePullablePredicted);
 
-        Subs.CVar(_cfg, CCVars.DefaultWalk, _ => RaiseNetworkEvent(new UpdateInputCVarsMessage()));
+        Subs.CVar(_cfg, CCVars.DefaultWalk, _ => SendInputCvars());
+    }
+
+    private void SendInputCvars()
+    {
+        // Pirate: Replay metadata applies CVars locally without a server connection.
+        if (!_net.IsConnected)
+            return;
+
+        RaiseNetworkEvent(new UpdateInputCVarsMessage());
     }
 
     private void OnUpdatePredicted(Entity<InputMoverComponent> entity, ref UpdateIsPredictedEvent args)

--- a/Content.Goobstation.Client/Polls/PollManager.cs
+++ b/Content.Goobstation.Client/Polls/PollManager.cs
@@ -23,8 +23,14 @@ public sealed class PollManager
 
     public bool HasUnseenPolls => _activePolls.Values.Any(p => p.Active && !_seenPolls.Contains(p.PollId));
 
+    // Pirate: Replay clients run disconnected; do not send poll requests from replay state/UI.
+    private bool CanSend() => _net.IsConnected;
+
     public void MarkAllSeen()
     {
+        if (!CanSend())
+            return;
+
         var changed = false;
         foreach (var poll in _activePolls.Values)
         {
@@ -54,18 +60,27 @@ public sealed class PollManager
 
     public void RequestActivePolls()
     {
+        if (!CanSend())
+            return;
+
         var msg = new MsgRequestActivePolls();
         _net.ClientSendMessage(msg);
     }
 
     public void RequestPollDetails(int pollId)
     {
+        if (!CanSend())
+            return;
+
         var msg = new MsgRequestPollDetails { PollId = pollId };
         _net.ClientSendMessage(msg);
     }
 
     public void CastVote(int pollId, int optionId)
     {
+        if (!CanSend())
+            return;
+
         if (!_playerVotes.ContainsKey(pollId))
             _playerVotes[pollId] = [];
 
@@ -92,6 +107,9 @@ public sealed class PollManager
 
     public void RemoveVote(int pollId, int optionId)
     {
+        if (!CanSend())
+            return;
+
         if (_playerVotes.TryGetValue(pollId, out var value))
             value.RemoveAll(v => v.OptionId == optionId);
 

--- a/Content.Goobstation.Client/Polls/PollManager.cs
+++ b/Content.Goobstation.Client/Polls/PollManager.cs
@@ -6,6 +6,8 @@ namespace Content.Goobstation.Client.Polls;
 
 public sealed class PollManager
 {
+    private const string NotConnectedError = "not connected";
+
     [Dependency] private readonly IClientNetManager _net = default!;
 
     private readonly Dictionary<int, PollData> _activePolls = [];
@@ -61,7 +63,13 @@ public sealed class PollManager
     public void RequestActivePolls()
     {
         if (!CanSend())
+        {
+            _activePolls.Clear();
+            _seenPolls.Clear();
+            OnActivePollsUpdated?.Invoke([]);
+            OnUnseenChanged?.Invoke();
             return;
+        }
 
         var msg = new MsgRequestActivePolls();
         _net.ClientSendMessage(msg);
@@ -70,7 +78,12 @@ public sealed class PollManager
     public void RequestPollDetails(int pollId)
     {
         if (!CanSend())
+        {
+            if (_activePolls.TryGetValue(pollId, out var poll))
+                OnPollDetailsReceived?.Invoke(poll, GetPlayerVotes(pollId));
+
             return;
+        }
 
         var msg = new MsgRequestPollDetails { PollId = pollId };
         _net.ClientSendMessage(msg);
@@ -79,7 +92,10 @@ public sealed class PollManager
     public void CastVote(int pollId, int optionId)
     {
         if (!CanSend())
+        {
+            OnVoteResponse?.Invoke(false, NotConnectedError);
             return;
+        }
 
         if (!_playerVotes.ContainsKey(pollId))
             _playerVotes[pollId] = [];
@@ -108,7 +124,10 @@ public sealed class PollManager
     public void RemoveVote(int pollId, int optionId)
     {
         if (!CanSend())
+        {
+            OnVoteResponse?.Invoke(false, NotConnectedError);
             return;
+        }
 
         if (_playerVotes.TryGetValue(pollId, out var value))
             value.RemoveAll(v => v.OptionId == optionId);

--- a/Content.Goobstation.Client/ServerCurrency/ClientCurrencyManager.cs
+++ b/Content.Goobstation.Client/ServerCurrency/ClientCurrencyManager.cs
@@ -14,6 +14,7 @@ namespace Content.Goobstation.Client.ServerCurrency;
 public sealed class ClientCurrencyManager : ICommonCurrencyManager, IEntityEventSubscriber, IPostInjectInit
 {
     [Dependency] private readonly IEntityManager _ent = default!;
+    [Dependency] private readonly IClientNetManager _net = default!;
     [Dependency] private readonly IPlayerManager _playMan = default!;
 
     private static int _cachedBalance = -1;
@@ -43,6 +44,10 @@ public sealed class ClientCurrencyManager : ICommonCurrencyManager, IEntityEvent
     private void OnStatusChanged(object? sender, SessionStatusEventArgs e)
     {
         if (e.NewStatus != SessionStatus.InGame)
+            return;
+
+        // Pirate: Replays run as singleplayer and have no server to answer this request.
+        if (!_net.IsConnected)
             return;
 
         var ev = new PlayerBalanceRequestEvent();

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Bones.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Bones.cs
@@ -219,7 +219,8 @@ public partial class TraumaSystem
 
         bool hasBrokenBones = false;
 
-        var rootPart = bodyComp.RootContainer.ContainedEntity;
+        // Pirate: Replay state application can call this before body containers are restored.
+        var rootPart = bodyComp.RootContainer?.ContainedEntity;
         if (rootPart.HasValue)
         {
             foreach (var (_, woundable) in _wound.GetAllWoundableChildren(rootPart.Value))


### PR DESCRIPTION
Фіксить помилки під час завантаження реплеїв: клієнтські системи більше не надсилають стартові запити без server connection, а Shitmed bone alert не падає на ще не відновленому body container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Виправлення помилок**
  * Покращено стабільність у сценаріях без активного з’єднання: деякі запити та сигнали більше не надсилаються під час запуску офлайн або в режимах відтворення.
  * Виправлено можливий збій під час оновлення сповіщення про стан кісток, коли дані персонажа ще не повністю доступні.
  * Зменшено ризик зайвих мережевих дій, що могло спричиняти некоректну поведінку в окремих клієнтських режимах.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->