### PR TITLE
Виправлення регресій хімії

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry-vials.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry-vials.yml
@@ -42,17 +42,18 @@
       color: "#FF9880"
     affectedLayers:
     - "enum.SolutionContainerLayers.Fill"
+  # Pirate: Keep all inherited DrinkBase components pointed at the same solution.
   - type: DrawableSolution #Goob
-    solution: beaker
+    solution: drink
   - type: SolutionContainerVisuals #goob
     maxFillLevels: 6
     inHandsMaxFillLevels: 4
     fillBaseName: fill-
     inHandsFillBaseName: -fill-
-    solutionName: beaker
+    solutionName: drink
   - type: SolutionContainerManager #goob
     solutions:
-      beaker:
+      drink:
         maxVol: 30
 
 ## Entities
@@ -114,7 +115,7 @@
     inHandsMaxFillLevels: 4
   - type: SolutionContainerManager
     solutions:
-      beaker: #Goob
+      drink: #Goob
         maxVol: 10
   - type: SolutionTransfer
     maxTransferAmount: 10
@@ -147,7 +148,7 @@
     currentLabel: reagent-name-vestine
   - type: SolutionContainerManager
     solutions:
-      beaker: #Goob
+      drink: #Goob
         maxVol: 30
         reagents:
         - ReagentId: Vestine
@@ -165,7 +166,7 @@
     currentLabel: reagent-name-radium
   - type: SolutionContainerManager
     solutions:
-      beaker: #Goob
+      drink: #Goob
         maxVol: 30 # Goobstation
         reagents:
           - ReagentId: Radium
@@ -182,7 +183,7 @@
     currentLabel: reagent-name-chlorine
   - type: SolutionContainerManager
     solutions:
-      beaker: #Goob
+      drink: #Goob
         maxVol: 30 # Goobstation
         reagents:
           - ReagentId: Chlorine
@@ -199,7 +200,7 @@
     currentLabel: reagent-name-plasma
   - type: SolutionContainerManager
     solutions:
-      beaker: #Goob
+      drink: #Goob
         maxVol: 30 # Goobstation
         reagents:
           - ReagentId: Plasma

--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -81,7 +81,7 @@
       amount: 4 # Goob edit - revert that once we get energy chem
   effects:
     - !type:SpawnEntity
-      entity: SheetPlastic1
+      entity: SheetPlastic10 # Pirate: restore the intended yield after the entity-effect refactor.
 
 - type: reaction
   id: FlashFreezeIce

--- a/Resources/Prototypes/_Goobstation/Heretic/Reagents/reagents.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Reagents/reagents.yml
@@ -52,6 +52,7 @@
           - type: Ghoul
           guidebookComponentName: reagent-comp-condition-heretic-or-ghoul
       - !type:CleanBloodstream
+        excluded: EldritchEssence # Pirate: do not purge the cleanser itself.
         cleanseRate: 3
         conditions:
         - !type:HasComponentCondition

--- a/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
@@ -282,6 +282,7 @@
           groups:
             Toxin: -6
       - !type:CleanBloodstream
+        excluded: Musiver # Pirate: do not purge the cleanser itself.
         cleanseRate: 6 # POWERFUL cleansing effect
       - !type:HealthChange
         damage:
@@ -581,6 +582,7 @@
       metabolismRate: 1
       effects:
       - !type:CleanBloodstream
+        excluded: Calomel # Pirate: do not purge the cleanser itself.
         cleanseRate: 4.5 # better than charcoal
       - !type:HealthChange
         damage:
@@ -1093,6 +1095,7 @@
       metabolismRate: 0.25
       effects:
       - !type:CleanBloodstream
+        excluded: PentenicAcid # Pirate: do not purge the cleanser itself.
       - !type:HealthChange
         damage:
           types:

--- a/Resources/Prototypes/_Goobstation/Wizard/reagents.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/reagents.yml
@@ -85,6 +85,7 @@
           - type: Apprentice
           guidebookComponentName: reagent-comp-condition-wizard-or-apprentice
       - !type:CleanBloodstream
+        excluded: Mugwort # Pirate: do not purge the cleanser itself.
         cleanseRate: 6
         conditions:
         - !type:HasComponentCondition


### PR DESCRIPTION
Виправлено регресії хімії після оновлення upstream.

:cl:
- fix: Рецепт пластику знову створює 10 листів за одну реакцію.
- fix: Хімічні мініколби знову коректно працюють із машинами та проливанням.
- fix: Пентенова кислота й інші очищувачі крові більше не виводять самі себе.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Реакція виготовлення пластикових листів тепер створює 10 листів замість одного.
  * Покращено відображення та обробку вмісту хімічних флаконів.
* **Виправлення помилок**
  * Очищення кровотоку більше не видаляє сам реагент-очищувач для Eldritch Essence, Musiver, Calomel, Pentenic Acid і Mugwort.
  * Виправлено сумісність розчинів у наповнених і порожніх хімічних флаконах.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->