### PR TITLE
Виправлення пробиття вдягненої броні

### DIFF
--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -69,7 +69,15 @@ public abstract class SharedArmorSystem : EntitySystem
         if (TryComp<MaskComponent>(uid, out var mask) && mask.IsToggled)
             return;
 
-        args.Args.Damage = DamageSpecifier.ApplyModifierSet(args.Args.Damage, component.Modifiers);
+        // Pirate: preserve armor coverage and penetration for inventory-relayed damage.
+        if (args.Args.TargetPart == null)
+            return;
+
+        var (partType, _) = _body.ConvertTargetBodyPart(args.Args.TargetPart);
+
+        if (component.ArmorCoverage.Contains(partType))
+            args.Args.Damage = DamageSpecifier.ApplyModifierSet(args.Args.Damage,
+                DamageSpecifier.PenetrateArmor(component.Modifiers, args.Args.Damage.ArmorPenetration));
     }
 
     private void OnBorgDamageModify(EntityUid uid, ArmorComponent component,


### PR DESCRIPTION
Відновлено врахування покриття частин тіла та пробиття для вдягненої броні.

:cl:
- fix: Виправлено пробиття броні набоями та іншими атаками.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Виправлення**
  * Броня тепер застосовує захист лише до частин тіла, які фактично покриває.
  * Додано коректне врахування бронепробиття під час розрахунку отриманої шкоди.
  * Обробка шкоди без зазначеної частини тіла більше не застосовує модифікатори броні.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->