### PR TITLE
Виправити здібності та фізичні емоції ПШІ

### DIFF
--- a/Content.Server/_Pirate/PAI/PAIPurchasedActionSystem.cs
+++ b/Content.Server/_Pirate/PAI/PAIPurchasedActionSystem.cs
@@ -16,17 +16,17 @@ public sealed class PAIPurchasedActionSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<PAIComponent, MindRemovedMessage>(OnMindRemoved, after: [typeof(ActionContainerSystem)]);
+        SubscribeLocalEvent<StoreComponent, MindRemovedMessage>(OnMindRemoved, after: [typeof(ActionContainerSystem)]);
     }
 
-    private void OnMindRemoved(Entity<PAIComponent> ent, ref MindRemovedMessage args)
+    private void OnMindRemoved(Entity<StoreComponent> ent, ref MindRemovedMessage args)
     {
-        if (!TryComp<StoreComponent>(ent.Owner, out var store) ||
+        if (!HasComp<PAIComponent>(ent.Owner) ||
             !TryComp<ActionsContainerComponent>(args.Mind.Owner, out var mindActions))
             return;
 
         // Installed software belongs to the pAI device, not the departing mind.
-        foreach (var purchased in store.BoughtEntities)
+        foreach (var purchased in ent.Comp.BoughtEntities)
         {
             if (!mindActions.Container.Contains(purchased) ||
                 !TryComp<ActionComponent>(purchased, out var action))

--- a/Content.Server/_Pirate/PAI/PAIPurchasedActionSystem.cs
+++ b/Content.Server/_Pirate/PAI/PAIPurchasedActionSystem.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Actions;
+using Content.Shared.Actions.Components;
+using Content.Shared.Mind.Components;
+using Content.Shared.PAI;
+using Content.Shared.Store.Components;
+
+namespace Content.Server._Pirate.PAI;
+
+public sealed class PAIPurchasedActionSystem : EntitySystem
+{
+    [Dependency] private readonly ActionContainerSystem _actionContainer = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PAIComponent, MindRemovedMessage>(OnMindRemoved, after: [typeof(ActionContainerSystem)]);
+    }
+
+    private void OnMindRemoved(Entity<PAIComponent> ent, ref MindRemovedMessage args)
+    {
+        if (!TryComp<StoreComponent>(ent.Owner, out var store) ||
+            !TryComp<ActionsContainerComponent>(args.Mind.Owner, out var mindActions))
+            return;
+
+        // Installed software belongs to the pAI device, not the departing mind.
+        foreach (var purchased in store.BoughtEntities)
+        {
+            if (!mindActions.Container.Contains(purchased) ||
+                !TryComp<ActionComponent>(purchased, out var action))
+                continue;
+
+            _actionContainer.TransferActionWithNewAttached(purchased, ent.Owner, ent.Owner, action);
+        }
+    }
+}

--- a/Resources/Prototypes/_Goobstation/Actions/emotes.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/emotes.yml
@@ -4,6 +4,9 @@
   id: Flip
   name: chat-emote-name-flip
   icon: _Goobstation/Interface/Emotes/flip.png
+  blacklist: # Pirate: pAIs cannot perform physical emotes
+    components:
+    - PAI
   chatMessages: ["chat-emote-msg-flip"]
   chatTriggers:
   - flip
@@ -92,6 +95,9 @@
   id: Jump
   name: chat-emote-name-jump
   icon: _Goobstation/Interface/Emotes/jump.png
+  blacklist: # Pirate: pAIs cannot perform physical emotes
+    components:
+    - PAI
   chatMessages: ["chat-emote-msg-jump"]
   chatTriggers:
   - jump


### PR DESCRIPTION
Зберігає придбані застосунки ПШІ після перезапуску та забороняє ПШІ стрибки й сальто.

:cl:
- fix: Придбані здібності ПШІ більше не зникають після вимкнення та повторного ввімкнення.
- fix: ПШІ більше не можуть стрибати та робити сальто.