### PR TITLE
Додати голоси та набори виживання Avali

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -119,6 +119,7 @@
   loadouts:
   - EmergencyNitrogen
   - EmergencyOxygen
+  - EmergencyOxygenAvali # Pirate
   - EmergencyPlasma
   - LoadoutSpeciesVoxNitrogen
   - LoadoutSpeciesPlasma # Goobstation
@@ -673,6 +674,7 @@
   loadouts:
   - EmergencyNitrogenClown
   - EmergencyOxygenClown
+  - EmergencyOxygenAvaliClown # Pirate
   - EmergencyPlasmaClown
   - LoadoutSpeciesVoxNitrogen
   - LoadoutSpeciesPlasma # Goobstation
@@ -742,6 +744,7 @@
   loadouts:
   - EmergencyNitrogenMime
   - EmergencyOxygenMime
+  - EmergencyOxygenAvaliMime # Pirate
   - EmergencySpeciesMothMime
   - EmergencyPlasmaMime
   - LoadoutSpeciesVoxNitrogen
@@ -1148,6 +1151,7 @@
   loadouts:
   - EmergencyNitrogenExtended
   - EmergencyOxygenExtended
+  - EmergencyOxygenAvaliExtended # Pirate
   - EmergencyPlasmaExtended
   - LoadoutSpeciesVoxNitrogen
   - LoadoutSpeciesPlasma # Goobstation
@@ -1531,6 +1535,7 @@
   loadouts:
   - EmergencyNitrogenSecurity
   - EmergencyOxygenSecurity
+  - EmergencyOxygenAvaliSecurity # Pirate
   - EmergencyPlasmaSecurity
   - LoadoutSpeciesVoxNitrogen
   - LoadoutSpeciesPlasma # Goobstation
@@ -1781,6 +1786,7 @@
   loadouts:
   - EmergencyNitrogenMedical
   - EmergencyOxygenMedical
+  - EmergencyOxygenAvaliMedical # Pirate
   - EmergencyPlasmaMedical
   - LoadoutSpeciesVoxNitrogen
   - LoadoutSpeciesPlasma # Goobstation
@@ -1826,6 +1832,7 @@
   loadouts:
   - EmergencyNitrogenSyndicate
   - EmergencyOxygenSyndicate
+  - EmergencyOxygenAvaliSyndicate # Pirate
   - EmergencyPlasmaSyndicate
   - LoadoutSpeciesVoxNitrogen
   - LoadoutSpeciesPlasma # Goobstation

--- a/Resources/Prototypes/_Corvax/barks.yml
+++ b/Resources/Prototypes/_Corvax/barks.yml
@@ -192,6 +192,7 @@
     collection: MaleAvaliBark
   speciesWhitelist:
     - Resomi
+    - Avali # Pirate
 
 # FemaleAvali
 - type: soundCollection
@@ -210,6 +211,7 @@
     collection: FemaleAvaliBark
   speciesWhitelist:
     - Resomi
+    - Avali # Pirate
 
 # Pai
 - type: soundCollection

--- a/Resources/Prototypes/_Pirate/Avali/emergencybox.yml
+++ b/Resources/Prototypes/_Pirate/Avali/emergencybox.yml
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Pirate: Avali survival boxes replace plant-based rations with tinned meat.
+
+- type: entity
+  parent: BoxSurvivalSlots
+  id: BoxSurvivalSlotsAvali
+  suffix: Standard, Avali
+  components:
+  - type: ContainerFill
+    containers:
+      water:
+      - DrinkWaterBottleFull
+      nutriblock:
+      - FoodTinMRE
+      flare:
+      - Flare
+      tank:
+      - EmergencyOxygenTankFilled
+      mask:
+      - ClothingMaskBreath
+      emergencypen:
+      - EmergencyMedipen
+      spacepen:
+      - SpaceMedipen
+
+- type: entity
+  parent: BoxSurvivalSlotsEngineering
+  id: BoxSurvivalSlotsEngineeringAvali
+  suffix: Extended, Avali
+  components:
+  - type: ContainerFill
+    containers:
+      water:
+      - DrinkWaterBottleFull
+      nutriblock:
+      - FoodTinMRE
+      flare:
+      - Flare
+      tank:
+      - ExtendedEmergencyOxygenTankFilled
+      mask:
+      - ClothingMaskBreath
+      emergencypen:
+      - EmergencyMedipen
+      spacepen:
+      - SpaceMedipen
+
+- type: entity
+  parent: BoxSurvivalSlotsSecurity
+  id: BoxSurvivalSlotsSecurityAvali
+  suffix: Security, Avali
+  components:
+  - type: ContainerFill
+    containers:
+      water:
+      - DrinkWaterBottleFull
+      nutriblock:
+      - FoodTinMRE
+      flare:
+      - Flare
+      tank:
+      - ExtendedEmergencyOxygenTankFilled
+      mask:
+      - ClothingMaskGasSecurity
+      emergencypen:
+      - EmergencyMedipen
+      spacepen:
+      - SpaceMedipen
+
+- type: entity
+  parent: BoxSurvivalSlotsMedical
+  id: BoxSurvivalSlotsMedicalAvali
+  suffix: Medical, Avali
+  components:
+  - type: ContainerFill
+    containers:
+      water:
+      - DrinkWaterBottleFull
+      nutriblock:
+      - FoodTinMRE
+      flare:
+      - Flare
+      tank:
+      - EmergencyOxygenTankFilled
+      mask:
+      - ClothingMaskBreathMedical
+      emergencypen:
+      - EmergencyMedipen
+      spacepen:
+      - SpaceMedipen
+
+- type: entity
+  parent: BoxHugSlots
+  id: BoxHugSlotsAvali
+  suffix: Emergency, Avali
+  components:
+  - type: ContainerFill
+    containers:
+      water:
+      - DrinkWaterBottleFull
+      nutriblock:
+      - FoodTinMRE
+      flare:
+      - Flare
+      tank:
+      - EmergencyFunnyOxygenTankFilled
+      mask:
+      - ClothingMaskBreath
+      emergencypen:
+      - EmergencyMedipen
+      spacepen:
+      - SpaceMedipen
+
+- type: entity
+  parent: BoxMimeSlots
+  id: BoxMimeSlotsAvali
+  suffix: Mime, Emergency, Avali
+  components:
+  - type: ContainerFill
+    containers:
+      water:
+      - DrinkWaterBottleFull
+      nutriblock:
+      - FoodTinMRE
+      flare:
+      - Flare
+      tank:
+      - EmergencyOxygenTankFilled
+      mask:
+      - ClothingMaskBreath
+      emergencypen:
+      - EmergencyMedipen
+      spacepen:
+      - SpaceMedipen
+
+- type: entity
+  parent: BoxSurvivalSlotsSyndicate
+  id: BoxSurvivalSlotsSyndicateAvali
+  suffix: Syndicate, Avali
+  components:
+  - type: ContainerFill
+    containers:
+      water:
+      - DrinkWaterBottleFull
+      nutriblock:
+      - FoodTinMRE
+      flare:
+      - Flare
+      tank:
+      - ExtendedEmergencyOxygenTankFilled
+      mask:
+      - ClothingMaskGasSyndicate
+      emergencypen:
+      - EmergencyMedipen
+      spacepen:
+      - SpaceMedipen

--- a/Resources/Prototypes/_Pirate/Avali/survival.yml
+++ b/Resources/Prototypes/_Pirate/Avali/survival.yml
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: loadoutEffectGroup
+  id: AvaliBreather
+  effects:
+  - !type:SpeciesLoadoutEffect
+    species:
+    - Avali
+
+- type: loadout
+  id: EmergencyOxygenAvali
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: AvaliBreather
+  storage:
+    back:
+    - BoxSurvivalSlotsAvali
+
+- type: loadout
+  id: EmergencyOxygenAvaliClown
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: AvaliBreather
+  storage:
+    back:
+    - BoxHugSlotsAvali
+
+- type: loadout
+  id: EmergencyOxygenAvaliMime
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: AvaliBreather
+  storage:
+    back:
+    - BoxMimeSlotsAvali
+
+- type: loadout
+  id: EmergencyOxygenAvaliExtended
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: AvaliBreather
+  storage:
+    back:
+    - BoxSurvivalSlotsEngineeringAvali
+
+- type: loadout
+  id: EmergencyOxygenAvaliMedical
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: AvaliBreather
+  storage:
+    back:
+    - BoxSurvivalSlotsMedicalAvali
+
+- type: loadout
+  id: EmergencyOxygenAvaliSecurity
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: AvaliBreather
+  storage:
+    back:
+    - BoxSurvivalSlotsSecurityAvali
+
+- type: loadout
+  id: EmergencyOxygenAvaliSyndicate
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: AvaliBreather
+  storage:
+    back:
+    - BoxSurvivalSlotsSyndicateAvali


### PR DESCRIPTION
Додає Avali їхні bark-голоси та окремі roundstart-набори виживання з м’ясною консервою замість nutribrick або багета.

:cl:
- fix: Avali мають доступ до власних голосів у редакторі персонажа.
- fix: Avali отримують набір виживання з м’ясною консервою на початку раунду.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Додано аварійні набори виживання для раси Avali: стандартний, інженерний, медичний, безпековий, мім, «обійми» та синдикатський варіанти.
  * Набори містять кисневе спорядження, маски, воду, їжу, сигнальні засоби та медичні препарати.
  * Аварійний кисень Avali тепер доступний у відповідних прихованих групах спорядження.
  * Додано підтримку Avali для чоловічих і жіночих bark-реплік.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->