### PR TITLE
Виправити кирилицю в мові авалі

### DIFF
--- a/Resources/Prototypes/_Pirate/Avali/language.yml
+++ b/Resources/Prototypes/_Pirate/Avali/language.yml
@@ -3,6 +3,6 @@
   isVisibleLanguage: true
   speech:
     color: "#FC7921"
-    fontId: Scratch
+    # fontId: Scratch # Pirate no cyrillic support
   obfuscation:
     !type:RandomObfuscation


### PR DESCRIPTION
Вимикає кастомний Scratch-шрифт для мови авалі, оскільки він не підтримує кирилицю. Помаранчевий колір мови збережено.

:cl:
- fix: Виправлено відображення кирилиці в мові авалі.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Зміни**
  * Оновлено мовні налаштування шрифту Scratch для коректнішої підтримки кирилиці в Pirate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->