### PR TITLE
Виправлення перевірки шарів RPD

### DIFF
--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -603,7 +603,7 @@ public sealed class RCDSystem : EntitySystem
                 if (HasComp<AtmosPipeLayersComponent>(ent))     //Goob - check for pipe layers
                 {
                     var entPipeLayer = Comp<AtmosPipeLayersComponent>(ent).CurrentPipeLayer;
-                    if (entPipeLayer != AtmosPipeLayer.Primary)
+                    if (entPipeLayer != GetPlacementLayer(component, prototype)) // Pirate: respect the active RPD layer
                         isIdentical = false;
                 }
 


### PR DESCRIPTION
Виправлено перевірку дублювання атмосферних пристроїв на secondary/tertiary шарах після #682.

:cl:
- fix: RPD більше не дозволяє дублювати той самий атмосферний пристрій на активному шарі.