### PR TITLE
Виправити самозарядку меча ГСБ

### DIFF
--- a/Content.Server/_Shitmed/ItemSwitch/ItemSwitchSystem.cs
+++ b/Content.Server/_Shitmed/ItemSwitch/ItemSwitchSystem.cs
@@ -44,7 +44,8 @@ public sealed class ItemSwitchSystem : SharedItemSwitchSystem
         if (ent.Comp.State == ent.Comp.DefaultState)
             return;
 
-        var count = (int) (battery.LastCharge / state.EnergyPerUse);
+        // Pirate: LastCharge is only a snapshot after battery unification.
+        var count = _battery.GetRemainingUses((ent.Owner, battery), state.EnergyPerUse);
         args.PushMarkup(Loc.GetString("melee-battery-examine", ("color", "yellow"), ("count", count)));
     }
 
@@ -55,7 +56,7 @@ public sealed class ItemSwitchSystem : SharedItemSwitchSystem
             || !component.States.TryGetValue(component.State, out var state))
             return;
 
-        component.IsPowered = battery.LastCharge >= state.EnergyPerUse;
+        component.IsPowered = _battery.GetCharge((uid, battery)) >= state.EnergyPerUse; // Pirate
 
         if (component is { IsPowered: false, DefaultState: { } defaultState } && component.State != defaultState)
             _itemSwitch.Switch((uid, component), defaultState);

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/justice.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/justice.yml
@@ -16,6 +16,7 @@
   - type: Battery
     maxCharge: 1000
     startingCharge: 1000
+  - type: ExaminableBattery # Pirate
   - type: BatterySelfRecharger
     autoRechargeRate: 50
     autoRechargePauseTime: 40


### PR DESCRIPTION
Повертає Justice коректне визначення заряду після battery refactor і додає показ відсотка батареї при огляді.

:cl:
- fix: Меч ГСБ Justice знову використовує накопичений самозаряд і показує рівень батареї.