### PR TITLE
Виправити перетравлення сирого м’яса Авалі

### DIFF
--- a/Resources/Prototypes/_Pirate/Avali/organs.yml
+++ b/Resources/Prototypes/_Pirate/Avali/organs.yml
@@ -15,7 +15,7 @@
       - AvianFood
   - type: Metabolizer
     maxPoisonsProcessable: 3
-    metabolizerTypes: [Avali]
+    metabolizerTypes: [Avali, Animal]
     groups:
     - id: Food
     - id: Drink


### PR DESCRIPTION
Повертає Авалі сумісне з оригіналом перетравлення сирого м’яса.

:cl:
- fix: Авалі більше не отруюються та не блюють від сирого м’яса.