### PR TITLE
(не) немощний культ

### DIFF
--- a/Content.Pirate.Server/BloodCult/EntitySystems/BloodCultEntityEffectSystem.cs
+++ b/Content.Pirate.Server/BloodCult/EntitySystems/BloodCultEntityEffectSystem.cs
@@ -5,6 +5,8 @@
 using Content.Server.Body.Components;
 using Content.Server.Body.Systems;
 using Content.Server.Damage.Systems;
+using Content.Shared._DV.CosmicCult.Components;
+using Content.Shared._DV.CosmicCult.EntityEffects;
 using Content.Shared.BloodCult;
 using Content.Shared.BloodCult.Components;
 using Content.Shared.BloodCult.EntityEffects;
@@ -15,6 +17,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 
 namespace Content.Server.BloodCult.EntitySystems;
 
@@ -27,6 +30,8 @@ public sealed class BloodCultEntityEffectSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly StaminaSystem _stamina = default!;
     [Dependency] private readonly IComponentFactory _componentFactory = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly BloodCultMindShieldSystem _deconversion = default!;
 
     public override void Initialize()
     {
@@ -34,6 +39,29 @@ public sealed class BloodCultEntityEffectSystem : EntitySystem
 
         SubscribeLocalEvent<ExecuteEntityEffectEvent<BleedSanguinePerniculate>>(OnBleedSanguinePerniculate);
         SubscribeLocalEvent<ExecuteEntityEffectEvent<DeCultify>>(OnDeCultify);
+        SubscribeLocalEvent<ExecuteEntityEffectEvent<CleanseCult>>(OnCleanseCult);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<BloodCultistComponent, CleanseCultComponent>();
+        while (query.MoveNext(out var uid, out _, out var cleanse))
+        {
+            if (_timing.CurTime < cleanse.CleanseTime)
+                continue;
+
+            RemComp<CleanseCultComponent>(uid);
+            _deconversion.TryDeconvert(uid, popupLocId: null, stunDuration: TimeSpan.Zero, log: false);
+        }
+    }
+
+    private void OnCleanseCult(ref ExecuteEntityEffectEvent<CleanseCult> args)
+    {
+        var target = args.Args.TargetEntity;
+        if (HasComp<BloodCultistComponent>(target))
+            EnsureComp<CleanseCultComponent>(target);
     }
 
     private void OnBleedSanguinePerniculate(ref ExecuteEntityEffectEvent<BleedSanguinePerniculate> args)

--- a/Content.Pirate.Server/BloodCult/EntitySystems/BloodCultEntityEffectSystem.cs
+++ b/Content.Pirate.Server/BloodCult/EntitySystems/BloodCultEntityEffectSystem.cs
@@ -53,7 +53,7 @@ public sealed class BloodCultEntityEffectSystem : EntitySystem
                 continue;
 
             RemComp<CleanseCultComponent>(uid);
-            _deconversion.TryDeconvert(uid, popupLocId: null, stunDuration: TimeSpan.Zero, log: false);
+            _deconversion.TryDeconvert(uid, popupLocId: null, stunDuration: TimeSpan.Zero, log: true);
         }
     }
 

--- a/Content.Pirate.Server/BloodCult/EntitySystems/BloodCultMindShieldSystem.cs
+++ b/Content.Pirate.Server/BloodCult/EntitySystems/BloodCultMindShieldSystem.cs
@@ -8,7 +8,6 @@ using Content.Server.Popups;
 using Content.Server.Roles;
 using Content.Shared.Database;
 using Content.Shared.IdentityManagement;
-using Content.Shared.Mindshield.Components;
 using Content.Shared.Popups;
 using Content.Shared.Stunnable;
 using Content.Shared.BloodCult;
@@ -23,7 +22,7 @@ using Content.Shared.BloodCult.Components;
 namespace Content.Server.BloodCult.EntitySystems;
 
 /// <summary>
-/// System that handles Blood Cult deconversion when a mindshield is implanted.
+/// System that handles Blood Cult deconversion cleanup.
 /// </summary>
 public sealed class BloodCultMindShieldSystem : EntitySystem
 {
@@ -35,13 +34,6 @@ public sealed class BloodCultMindShieldSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly AppearanceSystem _appearance = default!;
     [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
-
-    public override void Initialize()
-    {
-        base.Initialize();
-        // Subscribe to MindShieldComponent being added to avoid duplicate subscriptions with other systems
-        SubscribeLocalEvent<MindShieldComponent, ComponentAdd>(OnMindShieldAdded);
-    }
 
     /// <summary>
     /// Attempts to deconvert a blood cultist, stripping their abilities and restoring their faction alignment.
@@ -104,17 +96,5 @@ public sealed class BloodCultMindShieldSystem : EntitySystem
             _appearance.SetData(uid, CultEyesVisuals.CultEyes, false, appearance);
             _appearance.SetData(uid, CultHaloVisuals.CultHalo, false, appearance);
         }
-    }
-
-    /// <summary>
-    /// When a mindshield component is added to an entity, check if they're a cultist and deconvert them.
-    /// </summary>
-    private void OnMindShieldAdded(EntityUid uid, MindShieldComponent comp, ComponentAdd args)
-    {
-        // Only process if they're a blood cultist
-        if (!HasComp<BloodCultistComponent>(uid))
-            return;
-
-        TryDeconvert(uid);
     }
 }

--- a/Content.Pirate.Server/BloodCult/EntitySystems/BloodCultRuneCarverSystem.cs
+++ b/Content.Pirate.Server/BloodCult/EntitySystems/BloodCultRuneCarverSystem.cs
@@ -323,6 +323,11 @@ public sealed partial class BloodCultRuneCarverSystem : EntitySystem
 		if (args.Handled)
 			return;
 
+		// Transient drawing runes (…Rune_drawing) inherit BloodCultRuneComponent but aren't finished
+		// runes yet - don't let them be activated mid-carve.
+		if (MetaData(rune).EntityPrototype?.ID.EndsWith("_drawing") == true)
+			return;
+
 		// Only cultists can invoke runes.
 		if (!HasComp<BloodCultistComponent>(args.User))
 			return;

--- a/Content.Pirate.Server/BloodCult/EntitySystems/BloodCultRuneCarverSystem.cs
+++ b/Content.Pirate.Server/BloodCult/EntitySystems/BloodCultRuneCarverSystem.cs
@@ -79,6 +79,10 @@ public sealed partial class BloodCultRuneCarverSystem : EntitySystem
 
 		SubscribeLocalEvent<BloodCultRuneCarverComponent, GotEquippedHandEvent>(OnEquipped);
 
+		// The blade now erases runes on click (TryRemoveRuneWithBlade), so cultists invoke runes by
+		// clicking them with an empty hand. Runs after EmpowerOnStandSystem so the empowering rune keeps its own handling.
+		SubscribeLocalEvent<BloodCultRuneComponent, InteractHandEvent>(OnRuneInteractHand, after: new[] { typeof(EmpowerOnStandSystem) });
+
 		_runeQuery = GetEntityQuery<BloodCultRuneComponent>();
 	}
 
@@ -155,6 +159,12 @@ public sealed partial class BloodCultRuneCarverSystem : EntitySystem
 		// Second, if clicking on a rune, trigger its normal interaction (same as clicking with open hand)
 		if (_runeQuery.HasComponent(target))
         {
+			if (TryRemoveRuneWithBlade(ent, args.User, target))
+			{
+				args.Handled = true;
+				return;
+			}
+
             // Raise InteractHandEvent to simulate clicking with an open hand
             var interactHandEvent = new InteractHandEvent(args.User, target);
             RaiseLocalEvent(target, interactHandEvent, true);
@@ -285,6 +295,49 @@ public sealed partial class BloodCultRuneCarverSystem : EntitySystem
 			);
 		_doAfter.TryStartDoAfter(dargs);
     }
+
+	private bool TryRemoveRuneWithBlade(Entity<BloodCultRuneCarverComponent> ent, EntityUid user, EntityUid target)
+	{
+		if (!HasComp<CleanableRuneComponent>(target))
+			return false;
+
+		// Mirror DeleteEntityEffect: the tear veil and final rift runes are major ritual runes and
+		// must not be scraped away with the blade. Returning false lets the click fall through to invocation.
+		if (HasComp<TearVeilComponent>(target) || HasComp<FinalSummoningRuneComponent>(target))
+			return false;
+
+		_popupSystem.PopupEntity(Loc.GetString("cult-rune-cleaned"), user, user, PopupType.MediumCaution);
+		_audioSystem.PlayPvs(ent.Comp.CarveSound, Transform(target).Coordinates);
+		QueueDel(target);
+		return true;
+	}
+
+	/// <summary>
+	/// Empty-hand invocation path. Because clicking a rune with the cult blade now erases it, cultists
+	/// invoke runes by clicking them with an empty hand instead. This mirrors the activation the blade
+	/// used to perform, firing the rune's trigger (offering, revive, summon, barrier, tear veil, ...).
+	/// </summary>
+	private void OnRuneInteractHand(Entity<BloodCultRuneComponent> rune, ref InteractHandEvent args)
+	{
+		// Skip if a more specific handler already dealt with it (e.g. the empowering rune's spell menu).
+		if (args.Handled)
+			return;
+
+		// Only cultists can invoke runes.
+		if (!HasComp<BloodCultistComponent>(args.User))
+			return;
+
+		_interaction.InteractionActivate(
+			args.User,
+			rune,
+			checkCanInteract: false,
+			checkUseDelay: true,
+			checkAccess: false,
+			complexInteractions: true,
+			checkDeletion: false
+		);
+		args.Handled = true;
+	}
 
 	/// <summary>
 	/// Starts drawing a rune at the specified location. Handles all validation, special cases, and DoAfter setup.

--- a/Content.Pirate.Server/BloodCult/EntitySystems/CultHealingSourceSystem.cs
+++ b/Content.Pirate.Server/BloodCult/EntitySystems/CultHealingSourceSystem.cs
@@ -406,6 +406,9 @@ public sealed partial class CultHealingSourceSystem : EntitySystem
 			// Only restore if blood max volume > 0 (constructs have 0)
 			if (bloodstream.BloodMaxVolume > FixedPoint2.Zero)
 			{
+				if (bloodstream.BleedAmount > 0f)
+					_bloodstreamSystem.TryModifyBleedAmount((uid, bloodstream), -(adjustedHealing * time));
+
 				// Check current blood level
 				var currentBloodLevel = _bloodstreamSystem.GetBloodLevelPercentage((uid, bloodstream));
 				

--- a/Content.Pirate.Server/BloodCult/EntitySystems/CultistSpellSystem.cs
+++ b/Content.Pirate.Server/BloodCult/EntitySystems/CultistSpellSystem.cs
@@ -60,6 +60,7 @@ public sealed partial class CultistSpellSystem : EntitySystem
 	private static readonly ProtoId<StackPrototype> RunedSteelStack = "RunedSteel";
 	private static readonly ProtoId<StackPrototype> RunedGlassStack = "RunedGlass";
 	private static readonly ProtoId<StackPrototype> RunedPlasteelStack = "RunedPlasteel";
+	private const int MaxPreparedSpells = 4;
 
 	[Dependency] private readonly IRobustRandom _random = default!;
 	[Dependency] private readonly IPrototypeManager _proto = default!;
@@ -166,19 +167,10 @@ public sealed partial class CultistSpellSystem : EntitySystem
 
 		bool standingOnRune = IsStandingOnEmpoweringRune(uid);
 
-		if (comp.KnownSpells.Count > 3)
+		if (!standingOnRune && comp.KnownSpells.Count > 0)
 		{
 			_popup.PopupEntity(Loc.GetString("cult-spell-exceeded"), uid, uid);
 			return;
-		}
-
-		// If not on an empowering rune and they have existing spells, remove the actions matching those spells
-		if (!standingOnRune && comp.KnownSpells.Count > 0)
-		{
-			RemoveActionsMatchingKnownSpells(uid, comp);
-			// Clear KnownSpells since they can only have 0 spells when not on rune
-			comp.KnownSpells.Clear();
-			Dirty(uid, comp);
 		}
 
         if (data.Event != null)
@@ -207,16 +199,20 @@ public sealed partial class CultistSpellSystem : EntitySystem
 		}
 		else
 		{
+			if (standingOnRune)
+				MakeRoomForPreparedSpell(uid, comp);
+
 			foreach (var act in data.ActionPrototypes)
 				_action.AddAction(uid, act);
 			if (recordKnownSpell)
 				comp.KnownSpells.Add(data);
+			Dirty(uid, comp);
 		}
 	}
 
 	public void OnCarveSpellDoAfter(Entity<BloodCultistComponent> ent, ref CarveSpellDoAfterEvent args)
 	{
-		if (ent.Comp.KnownSpells.Count > 3 || (!args.StandingOnRune && ent.Comp.KnownSpells.Count > 0))
+		if (!args.StandingOnRune && ent.Comp.KnownSpells.Count > 0)
 		{
 			_popup.PopupEntity(Loc.GetString("cult-spell-exceeded"), ent, ent);
 			return;
@@ -231,6 +227,9 @@ public sealed partial class CultistSpellSystem : EntitySystem
 
         if (!args.Cancelled)
 		{
+			if (args.StandingOnRune)
+				MakeRoomForPreparedSpell(ent, ent.Comp);
+
 			foreach (var act in args.CultAbility.ActionPrototypes)
 			{
 				_action.AddAction(args.CarverUid, act);
@@ -256,6 +255,18 @@ public sealed partial class CultistSpellSystem : EntitySystem
 		comp.KnownSpells.Remove(GetSpell(id));
 	}
 
+	private void MakeRoomForPreparedSpell(EntityUid uid, BloodCultistComponent cultist)
+	{
+		while (cultist.KnownSpells.Count >= MaxPreparedSpells)
+		{
+			var spellToRemove = cultist.KnownSpells[0];
+			RemoveFirstActionForSpell(uid, spellToRemove);
+			cultist.KnownSpells.RemoveAt(0);
+		}
+
+		Dirty(uid, cultist);
+	}
+
 	/// <summary>
 	/// Checks if a cultist is currently standing on an EmpoweringRune.
 	/// </summary>
@@ -279,29 +290,20 @@ public sealed partial class CultistSpellSystem : EntitySystem
 		return false;
 	}
 
-	/// <summary>
-	/// Removes actions that match spells in the cultist's KnownSpells list.
-	/// This is called when adding a new spell while not on an empowering rune.
-	/// </summary>
-	private void RemoveActionsMatchingKnownSpells(EntityUid uid, BloodCultistComponent cultist)
+	private void RemoveFirstActionForSpell(EntityUid uid, ProtoId<CultAbilityPrototype> spellId)
 	{
-		// Get all actions for this cultist
 		var actions = _action.GetActions(uid);
-		
-		// Create a set of spell IDs for quick lookup
-		var knownSpellIds = new HashSet<ProtoId<CultAbilityPrototype>>(cultist.KnownSpells);
 
-		// Remove actions that match spells in KnownSpells
 		foreach (var action in actions)
 		{
 			if (!TryComp<CultistSpellComponent>(action.Owner, out var spellComp))
 				continue;
 
-			// Check if this action's AbilityId matches any spell in KnownSpells
-			if (knownSpellIds.Contains(spellComp.AbilityId))
-			{
-				_action.RemoveAction(action.Owner);
-			}
+			if (spellComp.AbilityId != spellId)
+				continue;
+
+			_action.RemoveAction(action.Owner);
+			return;
 		}
 	}
 
@@ -333,11 +335,9 @@ public sealed partial class CultistSpellSystem : EntitySystem
 
 	private void OnSpellSelectedMessage(Entity<BloodCultistComponent> ent, ref SpellsMessage args)
 	{
-		if (!CultistSpellComponent.ValidSpells.Contains(args.ProtoId) || ent.Comp.KnownSpells.Contains(args.ProtoId))
-		{
-			_popup.PopupEntity(Loc.GetString("cult-spell-havealready"), ent, ent);
+		if (!CultistSpellComponent.ValidSpells.Contains(args.ProtoId))
 			return;
-		}
+
 		AddSpell(ent, ent.Comp, args.ProtoId, recordKnownSpell:true);
 	}
 

--- a/Content.Pirate.Server/GameTicking/Rules/BloodCultRuleSystem.cs
+++ b/Content.Pirate.Server/GameTicking/Rules/BloodCultRuleSystem.cs
@@ -953,7 +953,7 @@ public sealed class BloodCultRuleSystem : GameRuleSystem<BloodCultRuleComponent>
 	private void OnMindRemoved(EntityUid uid, BloodCultistComponent cultist, MindRemovedMessage args)
 	{
 		_role.MindRemoveRole<BloodCultRoleComponent>(args.Mind.Owner);
-		// Pirate: no auto-evac when the cult dies out - the round continues normally.
+		// No auto-evac when the cult dies out - the round continues normally.
 	}
 
 	/// <summary>

--- a/Content.Pirate.Server/GameTicking/Rules/BloodCultRuleSystem.cs
+++ b/Content.Pirate.Server/GameTicking/Rules/BloodCultRuleSystem.cs
@@ -208,7 +208,6 @@ public sealed class BloodCultRuleSystem : GameRuleSystem<BloodCultRuleComponent>
 
 		SubscribeLocalEvent<BloodCultistComponent, MindAddedMessage>(OnMindAdded);
 		SubscribeLocalEvent<BloodCultistComponent, MindRemovedMessage>(OnMindRemoved);
-		SubscribeLocalEvent<BloodCultistComponent, ComponentRemove>(OnCultistRemoved);
 
 		// Ensure halos are applied when AppearanceComponent is added to cultists
 		SubscribeLocalEvent<AppearanceComponent, ComponentStartup>(OnAppearanceStartup);
@@ -954,12 +953,7 @@ public sealed class BloodCultRuleSystem : GameRuleSystem<BloodCultRuleComponent>
 	private void OnMindRemoved(EntityUid uid, BloodCultistComponent cultist, MindRemovedMessage args)
 	{
 		_role.MindRemoveRole<BloodCultRoleComponent>(args.Mind.Owner);
-		CheckCultistCountAndCallEvac();
-	}
-
-	private void OnCultistRemoved(EntityUid uid, BloodCultistComponent cultist, ComponentRemove args)
-	{
-		CheckCultistCountAndCallEvac();
+		// Pirate: no auto-evac when the cult dies out - the round continues normally.
 	}
 
 	/// <summary>
@@ -1025,32 +1019,6 @@ public sealed class BloodCultRuleSystem : GameRuleSystem<BloodCultRuleComponent>
 
 
 
-	private void CheckCultistCountAndCallEvac()
-	{
-		// Only check if there's an active rule
-		if (!TryGetActiveRule(out var rule))
-			return;
-
-		// Don't call evac if it's already been called
-		if (_roundEnd.IsRoundEndRequested())
-			return;
-
-		// Get all cultists (excluding constructs)
-		var cultists = GetCultists(includeConstructs: false);
-		var cultistCount = cultists.Count;
-
-		// Pirate: a lone cultist should still be able to continue the round.
-		if (cultistCount <= 0)
-		{
-			_roundEnd.RequestRoundEnd(
-				TimeSpan.FromMinutes(10),
-				null,
-				false,
-				"cult-evac-called-announcement",
-				"cult-evac-sender-announcement"
-			);
-		}
-	}
 
 	/// <summary>
 	/// Minimum gap between two forced cult chants from the same speaker.

--- a/Content.Server/_DV/CosmicCult/DeconversionSystem.cs
+++ b/Content.Server/_DV/CosmicCult/DeconversionSystem.cs
@@ -3,10 +3,10 @@ using Content.Server._DV.CosmicCult.Components;
 using Content.Shared._DV.CosmicCult;
 using Content.Shared._DV.CosmicCult.Components;
 using Content.Shared._DV.CosmicCult.Components.Examine;
-using Content.Shared._DV.CosmicCult.EntityEffects; // Pirate: stains
+using Content.Shared._DV.CosmicCult.EntityEffects; // Pirate: blood cult
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
-using Content.Shared.EntityEffects; // Pirate: stains
+using Content.Shared.EntityEffects; // Pirate: blood cult
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Jittering;
@@ -33,11 +33,11 @@ public sealed class DeconversionSystem : EntitySystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<ExecuteEntityEffectEvent<CleanseCult>>(OnCleanseCult); // Pirate: stains
+        SubscribeLocalEvent<ExecuteEntityEffectEvent<CleanseCult>>(OnCleanseCult); // Pirate: blood cult
         SubscribeLocalEvent<CleanseCultComponent, ComponentInit>(OnCompInit);
     }
 
-#region Pirate: stains
+#region Pirate: blood cult
     private void OnCleanseCult(ref ExecuteEntityEffectEvent<CleanseCult> args)
     {
         var uid = args.Args.TargetEntity;
@@ -62,8 +62,8 @@ public sealed class DeconversionSystem : EntitySystem
         var deconCultTimer = EntityQueryEnumerator<CleanseCultComponent>();
         while (deconCultTimer.MoveNext(out var uid, out var comp))
         {
-            if (!HasComp<CosmicCultComponent>(uid) && !HasComp<RogueAscendedInfectionComponent>(uid)) // Pirate: stains
-                continue; // Pirate: stains
+            if (!HasComp<CosmicCultComponent>(uid) && !HasComp<RogueAscendedInfectionComponent>(uid)) // Pirate: blood cult
+                continue; // Pirate: blood cult
 
             if (_timing.CurTime >= comp.CleanseTime && !HasComp<CosmicBlankComponent>(uid))
             {

--- a/Content.Server/_DV/CosmicCult/DeconversionSystem.cs
+++ b/Content.Server/_DV/CosmicCult/DeconversionSystem.cs
@@ -3,8 +3,10 @@ using Content.Server._DV.CosmicCult.Components;
 using Content.Shared._DV.CosmicCult;
 using Content.Shared._DV.CosmicCult.Components;
 using Content.Shared._DV.CosmicCult.Components.Examine;
+using Content.Shared._DV.CosmicCult.EntityEffects; // Pirate: stains
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
+using Content.Shared.EntityEffects; // Pirate: stains
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Jittering;
@@ -31,10 +33,21 @@ public sealed class DeconversionSystem : EntitySystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<CleanseOnUseComponent, AfterInteractEvent>(OnAfterInteract);
-        SubscribeLocalEvent<CleanseOnUseComponent, CleanseOnDoAfterEvent>(OnDoAfter);
+        SubscribeLocalEvent<ExecuteEntityEffectEvent<CleanseCult>>(OnCleanseCult); // Pirate: stains
         SubscribeLocalEvent<CleanseCultComponent, ComponentInit>(OnCompInit);
     }
+
+#region Pirate: stains
+    private void OnCleanseCult(ref ExecuteEntityEffectEvent<CleanseCult> args)
+    {
+        var uid = args.Args.TargetEntity;
+        if (HasComp<CosmicCultComponent>(uid)
+            || HasComp<RogueAscendedInfectionComponent>(uid))
+        {
+            EnsureComp<CleanseCultComponent>(uid);
+        }
+    }
+#endregion
 
     private void OnCompInit(Entity<CleanseCultComponent> uid, ref ComponentInit args)
     {
@@ -49,6 +62,9 @@ public sealed class DeconversionSystem : EntitySystem
         var deconCultTimer = EntityQueryEnumerator<CleanseCultComponent>();
         while (deconCultTimer.MoveNext(out var uid, out var comp))
         {
+            if (!HasComp<CosmicCultComponent>(uid) && !HasComp<RogueAscendedInfectionComponent>(uid)) // Pirate: stains
+                continue; // Pirate: stains
+
             if (_timing.CurTime >= comp.CleanseTime && !HasComp<CosmicBlankComponent>(uid))
             {
                 RemComp<CleanseCultComponent>(uid);

--- a/Content.Shared/_DV/CosmicCult/EntityEffects/CleanseCult.cs
+++ b/Content.Shared/_DV/CosmicCult/EntityEffects/CleanseCult.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared._DV.CosmicCult.EntityEffects;
 
-public sealed partial class CleanseCult : EventEntityEffect<CleanseCult> // Pirate: stains
+public sealed partial class CleanseCult : EventEntityEffect<CleanseCult> // Pirate: blood cult
 {
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
     {

--- a/Content.Shared/_DV/CosmicCult/EntityEffects/CleanseCult.cs
+++ b/Content.Shared/_DV/CosmicCult/EntityEffects/CleanseCult.cs
@@ -1,22 +1,12 @@
-using Content.Shared._DV.CosmicCult.Components;
 using Content.Shared.EntityEffects;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared._DV.CosmicCult.EntityEffects;
 
-public sealed partial class CleanseCult : EntityEffect
+public sealed partial class CleanseCult : EventEntityEffect<CleanseCult> // Pirate: stains
 {
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
     {
         return Loc.GetString("reagent-effect-guidebook-cleanse-cultist", ("chance", Probability));
-    }
-
-    public override void Effect(EntityEffectBaseArgs args)
-    {
-        var entityManager = args.EntityManager;
-        var uid = args.TargetEntity;
-        if (entityManager.HasComponent<CosmicCultComponent>(uid)
-            || entityManager.HasComponent<RogueAscendedInfectionComponent>(uid))
-            entityManager.EnsureComponent<CleanseCultComponent>(uid); // We just slap them with the component and let the Deconversion system handle the rest.
     }
 }

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1505,7 +1505,7 @@
       effects:
       - !type:SatiateThirst
         factor: 3
-      - !type:CleanseCult # DeltaV - Cosmic Cult
+      - !type:CleanseCult # Pirate: stains - shared cosmic/blood cult deconversion
         conditions:
         - !type:ReagentThreshold
           min: 10
@@ -1530,8 +1530,6 @@
           - WeakToHoly
     Medicine:
       effects:
-      - !type:DeCultify # Pirate - Blood Cult deconversion
-        amount: 2.5
       - !type:HealthChange # Pirate - Holy water harms blood cultists
         conditions:
         - !type:IsBloodCultist

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1505,7 +1505,7 @@
       effects:
       - !type:SatiateThirst
         factor: 3
-      - !type:CleanseCult # Pirate: stains - shared cosmic/blood cult deconversion
+      - !type:CleanseCult # Pirate: blood cult
         conditions:
         - !type:ReagentThreshold
           min: 10

--- a/Resources/Prototypes/_Pirate/BloodCult/Entities/clothing.yml
+++ b/Resources/Prototypes/_Pirate/BloodCult/Entities/clothing.yml
@@ -37,6 +37,9 @@
     containers:
       toggleable-clothing: !type:Container {}
   - type: GroupExamine
+  - type: ClothingSpeedModifier
+    walkModifier: 1
+    sprintModifier: 1
 
 - type: entity
   parent: ClothingHeadBase
@@ -86,6 +89,9 @@
   - type: Clothing
     sprite: _Pirate/BloodCult/Clothing/cult_boots.rsi
   - type: NoSlip
+  - type: ClothingSpeedModifier
+    walkModifier: 1.15
+    sprintModifier: 1.15
   - type: SlowedOverSlippery
     slowdownModifier: 0.7
   - type: SpeedModifierContactCapClothing


### PR DESCRIPTION
**Changelog**
:cl:
- tweak: пілони лікують кровотечі 
- tweak: руни можна стерти кинджалом культу
- tweak: черевічкі культу прискорюють на 15%
- tweak: броня культу більше не сповільнює
- tweak: можна вибирати однакові заклинання, замість видалення заклинань тепер замінюється first in first out (максимум одночасно без змін - 4, що дуже смішно, бо всього заклинань існує тільки 3)
- tweak: культисти крові деконвертуються тільки святою водою
- fix: вимкнув авто виклик еваку після деконверсії всих культистів


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Додано очищення культу через спеціальний ефект і підтримку поступового “зняття” культу з цілі.
  * Руни тепер можна активувати порожньою рукою, а деякі рунічні знаки можна стирати культовим клинком.

* **Bug Fixes**
  * Підправлено відновлення, щоб воно коректніше впливало на кровотечу.
  * Усунено автоматичне завершення раунду, коли культ зникає.

* **Balance**
  * Змінено обмеження та керування підготовленими закляттями.
  * Оновлено ефекти святої води та швидкість руху для окремого спорядження.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->