### PR TITLE
Фікс силосу і еваку Багелі

### DIFF
--- a/Content.Shared/Materials/OreSilo/OreSiloComponent.cs
+++ b/Content.Shared/Materials/OreSilo/OreSiloComponent.cs
@@ -23,7 +23,7 @@ public sealed partial class OreSiloComponent : Component
     /// Default value should be big enough to span a single large department.
     /// </remarks>
     [DataField, AutoNetworkedField]
-    public float Range = 40f; // Goob - 20->40
+    public float Range = 10000f; // Pirate - 40->10000
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Maps/Shuttles/emergency_lox.yml
+++ b/Resources/Maps/Shuttles/emergency_lox.yml
@@ -1,18 +1,16 @@
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 meta:
   format: 7
   category: Grid
-  engineVersion: 262.0.0
+  engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 06/09/2025 19:06:42
-  entityCount: 662
+  time: 07/15/2026 10:07:00
+  entityCount: 660
 maps: []
 grids:
-- 670
+- 1
 orphans:
-- 670
+- 1
 nullspace: []
 tilemap:
   0: Space
@@ -24,6 +22,7 @@ tilemap:
   62: FloorLino
   77: FloorReinforced
   79: FloorRockVault
+  1: FloorShuttleBlack
   84: FloorShuttleRed
   89: FloorSteel
   104: FloorTechMaint
@@ -34,13 +33,13 @@ tilemap:
 entities:
 - proto: ""
   entities:
-  - uid: 670
+  - uid: 1
     components:
     - type: MetaData
       name: NT Evac Lox
     - type: Transform
       pos: 2.2710133,-2.4148211
-
+      parent: invalid
     - type: MapGrid
       chunks:
         -1,0:
@@ -49,7 +48,7 @@ entities:
           version: 7
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAAB5AAAAAAAAJAAAAAACACQAAAAAAQAkAAAAAAAAJAAAAAAAACQAAAAAAwAkAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAATQAAAAAAAE0AAAAAAAAdAAAAAAMATwAAAAAAAE8AAAAAAABPAAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAB0AAAAAAAAdAAAAAAAAHQAAAAAAAE8AAAAAAABPAAAAAAAATwAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAABPAAAAAAAATwAAAAAAAE8AAAAAAAAdAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAB0AAAAAAQAdAAAAAAEAHQAAAAACAB0AAAAAAABUAAAAAAAAVAAAAAADAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAAdAAAAAAEAHQAAAAAAAB0AAAAAAQAdAAAAAAMAVAAAAAADAFQAAAAAAwB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAeQAAAAAAAB0AAAAAAQB5AAAAAAAAHQAAAAACAFQAAAAAAABUAAAAAAIAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaAAAAAAAAFkAAAAAAABZAAAAAAMAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAAdAAAAAAAAWQAAAAABAHkAAAAAAABZAAAAAAIAWQAAAAABAFkAAAAAAwB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABoAAAAAAAAWQAAAAACAFkAAAAAAQBZAAAAAAEAWQAAAAACAFkAAAAAAgBZAAAAAAAAWQAAAAACAA==
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAAB5AAAAAAAAJAAAAAACACQAAAAAAQAkAAAAAAAAJAAAAAAAACQAAAAAAwAkAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAATQAAAAAAAE0AAAAAAAAdAAAAAAMATwAAAAAAAE8AAAAAAABPAAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAB0AAAAAAAAdAAAAAAAAHQAAAAAAAE8AAAAAAABPAAAAAAAATwAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAABPAAAAAAAATwAAAAAAAE8AAAAAAAAdAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAB0AAAAAAQAdAAAAAAEAHQAAAAACAB0AAAAAAABUAAAAAAAAAQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAAdAAAAAAEAHQAAAAAAAB0AAAAAAQAdAAAAAAMAAQAAAAAAAAEAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAeQAAAAAAAB0AAAAAAQB5AAAAAAAAHQAAAAACAFQAAAAAAAABAAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaAAAAAAAAFkAAAAAAABZAAAAAAMAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAAdAAAAAAAAWQAAAAABAHkAAAAAAABZAAAAAAIAWQAAAAABAFkAAAAAAwB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABoAAAAAAAAWQAAAAACAFkAAAAAAQBZAAAAAAEAWQAAAAACAFkAAAAAAgBZAAAAAAAAWQAAAAACAA==
           version: 7
         0,-1:
           ind: 0,-1
@@ -93,10 +92,6 @@ entities:
             color: '#FFFFFFFF'
             id: Arrows
           decals:
-            77: -7,7
-            78: -7,5
-            79: -7,-1
-            80: -7,-3
             156: -6,-9
         - node:
             color: '#FFFFFFFF'
@@ -108,9 +103,6 @@ entities:
             color: '#FFFFFFFF'
             id: Arrows
           decals:
-            81: 1,-3
-            82: 1,-1
-            83: 1,5
             84: 1,7
         - node:
             angle: -3.141592653589793 rad
@@ -142,7 +134,6 @@ entities:
             86: 1,9
             87: 1,10
             140: 1,6
-            141: -7,-2
         - node:
             color: '#FFFFFFFF'
             id: BotRight
@@ -157,7 +148,6 @@ entities:
             55: -6,2
             56: -6,3
             57: -6,4
-            138: 1,-2
             139: -7,6
         - node:
             color: '#52B4E996'
@@ -168,15 +158,15 @@ entities:
             color: '#FFFFFFFF'
             id: BrickTileSteelBox
           decals:
-            0: 1,0
-            1: 1,2
-            2: 1,4
-            3: -3,0
-            4: -3,2
-            5: -3,4
-            6: -7,0
-            7: -7,2
-            8: -7,4
+            220: -3,2
+            221: -3,4
+            222: -3,0
+            223: 1,0
+            224: 1,2
+            225: 1,4
+            226: -7,4
+            227: -7,2
+            228: -7,0
         - node:
             color: '#52B4E996'
             id: BrickTileWhiteCornerNe
@@ -193,20 +183,25 @@ entities:
           decals:
             70: -4,11
         - node:
+            color: '#66A5DDFF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            209: -7,-5
+        - node:
             color: '#9FED5896'
             id: BrickTileWhiteCornerNw
           decals:
             58: -7,11
         - node:
-            color: '#DE3A3A96'
-            id: BrickTileWhiteCornerNw
-          decals:
-            162: -7,-5
-        - node:
             color: '#52B4E996'
             id: BrickTileWhiteCornerSe
           decals:
             72: -2,10
+        - node:
+            color: '#66A5DDFF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            213: -4,-6
         - node:
             color: '#9FED5896'
             id: BrickTileWhiteCornerSe
@@ -214,89 +209,45 @@ entities:
             60: -5,10
             61: -6,9
         - node:
-            color: '#DE3A3A96'
-            id: BrickTileWhiteCornerSe
-          decals:
-            164: -4,-6
-        - node:
             color: '#52B4E996'
             id: BrickTileWhiteCornerSw
           decals:
             73: -4,10
+        - node:
+            color: '#66A5DDFF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            210: -7,-6
         - node:
             color: '#9FED5896'
             id: BrickTileWhiteCornerSw
           decals:
             62: -7,9
         - node:
-            color: '#DE3A3A96'
-            id: BrickTileWhiteCornerSw
-          decals:
-            163: -7,-6
-        - node:
-            color: '#DE3A3A96'
+            color: '#66A5DDFF'
             id: BrickTileWhiteEndN
           decals:
-            169: -4,-4
+            215: -4,-4
         - node:
-            color: '#D4D4D428'
-            id: BrickTileWhiteInnerNe
-          decals:
-            110: -3,-1
-            111: -7,-1
-        - node:
-            color: '#D4D4D428'
+            color: '#66A5DDFF'
             id: BrickTileWhiteInnerNw
           decals:
-            108: 1,-1
-            109: -3,-1
-        - node:
-            color: '#DE3A3A96'
-            id: BrickTileWhiteInnerNw
-          decals:
-            168: -4,-5
+            217: -4,-5
         - node:
             color: '#9FED5896'
             id: BrickTileWhiteInnerSe
           decals:
             63: -6,10
         - node:
-            color: '#D4D4D428'
-            id: BrickTileWhiteInnerSe
-          decals:
-            102: -3,5
-            103: -7,5
-        - node:
-            color: '#D4D4D428'
-            id: BrickTileWhiteInnerSw
-          decals:
-            100: 1,5
-            101: -3,5
-        - node:
-            color: '#D4D4D428'
+            color: '#66A5DDFF'
             id: BrickTileWhiteLineE
           decals:
-            180: -7,0
-            181: -7,1
-            182: -7,2
-            183: -7,3
-            184: -7,4
-            195: -3,0
-            196: -3,1
-            197: -3,2
-            198: -3,3
-            199: -3,4
-        - node:
-            color: '#DE3A3A96'
-            id: BrickTileWhiteLineE
-          decals:
-            170: -4,-5
+            214: -4,-5
         - node:
             color: '#0000004A'
             id: BrickTileWhiteLineN
           decals:
             19: -2,6
-            20: -3,6
             21: -4,6
         - node:
             color: '#52B4E996'
@@ -304,61 +255,37 @@ entities:
           decals:
             71: -3,11
         - node:
+            color: '#66A5DDFF'
+            id: BrickTileWhiteLineN
+          decals:
+            216: -5,-5
+        - node:
             color: '#9FED5896'
             id: BrickTileWhiteLineN
           decals:
             64: -6,11
-        - node:
-            color: '#D4D4D428'
-            id: BrickTileWhiteLineN
-          decals:
-            104: 0,-1
-            105: -2,-1
-            106: -4,-1
-            107: -6,-1
-        - node:
-            color: '#DE3A3A96'
-            id: BrickTileWhiteLineN
-          decals:
-            167: -5,-5
         - node:
             color: '#52B4E996'
             id: BrickTileWhiteLineS
           decals:
             74: -3,10
         - node:
+            color: '#66A5DDFF'
+            id: BrickTileWhiteLineS
+          decals:
+            211: -6,-6
+            212: -5,-6
+        - node:
             color: '#D4D4D428'
             id: BrickTileWhiteLineS
           decals:
-            96: 0,5
             97: -2,5
             98: -4,5
-            99: -6,5
-        - node:
-            color: '#DE3A3A96'
-            id: BrickTileWhiteLineS
-          decals:
-            165: -5,-6
-            166: -6,-6
         - node:
             color: '#9FED5896'
             id: BrickTileWhiteLineW
           decals:
             65: -7,10
-        - node:
-            color: '#D4D4D428'
-            id: BrickTileWhiteLineW
-          decals:
-            185: -3,0
-            186: -3,1
-            187: -3,2
-            188: -3,3
-            189: -3,4
-            190: 1,0
-            191: 1,1
-            192: 1,2
-            193: 1,3
-            194: 1,4
         - node:
             color: '#FFFFFFFF'
             id: BushATwo
@@ -397,8 +324,6 @@ entities:
             157: 1,-4
             200: -5,5
             201: -1,5
-            202: -1,-1
-            203: -5,-1
             204: 0,-4
             207: 0,8
             208: 1,8
@@ -456,7 +381,6 @@ entities:
             id: HalfTileOverlayGreyscale
           decals:
             16: -4,6
-            17: -3,6
             18: -2,6
         - node:
             color: '#334E6DC8'
@@ -469,9 +393,6 @@ entities:
             color: '#D4D4D428'
             id: QuarterTileOverlayGreyscale
           decals:
-            22: -7,7
-            23: -7,5
-            24: -7,3
             92: 0,7
             93: 0,6
             206: 0,8
@@ -484,22 +405,6 @@ entities:
             135: 0,-7
             136: 0,-8
             137: 0,-9
-        - node:
-            color: '#D4D4D428'
-            id: QuarterTileOverlayGreyscale180
-          decals:
-            28: 1,-3
-            29: 1,-1
-            30: 1,1
-            160: -2,-2
-        - node:
-            color: '#D4D4D428'
-            id: QuarterTileOverlayGreyscale270
-          decals:
-            25: -7,1
-            26: -7,-1
-            27: -7,-3
-            161: -4,-2
         - node:
             color: '#EFDF4196'
             id: QuarterTileOverlayGreyscale270
@@ -525,11 +430,7 @@ entities:
             color: '#D4D4D428'
             id: QuarterTileOverlayGreyscale90
           decals:
-            31: 1,3
-            32: 1,5
             33: 1,7
-            94: -6,6
-            95: -6,7
             205: 1,8
         - node:
             color: '#EFDF4196'
@@ -557,10 +458,10 @@ entities:
           decals:
             153: -5,-9
         - node:
-            color: '#DE3A3A96'
+            color: '#66A5DDFF'
             id: WarnLineGreyscaleN
           decals:
-            171: -6,-5
+            218: -6,-5
         - node:
             color: '#DE3A3A96'
             id: WarnLineGreyscaleS
@@ -668,51 +569,24 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
-          - 21.824879
-          - 82.10312
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
         - volume: 2500
           immutable: True
-          moles:
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+          moles: {}
         - volume: 2500
           temperature: 293.15
           moles:
-          - 1400.0662
-          - 5266.916
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Oxygen: 1400.0662
+            Nitrogen: 5266.916
         chunkSize: 4
     - type: OccluderTree
     - type: Shuttle
+      dampingModifiers:
+        Cruise: 0.0075
+        Dampen: 0.25
+        Anchor: 2
+        None: 0.25
       dampingModifier: 0.25
     - type: RadiationGridResistance
     - type: GravityShake
@@ -721,3893 +595,3951 @@ entities:
     - type: SpreaderGrid
     - type: GridPathfinding
     - type: ImplicitRoof
+    - type: TileHistory
+      chunkHistory: {}
+    - type: FTLDrive
+    - type: ExplosionAirtightGrid
 - proto: AirCanister
   entities:
-  - uid: 609
+  - uid: 2
     components:
     - type: Transform
       pos: -6.5,-8.5
-      parent: 670
+      parent: 1
 - proto: AirlockCargoLocked
   entities:
-  - uid: 166
+  - uid: 3
     components:
     - type: Transform
       pos: 0.5,-9.5
-      parent: 670
+      parent: 1
 - proto: AirlockCommandLocked
-  entities:
-  - uid: 188
-    components:
-    - type: Transform
-      pos: 0.5,12.5
-      parent: 670
-- proto: AirlockEngineeringLocked
-  entities:
-  - uid: 8
-    components:
-    - type: Transform
-      pos: -0.5,-7.5
-      parent: 670
-- proto: AirlockGlass
-  entities:
-  - uid: 288
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-0.5
-      parent: 670
-  - uid: 295
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-0.5
-      parent: 670
-  - uid: 313
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,5.5
-      parent: 670
-  - uid: 314
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,5.5
-      parent: 670
-- proto: AirlockGlassShuttle
-  entities:
-  - uid: 73
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-0.5
-      parent: 670
-  - uid: 74
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,5.5
-      parent: 670
-  - uid: 75
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,7.5
-      parent: 670
-  - uid: 77
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,7.5
-      parent: 670
-  - uid: 81
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-2.5
-      parent: 670
-  - uid: 93
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,5.5
-      parent: 670
-  - uid: 96
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-2.5
-      parent: 670
-  - uid: 142
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-0.5
-      parent: 670
-- proto: AirlockSecurityLocked
-  entities:
-  - uid: 1
-    components:
-    - type: Transform
-      pos: -5.5,-3.5
-      parent: 670
-- proto: AirlockVirologyGlassLocked
-  entities:
-  - uid: 238
-    components:
-    - type: Transform
-      pos: -5.5,8.5
-      parent: 670
-- proto: APCBasic
-  entities:
-  - uid: 165
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-6.5
-      parent: 670
-  - uid: 171
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-8.5
-      parent: 670
-  - uid: 309
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,4.5
-      parent: 670
-  - uid: 354
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,12.5
-      parent: 670
-  - uid: 367
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,9.5
-      parent: 670
-  - uid: 370
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,9.5
-      parent: 670
-- proto: AtmosDeviceFanDirectional
-  entities:
-  - uid: 231
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-0.5
-      parent: 670
-  - uid: 232
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-2.5
-      parent: 670
-  - uid: 234
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,7.5
-      parent: 670
-  - uid: 240
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,5.5
-      parent: 670
-  - uid: 241
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,7.5
-      parent: 670
-  - uid: 242
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,5.5
-      parent: 670
-  - uid: 264
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-0.5
-      parent: 670
-  - uid: 270
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-2.5
-      parent: 670
-- proto: AtmosFixAirMarker
-  entities:
-  - uid: 511
-    components:
-    - type: Transform
-      pos: -6.5,-9.5
-      parent: 670
-  - uid: 512
-    components:
-    - type: Transform
-      pos: -5.5,-9.5
-      parent: 670
-- proto: BedsheetMedical
-  entities:
-  - uid: 263
-    components:
-    - type: Transform
-      pos: -3.5,11.5
-      parent: 670
-  - uid: 265
-    components:
-    - type: Transform
-      pos: -1.5,11.5
-      parent: 670
-- proto: BlastDoorOpen
-  entities:
-  - uid: 281
-    components:
-    - type: Transform
-      pos: -7.5,10.5
-      parent: 670
-  - uid: 657
-    components:
-    - type: Transform
-      pos: 2.5,-8.5
-      parent: 670
-  - uid: 658
-    components:
-    - type: Transform
-      pos: 2.5,-6.5
-      parent: 670
-  - uid: 659
-    components:
-    - type: Transform
-      pos: 2.5,-4.5
-      parent: 670
-- proto: CableApcExtension
-  entities:
-  - uid: 196
-    components:
-    - type: Transform
-      pos: -0.5,-8.5
-      parent: 670
-  - uid: 198
-    components:
-    - type: Transform
-      pos: -4.5,-8.5
-      parent: 670
-  - uid: 290
-    components:
-    - type: Transform
-      pos: -1.5,-8.5
-      parent: 670
-  - uid: 300
-    components:
-    - type: Transform
-      pos: -4.5,-4.5
-      parent: 670
-  - uid: 321
-    components:
-    - type: Transform
-      pos: -2.5,-3.5
-      parent: 670
-  - uid: 322
-    components:
-    - type: Transform
-      pos: -3.5,-3.5
-      parent: 670
-  - uid: 330
-    components:
-    - type: Transform
-      pos: 1.5,-6.5
-      parent: 670
-  - uid: 331
-    components:
-    - type: Transform
-      pos: 1.5,-5.5
-      parent: 670
-  - uid: 333
-    components:
-    - type: Transform
-      pos: -2.5,-8.5
-      parent: 670
-  - uid: 334
-    components:
-    - type: Transform
-      pos: 0.5,-8.5
-      parent: 670
-  - uid: 335
-    components:
-    - type: Transform
-      pos: 1.5,-8.5
-      parent: 670
-  - uid: 336
-    components:
-    - type: Transform
-      pos: 1.5,-7.5
-      parent: 670
-  - uid: 339
-    components:
-    - type: Transform
-      pos: -3.5,-8.5
-      parent: 670
-  - uid: 343
-    components:
-    - type: Transform
-      pos: -3.5,-4.5
-      parent: 670
-  - uid: 345
-    components:
-    - type: Transform
-      pos: 1.5,-2.5
-      parent: 670
-  - uid: 346
-    components:
-    - type: Transform
-      pos: -5.5,-6.5
-      parent: 670
-  - uid: 347
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
-      parent: 670
-  - uid: 348
-    components:
-    - type: Transform
-      pos: -5.5,-5.5
-      parent: 670
-  - uid: 349
-    components:
-    - type: Transform
-      pos: 1.5,-4.5
-      parent: 670
-  - uid: 350
-    components:
-    - type: Transform
-      pos: -5.5,-4.5
-      parent: 670
-  - uid: 361
-    components:
-    - type: Transform
-      pos: 1.5,-3.5
-      parent: 670
-  - uid: 395
-    components:
-    - type: Transform
-      pos: -5.5,-8.5
-      parent: 670
-  - uid: 410
-    components:
-    - type: Transform
-      pos: -1.5,-5.5
-      parent: 670
-  - uid: 411
-    components:
-    - type: Transform
-      pos: -2.5,-5.5
-      parent: 670
-  - uid: 412
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 670
-  - uid: 413
-    components:
-    - type: Transform
-      pos: -1.5,-3.5
-      parent: 670
-  - uid: 414
-    components:
-    - type: Transform
-      pos: -6.5,-4.5
-      parent: 670
-  - uid: 415
-    components:
-    - type: Transform
-      pos: -6.5,-3.5
-      parent: 670
-  - uid: 416
-    components:
-    - type: Transform
-      pos: -4.5,4.5
-      parent: 670
-  - uid: 417
-    components:
-    - type: Transform
-      pos: -4.5,5.5
-      parent: 670
-  - uid: 418
-    components:
-    - type: Transform
-      pos: -5.5,5.5
-      parent: 670
-  - uid: 419
-    components:
-    - type: Transform
-      pos: -6.5,5.5
-      parent: 670
-  - uid: 420
-    components:
-    - type: Transform
-      pos: -3.5,5.5
-      parent: 670
-  - uid: 421
-    components:
-    - type: Transform
-      pos: -2.5,5.5
-      parent: 670
-  - uid: 422
-    components:
-    - type: Transform
-      pos: -1.5,5.5
-      parent: 670
-  - uid: 423
-    components:
-    - type: Transform
-      pos: -0.5,5.5
-      parent: 670
-  - uid: 424
-    components:
-    - type: Transform
-      pos: 0.5,5.5
-      parent: 670
-  - uid: 425
-    components:
-    - type: Transform
-      pos: 1.5,5.5
-      parent: 670
-  - uid: 426
-    components:
-    - type: Transform
-      pos: -2.5,4.5
-      parent: 670
-  - uid: 427
-    components:
-    - type: Transform
-      pos: -2.5,3.5
-      parent: 670
-  - uid: 428
-    components:
-    - type: Transform
-      pos: -2.5,2.5
-      parent: 670
-  - uid: 429
-    components:
-    - type: Transform
-      pos: -2.5,1.5
-      parent: 670
-  - uid: 430
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 670
-  - uid: 431
-    components:
-    - type: Transform
-      pos: -2.5,-0.5
-      parent: 670
-  - uid: 432
-    components:
-    - type: Transform
-      pos: -3.5,-0.5
-      parent: 670
-  - uid: 433
-    components:
-    - type: Transform
-      pos: -4.5,-0.5
-      parent: 670
-  - uid: 434
-    components:
-    - type: Transform
-      pos: -5.5,-0.5
-      parent: 670
-  - uid: 435
-    components:
-    - type: Transform
-      pos: -6.5,-0.5
-      parent: 670
-  - uid: 436
-    components:
-    - type: Transform
-      pos: -1.5,-0.5
-      parent: 670
-  - uid: 437
-    components:
-    - type: Transform
-      pos: -0.5,-0.5
-      parent: 670
-  - uid: 438
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 670
-  - uid: 439
-    components:
-    - type: Transform
-      pos: 1.5,-0.5
-      parent: 670
-  - uid: 440
-    components:
-    - type: Transform
-      pos: 1.5,0.5
-      parent: 670
-  - uid: 441
-    components:
-    - type: Transform
-      pos: 1.5,1.5
-      parent: 670
-  - uid: 442
-    components:
-    - type: Transform
-      pos: 1.5,2.5
-      parent: 670
-  - uid: 443
-    components:
-    - type: Transform
-      pos: 1.5,3.5
-      parent: 670
-  - uid: 444
-    components:
-    - type: Transform
-      pos: 1.5,4.5
-      parent: 670
-  - uid: 445
-    components:
-    - type: Transform
-      pos: -6.5,0.5
-      parent: 670
-  - uid: 446
-    components:
-    - type: Transform
-      pos: -6.5,1.5
-      parent: 670
-  - uid: 447
-    components:
-    - type: Transform
-      pos: -6.5,2.5
-      parent: 670
-  - uid: 448
-    components:
-    - type: Transform
-      pos: -6.5,3.5
-      parent: 670
-  - uid: 449
-    components:
-    - type: Transform
-      pos: -6.5,4.5
-      parent: 670
-  - uid: 450
-    components:
-    - type: Transform
-      pos: -0.5,9.5
-      parent: 670
-  - uid: 451
-    components:
-    - type: Transform
-      pos: 0.5,9.5
-      parent: 670
-  - uid: 452
-    components:
-    - type: Transform
-      pos: 0.5,8.5
-      parent: 670
-  - uid: 453
-    components:
-    - type: Transform
-      pos: 0.5,7.5
-      parent: 670
-  - uid: 454
-    components:
-    - type: Transform
-      pos: 0.5,10.5
-      parent: 670
-  - uid: 455
-    components:
-    - type: Transform
-      pos: 0.5,11.5
-      parent: 670
-  - uid: 458
-    components:
-    - type: Transform
-      pos: -7.5,9.5
-      parent: 670
-  - uid: 459
-    components:
-    - type: Transform
-      pos: -3.5,10.5
-      parent: 670
-  - uid: 460
-    components:
-    - type: Transform
-      pos: -4.5,10.5
-      parent: 670
-  - uid: 461
-    components:
-    - type: Transform
-      pos: -5.5,10.5
-      parent: 670
-  - uid: 462
-    components:
-    - type: Transform
-      pos: -6.5,10.5
-      parent: 670
-  - uid: 463
-    components:
-    - type: Transform
-      pos: -7.5,10.5
-      parent: 670
-  - uid: 464
-    components:
-    - type: Transform
-      pos: -6.5,9.5
-      parent: 670
-  - uid: 465
-    components:
-    - type: Transform
-      pos: -6.5,8.5
-      parent: 670
-  - uid: 466
-    components:
-    - type: Transform
-      pos: -2.5,10.5
-      parent: 670
-  - uid: 467
-    components:
-    - type: Transform
-      pos: -1.5,10.5
-      parent: 670
-  - uid: 468
-    components:
-    - type: Transform
-      pos: -0.5,12.5
-      parent: 670
-  - uid: 469
-    components:
-    - type: Transform
-      pos: -0.5,13.5
-      parent: 670
-  - uid: 470
-    components:
-    - type: Transform
-      pos: -0.5,14.5
-      parent: 670
-  - uid: 471
-    components:
-    - type: Transform
-      pos: -1.5,14.5
-      parent: 670
-  - uid: 472
-    components:
-    - type: Transform
-      pos: -2.5,14.5
-      parent: 670
-  - uid: 473
-    components:
-    - type: Transform
-      pos: -3.5,14.5
-      parent: 670
-  - uid: 474
-    components:
-    - type: Transform
-      pos: -4.5,14.5
-      parent: 670
-  - uid: 475
-    components:
-    - type: Transform
-      pos: -5.5,14.5
-      parent: 670
-  - uid: 476
-    components:
-    - type: Transform
-      pos: -6.5,14.5
-      parent: 670
-  - uid: 477
-    components:
-    - type: Transform
-      pos: -6.5,15.5
-      parent: 670
-  - uid: 478
-    components:
-    - type: Transform
-      pos: -5.5,15.5
-      parent: 670
-  - uid: 479
-    components:
-    - type: Transform
-      pos: -5.5,16.5
-      parent: 670
-  - uid: 480
-    components:
-    - type: Transform
-      pos: -4.5,16.5
-      parent: 670
-  - uid: 481
-    components:
-    - type: Transform
-      pos: -3.5,16.5
-      parent: 670
-  - uid: 482
-    components:
-    - type: Transform
-      pos: -2.5,16.5
-      parent: 670
-  - uid: 483
-    components:
-    - type: Transform
-      pos: -1.5,16.5
-      parent: 670
-  - uid: 484
-    components:
-    - type: Transform
-      pos: -0.5,16.5
-      parent: 670
-  - uid: 485
-    components:
-    - type: Transform
-      pos: 0.5,16.5
-      parent: 670
-  - uid: 486
-    components:
-    - type: Transform
-      pos: 0.5,15.5
-      parent: 670
-  - uid: 487
-    components:
-    - type: Transform
-      pos: 1.5,15.5
-      parent: 670
-  - uid: 488
-    components:
-    - type: Transform
-      pos: 1.5,14.5
-      parent: 670
-  - uid: 489
-    components:
-    - type: Transform
-      pos: 0.5,14.5
-      parent: 670
-  - uid: 490
-    components:
-    - type: Transform
-      pos: 1.5,7.5
-      parent: 670
-  - uid: 494
-    components:
-    - type: Transform
-      pos: -6.5,-2.5
-      parent: 670
-  - uid: 495
-    components:
-    - type: Transform
-      pos: -5.5,-2.5
-      parent: 670
-  - uid: 496
-    components:
-    - type: Transform
-      pos: -7.5,-2.5
-      parent: 670
-  - uid: 497
-    components:
-    - type: Transform
-      pos: -7.5,-0.5
-      parent: 670
-  - uid: 498
-    components:
-    - type: Transform
-      pos: 2.5,-0.5
-      parent: 670
-  - uid: 499
-    components:
-    - type: Transform
-      pos: 2.5,-2.5
-      parent: 670
-  - uid: 500
-    components:
-    - type: Transform
-      pos: 2.5,5.5
-      parent: 670
-  - uid: 501
-    components:
-    - type: Transform
-      pos: 2.5,7.5
-      parent: 670
-  - uid: 502
-    components:
-    - type: Transform
-      pos: -7.5,5.5
-      parent: 670
-  - uid: 503
-    components:
-    - type: Transform
-      pos: -6.5,7.5
-      parent: 670
-  - uid: 504
-    components:
-    - type: Transform
-      pos: -7.5,7.5
-      parent: 670
-  - uid: 505
-    components:
-    - type: Transform
-      pos: -2.5,6.5
-      parent: 670
-  - uid: 506
-    components:
-    - type: Transform
-      pos: -2.5,7.5
-      parent: 670
-  - uid: 661
-    components:
-    - type: Transform
-      pos: -5.5,-9.5
-      parent: 670
-  - uid: 662
-    components:
-    - type: Transform
-      pos: -5.5,-10.5
-      parent: 670
-  - uid: 663
-    components:
-    - type: Transform
-      pos: -5.5,-11.5
-      parent: 670
-  - uid: 664
-    components:
-    - type: Transform
-      pos: 0.5,-9.5
-      parent: 670
-  - uid: 665
-    components:
-    - type: Transform
-      pos: 0.5,-10.5
-      parent: 670
-  - uid: 666
-    components:
-    - type: Transform
-      pos: 0.5,-11.5
-      parent: 670
-  - uid: 667
-    components:
-    - type: Transform
-      pos: -2.5,-9.5
-      parent: 670
-  - uid: 668
-    components:
-    - type: Transform
-      pos: -2.5,-10.5
-      parent: 670
-- proto: CableHV
-  entities:
-  - uid: 30
-    components:
-    - type: Transform
-      pos: -4.5,-6.5
-      parent: 670
-  - uid: 31
-    components:
-    - type: Transform
-      pos: -5.5,12.5
-      parent: 670
-  - uid: 156
-    components:
-    - type: Transform
-      pos: -5.5,11.5
-      parent: 670
-  - uid: 157
-    components:
-    - type: Transform
-      pos: -4.5,11.5
-      parent: 670
-  - uid: 158
-    components:
-    - type: Transform
-      pos: -3.5,11.5
-      parent: 670
-  - uid: 163
-    components:
-    - type: Transform
-      pos: -3.5,-6.5
-      parent: 670
-  - uid: 302
-    components:
-    - type: Transform
-      pos: -6.5,-7.5
-      parent: 670
-  - uid: 324
-    components:
-    - type: Transform
-      pos: -3.5,-7.5
-      parent: 670
-  - uid: 369
-    components:
-    - type: Transform
-      pos: -3.5,12.5
-      parent: 670
-  - uid: 517
-    components:
-    - type: Transform
-      pos: -5.5,-7.5
-      parent: 670
-  - uid: 518
-    components:
-    - type: Transform
-      pos: -4.5,-7.5
-      parent: 670
-- proto: CableMV
-  entities:
-  - uid: 11
-    components:
-    - type: Transform
-      pos: -5.5,5.5
-      parent: 670
-  - uid: 20
-    components:
-    - type: Transform
-      pos: -1.5,-8.5
-      parent: 670
-  - uid: 27
-    components:
-    - type: Transform
-      pos: -3.5,12.5
-      parent: 670
-  - uid: 28
-    components:
-    - type: Transform
-      pos: -3.5,11.5
-      parent: 670
-  - uid: 32
-    components:
-    - type: Transform
-      pos: -5.5,10.5
-      parent: 670
-  - uid: 33
-    components:
-    - type: Transform
-      pos: -5.5,9.5
-      parent: 670
-  - uid: 36
-    components:
-    - type: Transform
-      pos: 1.5,5.5
-      parent: 670
-  - uid: 37
-    components:
-    - type: Transform
-      pos: -1.5,5.5
-      parent: 670
-  - uid: 39
-    components:
-    - type: Transform
-      pos: 0.5,6.5
-      parent: 670
-  - uid: 50
-    components:
-    - type: Transform
-      pos: -5.5,-8.5
-      parent: 670
-  - uid: 89
-    components:
-    - type: Transform
-      pos: -0.5,13.5
-      parent: 670
-  - uid: 135
-    components:
-    - type: Transform
-      pos: -0.5,12.5
-      parent: 670
-  - uid: 145
-    components:
-    - type: Transform
-      pos: 1.5,1.5
-      parent: 670
-  - uid: 147
-    components:
-    - type: Transform
-      pos: -0.5,9.5
-      parent: 670
-  - uid: 152
-    components:
-    - type: Transform
-      pos: 1.5,2.5
-      parent: 670
-  - uid: 159
-    components:
-    - type: Transform
-      pos: -3.5,10.5
-      parent: 670
-  - uid: 160
-    components:
-    - type: Transform
-      pos: -4.5,10.5
-      parent: 670
-  - uid: 161
-    components:
-    - type: Transform
-      pos: -5.5,8.5
-      parent: 670
-  - uid: 162
-    components:
-    - type: Transform
-      pos: -5.5,6.5
-      parent: 670
-  - uid: 172
-    components:
-    - type: Transform
-      pos: -0.5,-8.5
-      parent: 670
-  - uid: 173
-    components:
-    - type: Transform
-      pos: -4.5,5.5
-      parent: 670
-  - uid: 175
-    components:
-    - type: Transform
-      pos: 0.5,5.5
-      parent: 670
-  - uid: 181
-    components:
-    - type: Transform
-      pos: -2.5,-8.5
-      parent: 670
-  - uid: 189
-    components:
-    - type: Transform
-      pos: -2.5,5.5
-      parent: 670
-  - uid: 190
-    components:
-    - type: Transform
-      pos: -3.5,5.5
-      parent: 670
-  - uid: 193
-    components:
-    - type: Transform
-      pos: -0.5,5.5
-      parent: 670
-  - uid: 199
-    components:
-    - type: Transform
-      pos: 0.5,8.5
-      parent: 670
-  - uid: 200
-    components:
-    - type: Transform
-      pos: 0.5,7.5
-      parent: 670
-  - uid: 316
-    components:
-    - type: Transform
-      pos: 1.5,-3.5
-      parent: 670
-  - uid: 317
-    components:
-    - type: Transform
-      pos: 1.5,-5.5
-      parent: 670
-  - uid: 318
-    components:
-    - type: Transform
-      pos: 1.5,-6.5
-      parent: 670
-  - uid: 327
-    components:
-    - type: Transform
-      pos: 1.5,-0.5
-      parent: 670
-  - uid: 328
-    components:
-    - type: Transform
-      pos: 1.5,-1.5
-      parent: 670
-  - uid: 329
-    components:
-    - type: Transform
-      pos: 1.5,-2.5
-      parent: 670
-  - uid: 332
-    components:
-    - type: Transform
-      pos: 0.5,9.5
-      parent: 670
-  - uid: 337
-    components:
-    - type: Transform
-      pos: 1.5,-7.5
-      parent: 670
-  - uid: 338
-    components:
-    - type: Transform
-      pos: 1.5,-4.5
-      parent: 670
-  - uid: 340
-    components:
-    - type: Transform
-      pos: 1.5,-8.5
-      parent: 670
-  - uid: 341
-    components:
-    - type: Transform
-      pos: 0.5,-8.5
-      parent: 670
-  - uid: 353
-    components:
-    - type: Transform
-      pos: 1.5,4.5
-      parent: 670
-  - uid: 366
-    components:
-    - type: Transform
-      pos: -5.5,-6.5
-      parent: 670
-  - uid: 368
-    components:
-    - type: Transform
-      pos: -5.5,7.5
-      parent: 670
-  - uid: 371
-    components:
-    - type: Transform
-      pos: -3.5,-8.5
-      parent: 670
-  - uid: 372
-    components:
-    - type: Transform
-      pos: -4.5,-8.5
-      parent: 670
-  - uid: 373
-    components:
-    - type: Transform
-      pos: 0.5,11.5
-      parent: 670
-  - uid: 374
-    components:
-    - type: Transform
-      pos: 0.5,12.5
-      parent: 670
-  - uid: 375
-    components:
-    - type: Transform
-      pos: -4.5,4.5
-      parent: 670
-  - uid: 376
-    components:
-    - type: Transform
-      pos: 0.5,13.5
-      parent: 670
-  - uid: 377
-    components:
-    - type: Transform
-      pos: -3.5,-7.5
-      parent: 670
-  - uid: 378
-    components:
-    - type: Transform
-      pos: -3.5,-6.5
-      parent: 670
-  - uid: 394
-    components:
-    - type: Transform
-      pos: -5.5,-7.5
-      parent: 670
-  - uid: 396
-    components:
-    - type: Transform
-      pos: 0.5,10.5
-      parent: 670
-  - uid: 397
-    components:
-    - type: Transform
-      pos: 1.5,3.5
-      parent: 670
-  - uid: 398
-    components:
-    - type: Transform
-      pos: 1.5,0.5
-      parent: 670
-  - uid: 456
-    components:
-    - type: Transform
-      pos: -7.5,9.5
-      parent: 670
-  - uid: 457
-    components:
-    - type: Transform
-      pos: -6.5,9.5
-      parent: 670
-  - uid: 491
-    components:
-    - type: Transform
-      pos: -3.5,13.5
-      parent: 670
-  - uid: 492
-    components:
-    - type: Transform
-      pos: -2.5,13.5
-      parent: 670
-  - uid: 493
-    components:
-    - type: Transform
-      pos: -1.5,13.5
-      parent: 670
-- proto: CableTerminal
-  entities:
-  - uid: 519
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-7.5
-      parent: 670
-- proto: CarpetGreen
-  entities:
-  - uid: 249
-    components:
-    - type: Transform
-      pos: -2.5,14.5
-      parent: 670
-  - uid: 250
-    components:
-    - type: Transform
-      pos: -3.5,13.5
-      parent: 670
-  - uid: 266
-    components:
-    - type: Transform
-      pos: -1.5,13.5
-      parent: 670
-  - uid: 267
-    components:
-    - type: Transform
-      pos: -1.5,14.5
-      parent: 670
-  - uid: 271
-    components:
-    - type: Transform
-      pos: -3.5,14.5
-      parent: 670
-  - uid: 272
-    components:
-    - type: Transform
-      pos: -2.5,13.5
-      parent: 670
-- proto: Catwalk
-  entities:
-  - uid: 627
-    components:
-    - type: Transform
-      pos: -6.5,-7.5
-      parent: 670
-  - uid: 630
-    components:
-    - type: Transform
-      pos: -5.5,-7.5
-      parent: 670
-  - uid: 633
-    components:
-    - type: Transform
-      pos: -4.5,-7.5
-      parent: 670
-- proto: Chair
-  entities:
-  - uid: 628
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-8.5
-      parent: 670
-  - uid: 629
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-9.5
-      parent: 670
-  - uid: 631
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-9.5
-      parent: 670
-  - uid: 632
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-8.5
-      parent: 670
-- proto: ChairOfficeDark
-  entities:
-  - uid: 635
-    components:
-    - type: Transform
-      pos: -2.5,-7.5
-      parent: 670
-- proto: ChairOfficeLight
-  entities:
-  - uid: 380
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,10.5
-      parent: 670
-  - uid: 403
-    components:
-    - type: Transform
-      pos: -5.5,11.5
-      parent: 670
-- proto: ChairPilotSeat
   entities:
   - uid: 4
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,0.5
-      parent: 670
-  - uid: 7
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-5.5
-      parent: 670
-  - uid: 13
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-4.5
-      parent: 670
-  - uid: 15
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,4.5
-      parent: 670
-  - uid: 16
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,4.5
-      parent: 670
-  - uid: 17
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,0.5
-      parent: 670
-  - uid: 21
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-4.5
-      parent: 670
-  - uid: 41
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-5.5
-      parent: 670
-  - uid: 43
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,3.5
-      parent: 670
-  - uid: 49
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-1.5
-      parent: 670
-  - uid: 55
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-5.5
-      parent: 670
-  - uid: 58
-    components:
-    - type: Transform
-      pos: -3.5,-3.5
-      parent: 670
-  - uid: 71
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-1.5
-      parent: 670
-  - uid: 100
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,9.5
-      parent: 670
-  - uid: 101
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-5.5
-      parent: 670
-  - uid: 105
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,2.5
-      parent: 670
-  - uid: 107
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,1.5
-      parent: 670
-  - uid: 113
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,3.5
-      parent: 670
-  - uid: 114
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,2.5
-      parent: 670
-  - uid: 120
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,1.5
-      parent: 670
-  - uid: 121
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,3.5
-      parent: 670
-  - uid: 136
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,2.5
-      parent: 670
-  - uid: 174
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,3.5
-      parent: 670
-  - uid: 187
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,1.5
-      parent: 670
-  - uid: 191
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,2.5
-      parent: 670
-  - uid: 192
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,0.5
-      parent: 670
-  - uid: 236
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,1.5
-      parent: 670
-  - uid: 303
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,4.5
-      parent: 670
-  - uid: 304
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,4.5
-      parent: 670
-  - uid: 363
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,0.5
-      parent: 670
-  - uid: 400
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,10.5
-      parent: 670
-  - uid: 515
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,6.5
-      parent: 670
-  - uid: 516
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,6.5
-      parent: 670
-  - uid: 520
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-8.5
-      parent: 670
-  - uid: 521
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-7.5
-      parent: 670
-  - uid: 522
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-6.5
-      parent: 670
-- proto: CigarGold
+      pos: 0.5,12.5
+      parent: 1
+- proto: AirlockEngineeringLocked
   entities:
-  - uid: 51
+  - uid: 5
     components:
     - type: Transform
-      pos: -0.57872725,15.578903
-      parent: 670
-  - uid: 65
-    components:
-    - type: Transform
-      pos: -0.32872725,15.578903
-      parent: 670
-  - uid: 69
-    components:
-    - type: Transform
-      pos: -0.45372725,15.578903
-      parent: 670
-- proto: ClosetWallEmergencyFilledRandom
-  entities:
-  - uid: 19
-    components:
-    - type: Transform
-      pos: 1.5,12.5
-      parent: 670
-- proto: ComfyChair
-  entities:
-  - uid: 229
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,7.5
-      parent: 670
-  - uid: 245
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,7.5
-      parent: 670
-  - uid: 255
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,13.5
-      parent: 670
-  - uid: 260
-    components:
-    - type: Transform
-      pos: -3.5,15.5
-      parent: 670
-  - uid: 268
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,14.5
-      parent: 670
-  - uid: 276
-    components:
-    - type: Transform
-      pos: -1.5,15.5
-      parent: 670
-  - uid: 279
-    components:
-    - type: Transform
-      pos: -2.5,8.5
-      parent: 670
-- proto: ComputerComms
-  entities:
-  - uid: 246
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,14.5
-      parent: 670
-- proto: ComputerEmergencyShuttle
-  entities:
-  - uid: 273
-    components:
-    - type: Transform
-      pos: -2.5,15.5
-      parent: 670
-- proto: ComputerId
-  entities:
-  - uid: 277
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,13.5
-      parent: 670
-- proto: DefibrillatorCabinetFilled
-  entities:
-  - uid: 12
-    components:
-    - type: Transform
-      pos: -4.5,0.5
-      parent: 670
-- proto: DogBed
-  entities:
-  - uid: 42
-    components:
-    - type: Transform
-      pos: -0.5,14.5
-      parent: 670
-- proto: DrinkGildlagerBottleFull
-  entities:
-  - uid: 68
-    components:
-    - type: Transform
-      pos: -2.5631022,13.969528
-      parent: 670
-- proto: DrinkGlass
-  entities:
-  - uid: 59
-    components:
-    - type: Transform
-      pos: -2.3443522,13.657028
-      parent: 670
-  - uid: 63
-    components:
-    - type: Transform
-      pos: -2.5631022,13.532028
-      parent: 670
-- proto: EmergencyLight
-  entities:
-  - uid: 143
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-1.5
-      parent: 670
-  - uid: 297
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,7.5
-      parent: 670
-- proto: ExtinguisherCabinetFilled
+      pos: -0.5,-7.5
+      parent: 1
+- proto: AirlockGlass
   entities:
   - uid: 6
     components:
     - type: Transform
-      pos: -0.5,0.5
-      parent: 670
-  - uid: 292
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 7
     components:
     - type: Transform
-      pos: -0.5,7.5
-      parent: 670
-- proto: FireAxeCabinetFilled
-  entities:
-  - uid: 513
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 8
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,12.5
-      parent: 670
-- proto: FirelockGlass
-  entities:
-  - uid: 164
-    components:
-    - type: Transform
-      pos: 0.5,8.5
-      parent: 670
-  - uid: 296
-    components:
-    - type: Transform
-      pos: 1.5,-3.5
-      parent: 670
-  - uid: 514
-    components:
-    - type: Transform
-      pos: 0.5,-3.5
-      parent: 670
-  - uid: 555
-    components:
-    - type: Transform
-      pos: -5.5,8.5
-      parent: 670
-  - uid: 580
-    components:
-    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -4.5,5.5
-      parent: 670
-  - uid: 610
+      parent: 1
+  - uid: 9
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -0.5,5.5
-      parent: 670
-  - uid: 611
-    components:
-    - type: Transform
-      pos: 1.5,8.5
-      parent: 670
-  - uid: 612
-    components:
-    - type: Transform
-      pos: -0.5,-0.5
-      parent: 670
-  - uid: 620
-    components:
-    - type: Transform
-      pos: -4.5,-0.5
-      parent: 670
-  - uid: 638
-    components:
-    - type: Transform
-      pos: -5.5,-3.5
-      parent: 670
-- proto: GasPassiveVent
+      parent: 1
+- proto: AirlockGlassShuttle
   entities:
-  - uid: 525
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-9.5
-      parent: 670
-  - uid: 526
+  - uid: 10
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -5.5,-9.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-- proto: GasPipeBend
-  entities:
-  - uid: 527
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-9.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 530
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 11
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -4.5,-7.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 535
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-7.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 536
-    components:
-    - type: Transform
-      pos: 1.5,-5.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 537
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-5.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 551
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,0.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 552
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,0.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 553
-    components:
-    - type: Transform
-      pos: -1.5,4.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 554
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 12
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -3.5,4.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 558
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-0.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 559
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 13
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-0.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 573
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-4.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-- proto: GasPipeFourway
-  entities:
-  - uid: 550
-    components:
-    - type: Transform
-      pos: -2.5,-0.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 582
-    components:
-    - type: Transform
-      pos: -2.5,6.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-- proto: GasPipeStraight
-  entities:
-  - uid: 529
-    components:
-    - type: Transform
-      pos: -4.5,-8.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 531
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 14
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,-7.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 534
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-7.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 538
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-7.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 544
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-4.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 545
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-3.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 546
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-2.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 560
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,0.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 561
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,1.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 562
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,2.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 563
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,0.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 566
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-0.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 567
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-0.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 568
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-0.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 569
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-0.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 571
-    components:
-    - type: Transform
-      pos: -5.5,-2.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 572
-    components:
-    - type: Transform
-      pos: -5.5,-3.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 576
-    components:
-    - type: Transform
-      pos: -3.5,1.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 577
-    components:
-    - type: Transform
-      pos: -3.5,2.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 578
-    components:
-    - type: Transform
-      pos: -3.5,3.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 579
-    components:
-    - type: Transform
-      pos: -1.5,1.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 581
-    components:
-    - type: Transform
-      pos: -1.5,3.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 585
-    components:
-    - type: Transform
-      pos: -2.5,5.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 586
+      pos: -7.5,-2.5
+      parent: 1
+  - uid: 15
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -3.5,6.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 587
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,6.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 588
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,6.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 589
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,6.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 590
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,7.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 591
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,8.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 596
-    components:
-    - type: Transform
-      pos: 0.5,7.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 597
-    components:
-    - type: Transform
-      pos: 0.5,8.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 598
-    components:
-    - type: Transform
-      pos: 0.5,9.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 599
-    components:
-    - type: Transform
-      pos: 0.5,10.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 600
-    components:
-    - type: Transform
-      pos: 0.5,11.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 601
-    components:
-    - type: Transform
-      pos: 0.5,12.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-- proto: GasPipeTJunction
-  entities:
-  - uid: 195
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,2.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 532
-    components:
-    - type: Transform
-      pos: -1.5,-7.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 539
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-6.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 547
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 16
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 0.5,-1.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 548
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 549
-    components:
-    - type: Transform
-      pos: -5.5,-0.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 556
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 557
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,4.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 570
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 17
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -5.5,-1.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 583
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,6.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 584
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,6.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-- proto: GasPort
-  entities:
-  - uid: 523
-    components:
-    - type: Transform
-      pos: -6.5,-8.5
-      parent: 670
-- proto: GasPressurePump
-  entities:
-  - uid: 528
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-7.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-- proto: GasVentPump
-  entities:
-  - uid: 533
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-8.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 540
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-6.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 541
-    components:
-    - type: Transform
-      pos: -6.5,3.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 543
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,-1.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 564
-    components:
-    - type: Transform
-      pos: 1.5,1.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 574
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-4.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 575
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,2.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 592
-    components:
-    - type: Transform
-      pos: -5.5,9.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 593
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,5.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 594
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,5.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 595
-    components:
-    - type: Transform
-      pos: -2.5,7.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 602
-    components:
-    - type: Transform
-      pos: 0.5,13.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 603
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-1.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 604
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-1.5
-      parent: 670
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-- proto: GeneratorBasic15kW
-  entities:
-  - uid: 402
-    components:
-    - type: Transform
-      pos: -6.5,-7.5
-      parent: 670
-- proto: GeneratorWallmountAPU
-  entities:
-  - uid: 29
-    components:
-    - type: Transform
-      pos: -5.5,12.5
-      parent: 670
-  - uid: 168
-    components:
-    - type: Transform
-      pos: -4.5,-6.5
-      parent: 670
-- proto: GravityGeneratorMini
-  entities:
-  - uid: 524
-    components:
-    - type: Transform
-      pos: -4.5,-7.5
-      parent: 670
-- proto: Grille
-  entities:
-  - uid: 35
-    components:
-    - type: Transform
-      pos: -6.5,-3.5
-      parent: 670
-  - uid: 47
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
-      parent: 670
-  - uid: 76
-    components:
-    - type: Transform
-      pos: 2.5,3.5
-      parent: 670
-  - uid: 108
-    components:
-    - type: Transform
-      pos: -7.5,3.5
-      parent: 670
-  - uid: 109
-    components:
-    - type: Transform
-      pos: -7.5,2.5
-      parent: 670
-  - uid: 110
-    components:
-    - type: Transform
-      pos: 2.5,1.5
-      parent: 670
-  - uid: 111
-    components:
-    - type: Transform
-      pos: 2.5,2.5
-      parent: 670
-  - uid: 153
-    components:
-    - type: Transform
-      pos: -3.5,-11.5
-      parent: 670
-  - uid: 180
-    components:
-    - type: Transform
-      pos: 2.5,6.5
-      parent: 670
-  - uid: 211
-    components:
-    - type: Transform
-      pos: 1.5,14.5
-      parent: 670
-  - uid: 212
-    components:
-    - type: Transform
-      pos: 1.5,15.5
-      parent: 670
-  - uid: 219
-    components:
-    - type: Transform
-      pos: -2.5,16.5
-      parent: 670
-  - uid: 220
-    components:
-    - type: Transform
-      pos: -3.5,16.5
-      parent: 670
-  - uid: 221
-    components:
-    - type: Transform
-      pos: -4.5,16.5
-      parent: 670
-  - uid: 222
-    components:
-    - type: Transform
-      pos: -5.5,16.5
-      parent: 670
-  - uid: 223
-    components:
-    - type: Transform
-      pos: 0.5,15.5
-      parent: 670
-  - uid: 224
-    components:
-    - type: Transform
-      pos: 0.5,16.5
-      parent: 670
-  - uid: 225
-    components:
-    - type: Transform
-      pos: -0.5,16.5
-      parent: 670
-  - uid: 226
-    components:
-    - type: Transform
-      pos: -5.5,15.5
-      parent: 670
-  - uid: 227
-    components:
-    - type: Transform
-      pos: -6.5,15.5
-      parent: 670
-  - uid: 228
-    components:
-    - type: Transform
-      pos: -6.5,14.5
-      parent: 670
-  - uid: 233
-    components:
-    - type: Transform
-      pos: -6.5,8.5
-      parent: 670
-  - uid: 237
-    components:
-    - type: Transform
-      pos: -7.5,6.5
-      parent: 670
-  - uid: 247
-    components:
-    - type: Transform
-      pos: -3.5,9.5
-      parent: 670
-  - uid: 254
-    components:
-    - type: Transform
-      pos: -1.5,9.5
-      parent: 670
-  - uid: 259
-    components:
-    - type: Transform
-      pos: 2.5,10.5
-      parent: 670
-  - uid: 282
-    components:
-    - type: Transform
-      pos: 2.5,11.5
-      parent: 670
-  - uid: 285
-    components:
-    - type: Transform
-      pos: -2.5,9.5
-      parent: 670
-  - uid: 291
-    components:
-    - type: Transform
-      pos: -7.5,10.5
-      parent: 670
-  - uid: 294
-    components:
-    - type: Transform
-      pos: -4.5,-11.5
-      parent: 670
-  - uid: 298
-    components:
-    - type: Transform
-      pos: 2.5,9.5
-      parent: 670
-  - uid: 308
-    components:
-    - type: Transform
-      pos: -1.5,-11.5
-      parent: 670
-  - uid: 312
-    components:
-    - type: Transform
-      pos: -2.5,-11.5
-      parent: 670
-  - uid: 325
-    components:
-    - type: Transform
-      pos: -4.5,-1.5
-      parent: 670
-  - uid: 326
-    components:
-    - type: Transform
-      pos: -0.5,-1.5
-      parent: 670
-  - uid: 355
-    components:
-    - type: Transform
-      pos: -0.5,6.5
-      parent: 670
-  - uid: 356
-    components:
-    - type: Transform
-      pos: -4.5,6.5
-      parent: 670
-  - uid: 385
-    components:
-    - type: Transform
-      pos: -7.5,1.5
-      parent: 670
-  - uid: 406
-    components:
-    - type: Transform
-      pos: -7.5,-1.5
-      parent: 670
-  - uid: 407
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 670
-  - uid: 409
-    components:
-    - type: Transform
-      pos: -1.5,16.5
-      parent: 670
-  - uid: 507
-    components:
-    - type: Transform
-      pos: -0.5,-11.5
-      parent: 670
-  - uid: 654
-    components:
-    - type: Transform
-      pos: 2.5,-4.5
-      parent: 670
-  - uid: 655
-    components:
-    - type: Transform
-      pos: 2.5,-6.5
-      parent: 670
-  - uid: 656
-    components:
-    - type: Transform
-      pos: 2.5,-8.5
-      parent: 670
-- proto: Gyroscope
-  entities:
-  - uid: 509
-    components:
-    - type: Transform
-      pos: -5.5,-10.5
-      parent: 670
-- proto: InflatableWallStack
-  entities:
-  - uid: 640
-    components:
-    - type: Transform
-      pos: -2.5105965,-9.325075
-      parent: 670
-- proto: Lamp
+      pos: -7.5,-0.5
+      parent: 1
+- proto: AirlockSecurityLocked
   entities:
   - uid: 18
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.4716127,8.832692
-      parent: 670
-- proto: LampGold
+      pos: -5.5,-3.5
+      parent: 1
+- proto: AirlockVirologyGlassLocked
   entities:
-  - uid: 256
+  - uid: 19
     components:
     - type: Transform
-      pos: -4.476436,15.938278
-      parent: 670
-- proto: Lighter
+      pos: -5.5,8.5
+      parent: 1
+- proto: APCBasic
   entities:
+  - uid: 20
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-6.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 21
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-8.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 22
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 23
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,12.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 24
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,9.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 25
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,9.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-0.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-2.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+- proto: AtmosFixAirMarker
+  entities:
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -5.5,-9.5
+      parent: 1
+- proto: BedsheetMedical
+  entities:
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+- proto: BlastDoorOpen
+  entities:
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: -4.5,-8.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
   - uid: 52
     components:
     - type: Transform
-      pos: -0.67247725,15.656836
-      parent: 670
-- proto: LockerEvacRepairFilled
+      pos: 1.5,-8.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -3.5,-8.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -5.5,-6.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -5.5,-8.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -5.5,10.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: -6.5,10.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: -5.5,14.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -6.5,14.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -6.5,15.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -5.5,15.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: -5.5,16.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -4.5,16.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: -3.5,16.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: -2.5,16.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: -1.5,16.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: -0.5,16.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 0.5,15.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 1.5,15.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -7.5,-2.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -5.5,-9.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: 0.5,-10.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 0.5,-11.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -2.5,-10.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -4.5,-6.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -5.5,12.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 175
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: -5.5,10.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -5.5,-8.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: 1.5,-8.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: -5.5,-6.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      pos: -3.5,-8.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      pos: -4.5,-8.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 234
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-7.5
+      parent: 1
+- proto: CarpetGreen
+  entities:
+  - uid: 235
+    components:
+    - type: Transform
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 241
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 1
+  - uid: 660
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 1
+- proto: Chair
+  entities:
+  - uid: 244
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-8.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-9.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-9.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-8.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 248
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-5.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-1.5
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 263
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 268
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 269
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 270
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 273
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 277
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 279
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-8.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-7.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-6.5
+      parent: 1
+- proto: CigarGold
+  entities:
+  - uid: 284
+    components:
+    - type: Transform
+      pos: -0.57872725,15.578903
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      pos: -0.32872725,15.578903
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      pos: -0.45372725,15.578903
+      parent: 1
+- proto: ClosetWallEmergencyFilledRandom
+  entities:
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: ComfyChair
+  entities:
+  - uid: 288
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,13.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      pos: -3.5,15.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 293
+    components:
+    - type: Transform
+      pos: -1.5,15.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+- proto: ComputerComms
+  entities:
+  - uid: 295
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,14.5
+      parent: 1
+- proto: ComputerEmergencyShuttle
+  entities:
+  - uid: 296
+    components:
+    - type: Transform
+      pos: -2.5,15.5
+      parent: 1
+- proto: ComputerId
+  entities:
+  - uid: 297
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,13.5
+      parent: 1
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 298
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: DogBed
   entities:
   - uid: 299
     components:
     - type: Transform
-      pos: -4.5,-10.5
-      parent: 670
-- proto: LockerEvidence
+      pos: -0.5,14.5
+      parent: 1
+- proto: DrinkGildlagerBottleFull
   entities:
-  - uid: 56
+  - uid: 300
     components:
     - type: Transform
-      pos: -1.5,-3.5
-      parent: 670
-- proto: LockerMedicineFilled
+      pos: -2.5631022,13.969528
+      parent: 1
+- proto: DrinkGlass
   entities:
-  - uid: 269
+  - uid: 301
     components:
     - type: Transform
-      pos: -4.5,11.5
-      parent: 670
-- proto: MedicalBed
-  entities:
-  - uid: 70
+      pos: -2.3443522,13.657028
+      parent: 1
+  - uid: 302
     components:
     - type: Transform
-      pos: -3.5,11.5
-      parent: 670
-  - uid: 252
-    components:
-    - type: Transform
-      pos: -1.5,11.5
-      parent: 670
-- proto: MedkitBruteFilled
+      pos: -2.5631022,13.532028
+      parent: 1
+- proto: EmergencyLight
   entities:
-  - uid: 253
-    components:
-    - type: Transform
-      pos: -6.3579483,9.476149
-      parent: 670
-- proto: MedkitBurnFilled
-  entities:
-  - uid: 286
-    components:
-    - type: Transform
-      pos: -6.4829483,9.616774
-      parent: 670
-- proto: MedkitOxygenFilled
-  entities:
-  - uid: 283
-    components:
-    - type: Transform
-      pos: -6.5766983,9.757399
-      parent: 670
-- proto: PlasmaReinforcedWindowDirectional
-  entities:
-  - uid: 542
+  - uid: 303
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,-9.5
-      parent: 670
-  - uid: 565
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,7.5
+      parent: 1
+- proto: ExtinguisherCabinetFilled
+  entities:
+  - uid: 305
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 306
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: FireAxeCabinetFilled
+  entities:
+  - uid: 307
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,12.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: FirelockGlass
+  entities:
+  - uid: 308
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 1
+- proto: GasPassiveVent
+  entities:
+  - uid: 318
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-9.5
-      parent: 670
-  - uid: 605
+      parent: 1
+  - uid: 319
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-9.5
-      parent: 670
-  - uid: 606
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GasPipeBend
+  entities:
+  - uid: 320
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 321
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 322
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 324
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 325
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 326
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 327
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 328
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 329
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 330
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 331
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GasPipeFourway
+  entities:
+  - uid: 332
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 333
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 334
+    components:
+    - type: Transform
+      pos: -4.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 335
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 336
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 337
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 338
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 339
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 340
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 341
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 342
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 343
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 344
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 345
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 346
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 347
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 348
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 349
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 350
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 351
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 352
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 353
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 354
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 355
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 356
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 357
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 358
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 359
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 360
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 361
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 362
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 363
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 364
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 365
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 366
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 367
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 368
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 369
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 370
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 371
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 372
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 373
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 374
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 375
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 376
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 377
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 378
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 379
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GasPort
+  entities:
+  - uid: 380
+    components:
+    - type: Transform
+      pos: -6.5,-8.5
+      parent: 1
+- proto: GasPressurePump
+  entities:
+  - uid: 381
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 382
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 383
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 384
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 385
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 386
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 387
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 388
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 389
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 390
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 391
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 392
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 393
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 394
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 395
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 396
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 1
+- proto: GeneratorWallmountAPU
+  entities:
+  - uid: 397
+    components:
+    - type: Transform
+      pos: -5.5,12.5
+      parent: 1
+  - uid: 398
+    components:
+    - type: Transform
+      pos: -4.5,-6.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 399
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 400
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 401
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 402
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 403
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 404
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 405
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 406
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 407
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 1
+  - uid: 408
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 409
+    components:
+    - type: Transform
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 410
+    components:
+    - type: Transform
+      pos: 1.5,15.5
+      parent: 1
+  - uid: 411
+    components:
+    - type: Transform
+      pos: -2.5,16.5
+      parent: 1
+  - uid: 412
+    components:
+    - type: Transform
+      pos: -3.5,16.5
+      parent: 1
+  - uid: 413
+    components:
+    - type: Transform
+      pos: -4.5,16.5
+      parent: 1
+  - uid: 414
+    components:
+    - type: Transform
+      pos: -5.5,16.5
+      parent: 1
+  - uid: 415
+    components:
+    - type: Transform
+      pos: 0.5,15.5
+      parent: 1
+  - uid: 416
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 417
+    components:
+    - type: Transform
+      pos: -0.5,16.5
+      parent: 1
+  - uid: 418
+    components:
+    - type: Transform
+      pos: -5.5,15.5
+      parent: 1
+  - uid: 419
+    components:
+    - type: Transform
+      pos: -6.5,15.5
+      parent: 1
+  - uid: 420
+    components:
+    - type: Transform
+      pos: -6.5,14.5
+      parent: 1
+  - uid: 421
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 422
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 423
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 424
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 425
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 426
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 427
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 429
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 1
+  - uid: 430
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 431
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 1
+  - uid: 432
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 433
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 434
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 435
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 436
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 437
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 438
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 1
+  - uid: 439
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 440
+    components:
+    - type: Transform
+      pos: -1.5,16.5
+      parent: 1
+  - uid: 441
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 1
+  - uid: 442
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 443
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+  - uid: 444
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 445
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 1
+- proto: InflatableWallStack
+  entities:
+  - uid: 446
+    components:
+    - type: Transform
+      pos: -2.5105965,-9.325075
+      parent: 1
+- proto: Lamp
+  entities:
+  - uid: 447
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.4716127,8.832692
+      parent: 1
+- proto: LampGold
+  entities:
+  - uid: 448
+    components:
+    - type: Transform
+      pos: -4.476436,15.938278
+      parent: 1
+- proto: Lighter
+  entities:
+  - uid: 449
+    components:
+    - type: Transform
+      pos: -0.67247725,15.656836
+      parent: 1
+- proto: LockableButtonSecurity
+  entities:
+  - uid: 545
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        495:
+        - - Pressed
+          - Toggle
+    - type: Fixtures
+      fixtures: {}
+- proto: LockerEvacRepairFilled
+  entities:
+  - uid: 450
+    components:
+    - type: Transform
+      pos: -4.5,-10.5
+      parent: 1
+- proto: LockerEvidence
+  entities:
+  - uid: 451
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Security
+- proto: LockerMedicineFilled
+  entities:
+  - uid: 452
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+- proto: MedicalBed
+  entities:
+  - uid: 453
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 454
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+- proto: MedkitBruteFilled
+  entities:
+  - uid: 455
+    components:
+    - type: Transform
+      pos: -6.3579483,9.476149
+      parent: 1
+- proto: MedkitBurnFilled
+  entities:
+  - uid: 456
+    components:
+    - type: Transform
+      pos: -6.4829483,9.616774
+      parent: 1
+- proto: MedkitOxygenFilled
+  entities:
+  - uid: 457
+    components:
+    - type: Transform
+      pos: -6.5766983,9.757399
+      parent: 1
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 458
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-9.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-9.5
+      parent: 1
+  - uid: 460
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-9.5
+      parent: 1
+  - uid: 461
     components:
     - type: Transform
       pos: -5.5,-9.5
-      parent: 670
-  - uid: 607
+      parent: 1
+  - uid: 462
     components:
     - type: Transform
       pos: -6.5,-9.5
-      parent: 670
-  - uid: 637
+      parent: 1
+  - uid: 463
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-9.5
-      parent: 670
+      parent: 1
+- proto: PlushieAtmosian
+  entities:
+  - uid: 635
+    components:
+    - type: Transform
+      pos: 2.527267,-10.432823
+      parent: 1
 - proto: PortableScrubber
   entities:
-  - uid: 636
+  - uid: 464
     components:
     - type: Transform
       pos: 1.5,-5.5
-      parent: 670
+      parent: 1
 - proto: PosterContrabandBeachStarYamamoto
   entities:
-  - uid: 650
+  - uid: 465
     components:
     - type: MetaData
       desc: A pink-haired woman on a beach.
       name: Beach Star Bratton!
     - type: Transform
       pos: -1.5,-6.5
-      parent: 670
-- proto: PosterContrabandFreeSyndicateEncryptionKey
-  entities:
-  - uid: 652
-    components:
-    - type: Transform
-      pos: -0.5,-4.5
-      parent: 670
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterContrabandHighEffectEngineering
   entities:
-  - uid: 651
+  - uid: 467
     components:
     - type: Transform
       pos: 1.5,-10.5
-      parent: 670
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: PosterContrabandWehWatches
+  entities:
+  - uid: 466
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterLegitGetYourLEGS
   entities:
-  - uid: 648
+  - uid: 468
     components:
     - type: Transform
       pos: -0.5,10.5
-      parent: 670
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterLegitNanotrasenLogo
   entities:
-  - uid: 9
+  - uid: 469
     components:
     - type: Transform
       pos: -0.5,4.5
-      parent: 670
-  - uid: 64
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 470
     components:
     - type: Transform
       pos: -4.5,12.5
-      parent: 670
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterLegitReportCrimes
   entities:
-  - uid: 649
+  - uid: 471
     components:
     - type: Transform
       pos: -0.5,-2.5
-      parent: 670
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: PottedPlant21
   entities:
-  - uid: 72
+  - uid: 472
     components:
     - type: Transform
       pos: 1.5,11.5
-      parent: 670
+      parent: 1
 - proto: PowerCellRecharger
   entities:
-  - uid: 653
+  - uid: 473
     components:
     - type: Transform
       pos: -2.5,-8.5
-      parent: 670
+      parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 310
+  - uid: 474
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-1.5
-      parent: 670
-  - uid: 613
+      parent: 1
+  - uid: 475
     components:
     - type: Transform
       pos: -4.5,3.5
-      parent: 670
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 614
+  - uid: 476
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,1.5
-      parent: 670
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 615
+  - uid: 477
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-5.5
-      parent: 670
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 616
+  - uid: 478
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,10.5
-      parent: 670
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 619
+  - uid: 479
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,9.5
-      parent: 670
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 621
+  - uid: 480
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-6.5
-      parent: 670
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 622
+  - uid: 481
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,9.5
-      parent: 670
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 624
+  - uid: 482
     components:
     - type: Transform
       pos: -2.5,-7.5
-      parent: 670
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
 - proto: PoweredSmallLight
   entities:
-  - uid: 608
+  - uid: 483
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-8.5
-      parent: 670
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 617
+  - uid: 484
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,7.5
-      parent: 670
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 618
+  - uid: 485
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,13.5
-      parent: 670
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 623
+  - uid: 486
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-5.5
-      parent: 670
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 634
+  - uid: 487
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-10.5
-      parent: 670
+      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
 - proto: Screen
   entities:
-  - uid: 122
+  - uid: 488
     components:
     - type: Transform
       pos: -2.5,-6.5
-      parent: 670
-  - uid: 132
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 489
     components:
     - type: Transform
       pos: -7.5,4.5
-      parent: 670
-  - uid: 144
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 490
     components:
     - type: Transform
       pos: 2.5,0.5
-      parent: 670
-  - uid: 170
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 491
     components:
     - type: Transform
       pos: 2.5,8.5
-      parent: 670
-  - uid: 177
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 492
     components:
     - type: Transform
       pos: -2.5,12.5
-      parent: 670
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: ShotGunCabinetFilled
   entities:
-  - uid: 106
+  - uid: 493
     components:
     - type: Transform
       pos: -3.5,-2.5
-      parent: 670
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: ShuttersWindowOpen
   entities:
-  - uid: 62
+  - uid: 494
     components:
     - type: Transform
       pos: -2.5,-2.5
-      parent: 670
-  - uid: 99
+      parent: 1
+  - uid: 495
     components:
     - type: Transform
       pos: -6.5,-3.5
-      parent: 670
-  - uid: 251
+      parent: 1
+  - uid: 496
     components:
     - type: Transform
       pos: -6.5,8.5
-      parent: 670
-  - uid: 257
+      parent: 1
+  - uid: 497
     components:
     - type: Transform
       pos: -2.5,9.5
-      parent: 670
-  - uid: 274
+      parent: 1
+  - uid: 498
     components:
     - type: Transform
       pos: -3.5,9.5
-      parent: 670
-  - uid: 284
+      parent: 1
+  - uid: 499
     components:
     - type: Transform
       pos: -1.5,9.5
-      parent: 670
+      parent: 1
 - proto: ShuttleWindow
   entities:
-  - uid: 2
+  - uid: 500
     components:
     - type: Transform
       pos: 2.5,-8.5
-      parent: 670
-  - uid: 3
+      parent: 1
+  - uid: 501
     components:
     - type: Transform
       pos: 2.5,-6.5
-      parent: 670
-  - uid: 22
+      parent: 1
+  - uid: 502
     components:
     - type: Transform
       pos: -2.5,-11.5
-      parent: 670
-  - uid: 23
+      parent: 1
+  - uid: 503
     components:
     - type: Transform
       pos: -1.5,-11.5
-      parent: 670
-  - uid: 24
+      parent: 1
+  - uid: 504
     components:
     - type: Transform
       pos: -0.5,-11.5
-      parent: 670
-  - uid: 45
+      parent: 1
+  - uid: 505
     components:
     - type: Transform
       pos: -7.5,-1.5
-      parent: 670
-  - uid: 82
+      parent: 1
+  - uid: 506
     components:
     - type: Transform
       pos: 2.5,9.5
-      parent: 670
-  - uid: 90
+      parent: 1
+  - uid: 507
     components:
     - type: Transform
       pos: 2.5,10.5
-      parent: 670
-  - uid: 104
-    components:
-    - type: Transform
-      pos: 2.5,2.5
-      parent: 670
-  - uid: 116
-    components:
-    - type: Transform
-      pos: -7.5,6.5
-      parent: 670
-  - uid: 117
-    components:
-    - type: Transform
-      pos: -7.5,1.5
-      parent: 670
-  - uid: 129
-    components:
-    - type: Transform
-      pos: 2.5,1.5
-      parent: 670
-  - uid: 133
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 670
-  - uid: 137
-    components:
-    - type: Transform
-      pos: 2.5,11.5
-      parent: 670
-  - uid: 140
-    components:
-    - type: Transform
-      pos: -7.5,2.5
-      parent: 670
-  - uid: 146
-    components:
-    - type: Transform
-      pos: -6.5,-3.5
-      parent: 670
-  - uid: 149
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
-      parent: 670
-  - uid: 183
-    components:
-    - type: Transform
-      pos: 2.5,3.5
-      parent: 670
-  - uid: 185
-    components:
-    - type: Transform
-      pos: 2.5,6.5
-      parent: 670
-  - uid: 201
-    components:
-    - type: Transform
-      pos: -7.5,10.5
-      parent: 670
-  - uid: 202
-    components:
-    - type: Transform
-      pos: -6.5,14.5
-      parent: 670
-  - uid: 203
-    components:
-    - type: Transform
-      pos: -5.5,15.5
-      parent: 670
-  - uid: 206
-    components:
-    - type: Transform
-      pos: -2.5,9.5
-      parent: 670
-  - uid: 209
-    components:
-    - type: Transform
-      pos: -6.5,8.5
-      parent: 670
-  - uid: 213
-    components:
-    - type: Transform
-      pos: -1.5,16.5
-      parent: 670
-  - uid: 214
-    components:
-    - type: Transform
-      pos: -3.5,16.5
-      parent: 670
-  - uid: 215
-    components:
-    - type: Transform
-      pos: -4.5,16.5
-      parent: 670
-  - uid: 216
-    components:
-    - type: Transform
-      pos: 1.5,15.5
-      parent: 670
-  - uid: 217
-    components:
-    - type: Transform
-      pos: 0.5,15.5
-      parent: 670
-  - uid: 218
-    components:
-    - type: Transform
-      pos: 0.5,16.5
-      parent: 670
-  - uid: 320
-    components:
-    - type: Transform
-      pos: -3.5,9.5
-      parent: 670
-  - uid: 351
-    components:
-    - type: Transform
-      pos: 1.5,14.5
-      parent: 670
-  - uid: 357
-    components:
-    - type: Transform
-      pos: -4.5,6.5
-      parent: 670
-  - uid: 358
-    components:
-    - type: Transform
-      pos: -4.5,-11.5
-      parent: 670
-  - uid: 359
-    components:
-    - type: Transform
-      pos: -3.5,-11.5
-      parent: 670
-  - uid: 360
-    components:
-    - type: Transform
-      pos: -4.5,-1.5
-      parent: 670
-  - uid: 364
-    components:
-    - type: Transform
-      pos: -1.5,9.5
-      parent: 670
-  - uid: 365
-    components:
-    - type: Transform
-      pos: -5.5,16.5
-      parent: 670
-  - uid: 382
-    components:
-    - type: Transform
-      pos: -2.5,16.5
-      parent: 670
-  - uid: 384
-    components:
-    - type: Transform
-      pos: -7.5,3.5
-      parent: 670
-  - uid: 392
-    components:
-    - type: Transform
-      pos: -6.5,15.5
-      parent: 670
-  - uid: 401
-    components:
-    - type: Transform
-      pos: 2.5,-4.5
-      parent: 670
-  - uid: 408
-    components:
-    - type: Transform
-      pos: -0.5,16.5
-      parent: 670
+      parent: 1
   - uid: 508
     components:
     - type: Transform
-      pos: -0.5,-1.5
-      parent: 670
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 509
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 1
   - uid: 510
     components:
     - type: Transform
-      pos: -0.5,6.5
-      parent: 670
-- proto: SignalButton
-  entities:
-  - uid: 54
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 511
     components:
     - type: Transform
-      pos: -4.5,-3.5
-      parent: 670
-    - type: DeviceLinkSource
-      linkedPorts:
-        99:
-        - - Pressed
-          - Toggle
-        62:
-        - - Pressed
-          - Toggle
-  - uid: 244
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 512
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 513
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 514
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 515
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 516
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 517
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 518
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 519
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 520
+    components:
+    - type: Transform
+      pos: -6.5,14.5
+      parent: 1
+  - uid: 521
+    components:
+    - type: Transform
+      pos: -5.5,15.5
+      parent: 1
+  - uid: 522
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 523
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 524
+    components:
+    - type: Transform
+      pos: -1.5,16.5
+      parent: 1
+  - uid: 525
+    components:
+    - type: Transform
+      pos: -3.5,16.5
+      parent: 1
+  - uid: 526
+    components:
+    - type: Transform
+      pos: -4.5,16.5
+      parent: 1
+  - uid: 527
+    components:
+    - type: Transform
+      pos: 1.5,15.5
+      parent: 1
+  - uid: 528
+    components:
+    - type: Transform
+      pos: 0.5,15.5
+      parent: 1
+  - uid: 529
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 530
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 531
+    components:
+    - type: Transform
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 532
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 533
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 1
+  - uid: 534
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 1
+  - uid: 535
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 536
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 537
+    components:
+    - type: Transform
+      pos: -5.5,16.5
+      parent: 1
+  - uid: 538
+    components:
+    - type: Transform
+      pos: -2.5,16.5
+      parent: 1
+  - uid: 539
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 540
+    components:
+    - type: Transform
+      pos: -6.5,15.5
+      parent: 1
+  - uid: 541
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 542
+    components:
+    - type: Transform
+      pos: -0.5,16.5
+      parent: 1
+  - uid: 543
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 544
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+- proto: SignalButton
+  entities:
+  - uid: 546
     components:
     - type: Transform
       pos: -4.5,9.5
-      parent: 670
+      parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        251:
+        496:
         - - Pressed
           - Toggle
-        274:
+        498:
         - - Pressed
           - Toggle
-        257:
+        497:
         - - Pressed
           - Toggle
-        284:
+        499:
         - - Pressed
           - Toggle
-        281:
+        38:
         - - Pressed
           - Toggle
-  - uid: 660
+    - type: Fixtures
+      fixtures: {}
+  - uid: 547
     components:
     - type: Transform
       pos: -0.5,-6.5
-      parent: 670
+      parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        658:
+        40:
         - - Pressed
           - Toggle
-        657:
+        39:
         - - Pressed
           - Toggle
-        659:
+        41:
         - - Pressed
           - Toggle
+    - type: Fixtures
+      fixtures: {}
 - proto: SignMedical
   entities:
-  - uid: 5
+  - uid: 548
     components:
     - type: Transform
       pos: -4.5,8.5
-      parent: 670
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: SignSecurity
   entities:
-  - uid: 186
+  - uid: 549
     components:
     - type: Transform
       pos: -4.5,-2.5
-      parent: 670
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: SMESBasic
   entities:
-  - uid: 323
+  - uid: 550
     components:
     - type: Transform
       pos: -5.5,-7.5
-      parent: 670
+      parent: 1
 - proto: StasisBed
   entities:
-  - uid: 248
+  - uid: 551
     components:
     - type: Transform
       pos: -2.5,11.5
-      parent: 670
+      parent: 1
 - proto: SubstationWallBasic
   entities:
-  - uid: 167
+  - uid: 552
     components:
     - type: Transform
       pos: -3.5,12.5
-      parent: 670
-  - uid: 399
+      parent: 1
+  - uid: 553
     components:
     - type: Transform
       pos: -3.5,-6.5
-      parent: 670
+      parent: 1
 - proto: Table
   entities:
-  - uid: 625
+  - uid: 554
     components:
     - type: Transform
       pos: -2.5,-9.5
-      parent: 670
-  - uid: 626
+      parent: 1
+  - uid: 555
     components:
     - type: Transform
       pos: -2.5,-8.5
-      parent: 670
+      parent: 1
 - proto: TableCarpet
   entities:
-  - uid: 67
+  - uid: 556
     components:
     - type: Transform
       pos: -2.5,13.5
-      parent: 670
-  - uid: 280
+      parent: 1
+  - uid: 557
     components:
     - type: Transform
       pos: -3.5,8.5
-      parent: 670
+      parent: 1
 - proto: TableReinforcedGlass
   entities:
-  - uid: 404
+  - uid: 558
     components:
     - type: Transform
       pos: -6.5,9.5
-      parent: 670
+      parent: 1
 - proto: TableWood
   entities:
-  - uid: 275
+  - uid: 559
     components:
     - type: Transform
       pos: -4.5,15.5
-      parent: 670
-  - uid: 278
+      parent: 1
+  - uid: 560
     components:
     - type: Transform
       pos: -0.5,15.5
-      parent: 670
-- proto: ThrusterShuttleEvac # Goob edit
+      parent: 1
+- proto: ThrusterShuttleEvac
   entities:
-  - uid: 61
+  - uid: 561
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-11.5
-      parent: 670
-  - uid: 97
+      parent: 1
+  - uid: 562
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-11.5
-      parent: 670
-  - uid: 235
+      parent: 1
+  - uid: 563
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,13.5
-      parent: 670
-  - uid: 261
+      parent: 1
+  - uid: 564
     components:
     - type: Transform
       pos: 2.5,14.5
-      parent: 670
-  - uid: 319
+      parent: 1
+  - uid: 565
     components:
     - type: Transform
       pos: -7.5,14.5
-      parent: 670
-  - uid: 391
+      parent: 1
+  - uid: 566
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,13.5
-      parent: 670
+      parent: 1
 - proto: VendingMachineBooze
   entities:
-  - uid: 66
+  - uid: 567
     components:
     - type: Transform
       pos: 0.5,14.5
-      parent: 670
+      parent: 1
 - proto: VendingMachineCigs
   entities:
-  - uid: 262
+  - uid: 568
     components:
     - type: Transform
       pos: -1.5,8.5
-      parent: 670
+      parent: 1
 - proto: VendingMachineMedical
   entities:
-  - uid: 381
+  - uid: 569
     components:
     - type: Transform
       pos: -6.5,11.5
-      parent: 670
+      parent: 1
 - proto: WallShuttle
   entities:
-  - uid: 14
+  - uid: 570
     components:
     - type: Transform
       pos: 2.5,-5.5
-      parent: 670
-  - uid: 25
+      parent: 1
+  - uid: 571
     components:
     - type: Transform
       pos: -7.5,-9.5
-      parent: 670
-  - uid: 26
+      parent: 1
+  - uid: 572
     components:
     - type: Transform
       pos: -6.5,-10.5
-      parent: 670
-  - uid: 38
+      parent: 1
+  - uid: 573
     components:
     - type: Transform
       pos: -0.5,-5.5
-      parent: 670
-  - uid: 40
+      parent: 1
+  - uid: 574
     components:
     - type: Transform
       pos: -0.5,-6.5
-      parent: 670
-  - uid: 44
+      parent: 1
+  - uid: 575
     components:
     - type: Transform
       pos: -7.5,0.5
-      parent: 670
-  - uid: 46
+      parent: 1
+  - uid: 576
     components:
     - type: Transform
       pos: -0.5,7.5
-      parent: 670
-  - uid: 48
+      parent: 1
+  - uid: 577
     components:
     - type: Transform
       pos: -0.5,-4.5
-      parent: 670
-  - uid: 53
+      parent: 1
+  - uid: 578
     components:
     - type: Transform
       pos: 0.5,-11.5
-      parent: 670
-  - uid: 60
+      parent: 1
+  - uid: 579
     components:
     - type: Transform
       pos: -1.5,-2.5
-      parent: 670
-  - uid: 78
+      parent: 1
+  - uid: 580
     components:
     - type: Transform
       pos: -4.5,-3.5
-      parent: 670
-  - uid: 83
+      parent: 1
+  - uid: 581
     components:
     - type: Transform
       pos: -0.5,4.5
-      parent: 670
-  - uid: 85
+      parent: 1
+  - uid: 582
     components:
     - type: Transform
       pos: -4.5,-6.5
-      parent: 670
-  - uid: 88
+      parent: 1
+  - uid: 583
     components:
     - type: Transform
       pos: -4.5,-2.5
-      parent: 670
-  - uid: 91
+      parent: 1
+  - uid: 584
     components:
     - type: Transform
       pos: -0.5,0.5
-      parent: 670
-  - uid: 92
+      parent: 1
+  - uid: 585
     components:
     - type: Transform
       pos: -4.5,8.5
-      parent: 670
-  - uid: 94
+      parent: 1
+  - uid: 586
     components:
     - type: Transform
       pos: -7.5,8.5
-      parent: 670
-  - uid: 95
+      parent: 1
+  - uid: 587
     components:
     - type: Transform
       pos: 2.5,8.5
-      parent: 670
-  - uid: 98
+      parent: 1
+  - uid: 588
     components:
     - type: Transform
       pos: 2.5,-7.5
-      parent: 670
-  - uid: 102
+      parent: 1
+  - uid: 589
     components:
     - type: Transform
       pos: -5.5,-6.5
-      parent: 670
-  - uid: 103
+      parent: 1
+  - uid: 590
     components:
     - type: Transform
       pos: -7.5,-3.5
-      parent: 670
-  - uid: 112
+      parent: 1
+  - uid: 591
     components:
     - type: Transform
       pos: -7.5,4.5
-      parent: 670
-  - uid: 115
+      parent: 1
+  - uid: 592
     components:
     - type: Transform
       pos: 2.5,4.5
-      parent: 670
-  - uid: 123
+      parent: 1
+  - uid: 593
     components:
     - type: Transform
       pos: 1.5,-10.5
-      parent: 670
-  - uid: 124
+      parent: 1
+  - uid: 594
     components:
     - type: Transform
       pos: -2.5,-6.5
-      parent: 670
-  - uid: 125
+      parent: 1
+  - uid: 595
     components:
     - type: Transform
       pos: -3.5,-6.5
-      parent: 670
-  - uid: 126
+      parent: 1
+  - uid: 596
     components:
     - type: Transform
       pos: -3.5,-2.5
-      parent: 670
-  - uid: 127
+      parent: 1
+  - uid: 597
     components:
     - type: Transform
       pos: -6.5,-6.5
-      parent: 670
-  - uid: 128
+      parent: 1
+  - uid: 598
     components:
     - type: Transform
       pos: -1.5,12.5
-      parent: 670
-  - uid: 130
+      parent: 1
+  - uid: 599
     components:
     - type: Transform
       pos: 2.5,-3.5
-      parent: 670
-  - uid: 131
+      parent: 1
+  - uid: 600
     components:
     - type: Transform
       pos: 2.5,0.5
-      parent: 670
-  - uid: 134
+      parent: 1
+  - uid: 601
     components:
     - type: Transform
       pos: -0.5,12.5
-      parent: 670
-  - uid: 138
+      parent: 1
+  - uid: 602
     components:
     - type: Transform
       pos: -7.5,9.5
-      parent: 670
-  - uid: 139
+      parent: 1
+  - uid: 603
     components:
     - type: Transform
       pos: -0.5,8.5
-      parent: 670
-  - uid: 141
+      parent: 1
+  - uid: 604
     components:
     - type: Transform
       pos: -1.5,-6.5
-      parent: 670
-  - uid: 148
+      parent: 1
+  - uid: 605
     components:
     - type: Transform
       pos: -5.5,-11.5
-      parent: 670
-  - uid: 151
+      parent: 1
+  - uid: 606
     components:
     - type: Transform
       pos: -0.5,9.5
-      parent: 670
-  - uid: 154
+      parent: 1
+  - uid: 607
     components:
     - type: Transform
       pos: -7.5,-5.5
-      parent: 670
-  - uid: 155
+      parent: 1
+  - uid: 608
     components:
     - type: Transform
       pos: -0.5,-2.5
-      parent: 670
-  - uid: 169
+      parent: 1
+  - uid: 609
     components:
     - type: Transform
       pos: -0.5,-3.5
-      parent: 670
-  - uid: 182
+      parent: 1
+  - uid: 610
     components:
     - type: Transform
       pos: -7.5,-6.5
-      parent: 670
-  - uid: 184
+      parent: 1
+  - uid: 611
     components:
     - type: Transform
       pos: -6.5,12.5
-      parent: 670
-  - uid: 194
+      parent: 1
+  - uid: 612
     components:
     - type: Transform
       pos: -4.5,9.5
-      parent: 670
-  - uid: 204
+      parent: 1
+  - uid: 613
     components:
     - type: Transform
       pos: -5.5,12.5
-      parent: 670
-  - uid: 205
+      parent: 1
+  - uid: 614
     components:
     - type: Transform
       pos: -4.5,12.5
-      parent: 670
-  - uid: 207
+      parent: 1
+  - uid: 615
     components:
     - type: Transform
       pos: -0.5,11.5
-      parent: 670
-  - uid: 208
+      parent: 1
+  - uid: 616
     components:
     - type: Transform
       pos: -0.5,10.5
-      parent: 670
-  - uid: 210
+      parent: 1
+  - uid: 617
     components:
     - type: Transform
       pos: -2.5,12.5
-      parent: 670
-  - uid: 239
+      parent: 1
+  - uid: 618
     components:
     - type: Transform
       pos: -7.5,-8.5
-      parent: 670
-  - uid: 289
+      parent: 1
+  - uid: 619
     components:
     - type: Transform
       pos: -0.5,-8.5
-      parent: 670
-  - uid: 293
+      parent: 1
+  - uid: 620
     components:
     - type: Transform
       pos: -7.5,-4.5
-      parent: 670
-  - uid: 301
+      parent: 1
+  - uid: 621
     components:
     - type: Transform
       pos: -6.5,-11.5
-      parent: 670
-  - uid: 305
+      parent: 1
+  - uid: 622
     components:
     - type: Transform
       pos: -4.5,0.5
-      parent: 670
-  - uid: 307
+      parent: 1
+  - uid: 623
     components:
     - type: Transform
       pos: 1.5,-9.5
-      parent: 670
-  - uid: 311
+      parent: 1
+  - uid: 624
     components:
     - type: Transform
       pos: 1.5,-11.5
-      parent: 670
-  - uid: 315
+      parent: 1
+  - uid: 625
     components:
     - type: Transform
       pos: -7.5,-7.5
-      parent: 670
-  - uid: 342
+      parent: 1
+  - uid: 626
     components:
     - type: Transform
       pos: -0.5,-9.5
-      parent: 670
-  - uid: 344
+      parent: 1
+  - uid: 627
     components:
     - type: Transform
       pos: -4.5,4.5
-      parent: 670
-  - uid: 352
+      parent: 1
+  - uid: 628
     components:
     - type: Transform
       pos: 1.5,13.5
-      parent: 670
-  - uid: 379
+      parent: 1
+  - uid: 629
     components:
     - type: Transform
       pos: -3.5,12.5
-      parent: 670
-  - uid: 383
+      parent: 1
+  - uid: 630
     components:
     - type: Transform
       pos: -4.5,7.5
-      parent: 670
-  - uid: 386
+      parent: 1
+  - uid: 631
     components:
     - type: Transform
       pos: -7.5,11.5
-      parent: 670
-  - uid: 387
+      parent: 1
+  - uid: 632
     components:
     - type: Transform
       pos: 1.5,12.5
-      parent: 670
-  - uid: 390
+      parent: 1
+  - uid: 633
     components:
     - type: Transform
       pos: -6.5,13.5
-      parent: 670
-  - uid: 405
+      parent: 1
+  - uid: 634
     components:
     - type: Transform
       pos: 2.5,-9.5
-      parent: 670
+      parent: 1
 - proto: WallShuttleDiagonal
   entities:
-  - uid: 57
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-10.5
-      parent: 670
-  - uid: 150
+  - uid: 636
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,12.5
-      parent: 670
-  - uid: 197
+      parent: 1
+  - uid: 637
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-10.5
-      parent: 670
-  - uid: 388
+      parent: 1
+  - uid: 638
     components:
     - type: Transform
       pos: -7.5,12.5
-      parent: 670
+      parent: 1
 - proto: WindoorSecure
-  entities:
-  - uid: 230
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,6.5
-      parent: 670
-- proto: WindoorSecureMedicalLocked
-  entities:
-  - uid: 258
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,10.5
-      parent: 670
-- proto: WindoorSecureSecurityLocked
-  entities:
-  - uid: 287
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-4.5
-      parent: 670
-- proto: WindowFrostedDirectional
-  entities:
-  - uid: 79
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,6.5
-      parent: 670
-  - uid: 80
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,6.5
-      parent: 670
-- proto: WindowReinforcedDirectional
-  entities:
-  - uid: 10
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-3.5
-      parent: 670
-  - uid: 34
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-5.5
-      parent: 670
-  - uid: 84
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,1.5
-      parent: 670
-  - uid: 86
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,2.5
-      parent: 670
-  - uid: 87
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,3.5
-      parent: 670
-  - uid: 118
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,1.5
-      parent: 670
-  - uid: 119
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,2.5
-      parent: 670
-  - uid: 176
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,1.5
-      parent: 670
-  - uid: 178
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,3.5
-      parent: 670
-  - uid: 179
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,1.5
-      parent: 670
-  - uid: 243
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,11.5
-      parent: 670
-  - uid: 306
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,3.5
-      parent: 670
-  - uid: 362
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,2.5
-      parent: 670
-  - uid: 389
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,3.5
-      parent: 670
-  - uid: 393
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,2.5
-      parent: 670
-- proto: Wrench
   entities:
   - uid: 639
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,6.5
+      parent: 1
+- proto: WindoorSecureMedicalLocked
+  entities:
+  - uid: 640
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,10.5
+      parent: 1
+- proto: WindoorSecureSecurityLocked
+  entities:
+  - uid: 641
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-4.5
+      parent: 1
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
+    - type: Door
+      secondsUntilStateChange: -376.54178
+      state: Opening
+    - type: Airlock
+      autoClose: False
+- proto: WindowFrostedDirectional
+  entities:
+  - uid: 642
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 643
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,6.5
+      parent: 1
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 644
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 645
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 646
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 647
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 648
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 649
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 650
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 651
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 652
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 653
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 654
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,11.5
+      parent: 1
+  - uid: 655
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 656
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 657
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 658
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+- proto: Wrench
+  entities:
+  - uid: 659
+    components:
+    - type: Transform
       pos: -2.50018,-9.2833805
-      parent: 670
+      parent: 1
 ...


### PR DESCRIPTION

## Про ПР
1.Змінив радіус підключення силосу з 40 до 10000, щоб не виникало проблем з цим і щоб не треба було через АА міняти його, щоб він лінкувався по всій станції.
2.Замінив чорно-фіолетові тайли еваку Багель на нормально відображаючіся чорні тайли [(Пост щчура про це в До-фіксу)
](https://discord.com/channels/1158407971936677960/1526446235957989396/1526446235957989396)
## Чому / Баланс
<!-- Опишіть як це змінить ігровий баланс, або поясніть чому ці зміни були внесені. Відмітьте усі пов'язані діалоги або проблеми. -->

## Вимоги
- [X] Я прочитав та дотримуюсь [Правил запитів на злиття та журналу змін](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Цей запит на злиття не потребує медіа.
<!-- На цей раз було лінь писати тут якусь смішнявку тому все по шаблону -->

**Чейнджлог**

:cl:
- tweak: Змінено радіус силосу - 40 ->10000.
- fix: Відсутня текстурка тайлу на еваці Багелі замінена.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Значно збільшено максимальну дальність роботи силосу руди.

* **Оновлення карт**
  * Оновлено карту аварійного шатла «Локс»: змінено декоративне оформлення, кольори та розташування елементів.
  * Додано чорне покриття шатла та скориговано попереджувальні позначки.

* **Покращення**
  * Налаштовано склад атмосфери й параметри руху шатла для більш узгодженої поведінки під час польоту, гальмування та стоянки.
  * Оновлено розміщення та структуру об’єктів карти для сумісності з актуальними налаштуваннями.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->