### PR TITLE
Fix normal blood level handling

### DIFF
--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -305,9 +305,9 @@ public sealed class HealthAnalyzerSystem : EntitySystem
 
         if (TryComp<BloodstreamComponent>(target, out var bloodstream) &&
             _solutionContainerSystem.ResolveSolution(target, bloodstream.BloodSolutionName,
-                ref bloodstream.BloodSolution, out var bloodSolution))
+                ref bloodstream.BloodSolution))
         {
-            bloodAmount = bloodSolution.FillFraction;
+            bloodAmount = _bloodstreamSystem.GetBloodLevel((target, bloodstream)); // Pirate: reserve capacity is not missing blood.
             bloodLow = bloodAmount < bloodstream.BloodlossThreshold; // Goobstation
         }
 

--- a/Content.Server/_Pirate/Blood/BloodRegenerationPirateSystem.cs
+++ b/Content.Server/_Pirate/Blood/BloodRegenerationPirateSystem.cs
@@ -57,7 +57,7 @@ public sealed class BloodRegenerationPirateSystem : EntitySystem
         // Amount scaled by component; allows negative for loss if desired.
         var amount = ev.Amount;
 
-        if (amount > FixedPoint2.Zero && bloodSolution.Volume >= bloodSolution.MaxVolume)
+        if (amount > FixedPoint2.Zero && _bloodstream.GetBloodLevel(ent.AsNullable()) >= 1f)
             return false;
 
         // Costs


### PR DESCRIPTION
Виправлено відображення нормального рівня крові як 50% та постійне витрачання голоду і спраги на зайву регенерацію.

:cl:
- fix: Нормальний рівень крові знову відображається як 100% і не спричиняє постійний голод та спрагу.