### PR TITLE
Secretdoor fix

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -26,7 +26,7 @@
   description: Keeps the air in and the greytide out.
   components:
   - type: Sprite
-    sprite: Structures/Doors/secret_door.rsi
+    sprite: _Pirate/Structures/Doors/secret_door.rsi # Pirate
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
@@ -101,7 +101,7 @@
   - type: Clickable
   - type: InteractionOutline
   - type: Sprite
-    sprite: Structures/Doors/secret_door.rsi
+    sprite: _Pirate/Structures/Doors/secret_door.rsi # Pirate
     state: assembly
   - type: Physics
   - type: Fixtures

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -702,9 +702,9 @@
   suffix: indestructible
   components:
     - type: Sprite
-      sprite: _Pirate/Structures/Walls/plastitanium.rsi # Pirate
+      sprite: Structures/Walls/plastitanium.rsi
     - type: Icon
-      sprite: _Pirate/Structures/Walls/plastitanium.rsi # Pirate
+      sprite: Structures/Walls/plastitanium.rsi
     - type: IconSmooth
       key: walls
       base: plastitanium


### PR DESCRIPTION
:cl:
- fix: Звичайні секретні двері тепер використовують нову текстуру, замість старої
- fix: Пластитанові стіни використовують свою текстуру замість версії Онікса


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Зміни зовнішнього вигляду**
  * Оновлено візуальні ресурси для деяких дверей, щоб вони використовували піратську стилістику.
  * Виправлено відображення для особливого різновиду пластитанієвої стіни, щоб вона показувалася з правильними іконкою та спрайтом.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->