### PR TITLE
Повернути Родентіям повторний обшук смітників

### DIFF
--- a/Content.Shared/RatKing/Systems/RummagerSystem.cs
+++ b/Content.Shared/RatKing/Systems/RummagerSystem.cs
@@ -72,10 +72,14 @@ public sealed class RummagerSystem : EntitySystem
 
     private void OnDoAfterComplete(Entity<RummageableComponent> ent, ref RummageDoAfterEvent args)
     {
-        if (args.Cancelled || ent.Comp.Looted)
+        // Pirate: restore repeat rummaging lost during the Rat King refactor.
+        var time = _gameTiming.CurTime;
+        if (args.Cancelled ||
+            ent.Comp.Looted ||
+            time < ent.Comp.LastLooted + ent.Comp.RummageCooldown)
             return;
 
-        ent.Comp.Looted = true;
+        ent.Comp.LastLooted = time;
         Dirty(ent, ent.Comp);
         _audio.PlayPredicted(ent.Comp.Sound, ent, args.User);
 


### PR DESCRIPTION
Повертає повторний обшук rummageable-контейнерів після наявного хвилинного cooldown замість одноразового використання.

:cl:
- fix: Родентії знову можуть повторно обшукувати смітники після перезарядки.