### PR TITLE
Fix integration test state races

### DIFF
--- a/Content.IntegrationTests/Tests/Minds/GhostRoleTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/GhostRoleTests.cs
@@ -48,6 +48,7 @@ public sealed class GhostRoleTests
         await using var pair = await PoolManager.GetServerClient(new PoolSettings
         {
             Dirty = true,
+            Fresh = true,
             DummyTicker = false,
             Connected = true
         });

--- a/Content.Server/Toolshed/TypeParsers/StatusEffects/StatusEffectCompletionParser.cs
+++ b/Content.Server/Toolshed/TypeParsers/StatusEffects/StatusEffectCompletionParser.cs
@@ -1,5 +1,7 @@
 ﻿using Content.Shared.StatusEffectNew;
 using Robust.Shared.Console;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Toolshed.Syntax;
@@ -9,8 +11,12 @@ namespace Content.Server.Toolshed.TypeParsers.StatusEffects;
 
 public sealed class StatusEffectCompletionParser : CustomCompletionParser<EntProtoId>
 {
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+
     public override CompletionResult? TryAutocomplete(ParserContext ctx, CommandArgument? arg)
     {
-        return CompletionResult.FromHintOptions(StatusEffectsSystem.StatusEffectPrototypes, GetArgHint(arg));
+        return CompletionResult.FromHintOptions(
+            _entityManager.System<StatusEffectsSystem>().StatusEffectPrototypes,
+            GetArgHint(arg));
     }
 }

--- a/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
@@ -23,7 +23,9 @@ public sealed partial class StatusEffectsSystem : EntitySystem
     private EntityQuery<StatusEffectContainerComponent> _containerQuery;
     private EntityQuery<StatusEffectComponent> _effectQuery;
 
-    public static HashSet<string> StatusEffectPrototypes = [];
+    private readonly HashSet<string> _statusEffectPrototypes = [];
+
+    public IReadOnlySet<string> StatusEffectPrototypes => _statusEffectPrototypes;
 
     public override void Initialize()
     {
@@ -78,12 +80,12 @@ public sealed partial class StatusEffectsSystem : EntitySystem
 
     private void ReloadStatusEffectsCache()
     {
-        StatusEffectPrototypes.Clear();
+        _statusEffectPrototypes.Clear();
 
         foreach (var ent in _proto.EnumeratePrototypes<EntityPrototype>())
         {
             if (ent.TryGetComponent<StatusEffectComponent>(out _, _factory))
-                StatusEffectPrototypes.Add(ent.ID);
+                _statusEffectPrototypes.Add(ent.ID);
         }
     }
 


### PR DESCRIPTION
Виправляє спільний static-кеш статус-ефектів між тестовими інстансами та ізолює GhostRoleTests від повторно використаного стану пулу.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Покращення**
  * Підвищено надійність отримання підказок для статус-ефектів у внутрішніх інструментах.
  * Доступ до списку доступних статус-ефектів став безпечнішим і передбачуванішим.

* **Тести**
  * Уточнено налаштування інтеграційного тестування ролі привида для стабільнішої перевірки сценарію отримання та повернення ролі.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->