### PR TITLE
Виправлення клинків, пілонів, конструктів і рун культу

### DIFF
--- a/Content.Pirate.Server/BloodCult/EntitySystems/BloodCultConstructSystem.cs
+++ b/Content.Pirate.Server/BloodCult/EntitySystems/BloodCultConstructSystem.cs
@@ -34,7 +34,6 @@ using Robust.Shared.Map;
 using Content.Shared.NPC.Systems;
 using Content.Shared.NPC.Components;
 using Content.Server.GameTicking.Rules;
-using Content.Shared.Actions;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
@@ -60,22 +59,11 @@ public sealed partial class BloodCultConstructSystem : EntitySystem
 	[Dependency] private readonly IRobustRandom _random = default!;
 	[Dependency] private readonly SharedTransformSystem _transform = default!;
 	[Dependency] private readonly NpcFactionSystem _npcFaction = default!;
-	[Dependency] private readonly SharedActionsSystem _actions = default!;
 	[Dependency] private readonly SharedMeleeWeaponSystem _melee = default!;
 	[Dependency] private readonly UserInterfaceSystem _ui = default!;
 	[Dependency] private readonly IPrototypeManager _prototype = default!;
 
 	private readonly Dictionary<EntityUid, PendingConstructSource> _pendingConstructs = new();
-
-	/// <summary>
-	/// Grants the Commune action to a juggernaut
-	/// </summary>
-	private void GrantCommuneAction(EntityUid juggernaut)
-	{
-		EntityUid? communeAction = null;
-		_actions.AddAction(juggernaut, ref communeAction, "ActionCultistCommune");
-	}
-
 
 	public override void Initialize()
 	{
@@ -215,9 +203,6 @@ public sealed partial class BloodCultConstructSystem : EntitySystem
 		}
 		_npcFaction.AddFaction(juggernaut, BloodCultRuleSystem.BloodCultistFactionId);
 		
-		// Grant Commune ability to juggernaut
-		GrantCommuneAction(juggernaut);
-		
 		// Play transformation audio
 		_audio.PlayPvs(new SoundPathSpecifier("/Audio/Magic/blink.ogg"), shellTransform.Coordinates);
 		
@@ -244,9 +229,6 @@ public sealed partial class BloodCultConstructSystem : EntitySystem
 
 		// Reactivate the juggernaut.
 		juggComp.IsInactive = false;
-
-		// Grant Commune ability to juggernaut if not already granted
-		GrantCommuneAction(juggernaut);
 
 		// DON'T heal the juggernaut - it stays in critical state until healed with blood
 
@@ -361,9 +343,6 @@ public sealed partial class BloodCultConstructSystem : EntitySystem
 			_npcFaction.ClearFactions((juggernaut, npcFaction), false);
 		}
 		_npcFaction.AddFaction(juggernaut, BloodCultRuleSystem.BloodCultistFactionId);
-		
-		// Grant Commune ability to juggernaut
-		GrantCommuneAction(juggernaut);
 		
 		// Play transformation audio
 		_audio.PlayPvs(new SoundPathSpecifier("/Audio/Magic/blink.ogg"), shellTransform.Coordinates);
@@ -650,9 +629,6 @@ public sealed partial class BloodCultConstructSystem : EntitySystem
 
 		// Reactivate the juggernaut.
 		juggComp.IsInactive = false;
-
-		// Grant Commune ability to juggernaut if not already granted
-		GrantCommuneAction(juggernaut);
 
 		// DON'T heal the juggernaut - it stays in critical state until healed with blood
 

--- a/Content.Pirate.Server/BloodCult/EntitySystems/BloodCultRuneCarverSystem.cs
+++ b/Content.Pirate.Server/BloodCult/EntitySystems/BloodCultRuneCarverSystem.cs
@@ -28,6 +28,9 @@ using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.DoAfter;
 using Content.Shared.Hands;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Item;
+using Content.Shared.Kitchen.Components;
 //using Content.Shared.Transform;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
@@ -50,6 +53,7 @@ public sealed partial class BloodCultRuneCarverSystem : EntitySystem
 
 	[Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
 	[Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+	[Dependency] private readonly SharedHandsSystem _hands = default!;
 	[Dependency] private readonly SharedTransformSystem _transform = default!;
 	[Dependency] private readonly MapSystem _mapSystem = default!;
 	[Dependency] private readonly IMapManager _mapManager = default!;
@@ -66,14 +70,12 @@ public sealed partial class BloodCultRuneCarverSystem : EntitySystem
 	{
 		base.Initialize();
 
-		SubscribeLocalEvent<BloodCultRuneCarverComponent, MapInitEvent>(OnMapInit);
-
 		SubscribeLocalEvent<BloodCultRuneCarverComponent, AfterInteractEvent>(OnTryDrawRune);
 		SubscribeLocalEvent<DamageableComponent, DrawRuneDoAfterEvent>(OnRuneDoAfter);
 		SubscribeLocalEvent<BloodCultRuneCarverComponent, UseInHandEvent>(OnUseInHand, before: new[] { typeof(ActivatableUISystem) });
 		//SubscribeLocalEvent<HereticRitualRuneComponent, InteractHandEvent>(OnInteract);
 
-		SubscribeLocalEvent<BloodCultRuneCarverComponent, GetVerbsEvent<InteractionVerb>>(OnVerb);
+		SubscribeLocalEvent<SharpComponent, GetVerbsEvent<InteractionVerb>>(OnSharpVerb);
 
 		SubscribeLocalEvent<BloodCultRuneCarverComponent, RunesMessage>(OnRuneChosenMessage);
 
@@ -86,48 +88,63 @@ public sealed partial class BloodCultRuneCarverSystem : EntitySystem
 		_runeQuery = GetEntityQuery<BloodCultRuneComponent>();
 	}
 
-	private void OnMapInit(EntityUid uid, BloodCultRuneCarverComponent component, MapInitEvent args)
-	{
-
-	}
-
 	#region UserInterface
-	private void OnVerb(EntityUid uid, BloodCultRuneCarverComponent component, GetVerbsEvent<InteractionVerb> args)
-    {
-        if (!args.CanAccess || !args.CanInteract || component.User != args.User)
-            return;
+	private void OnSharpVerb(EntityUid uid, SharpComponent component, GetVerbsEvent<InteractionVerb> args)
+	{
+		if (!args.CanAccess ||
+			!args.CanInteract ||
+			!HasComp<ItemComponent>(uid) ||
+			!HasComp<BloodCultistComponent>(args.User) ||
+			!_hands.IsHolding(args.User, uid) ||
+			TryComp<BloodCultRuneCarverComponent>(uid, out var existingCarver) && !existingCarver.GrantedBySharp)
+		{
+			return;
+		}
 
-        args.Verbs.Add(new InteractionVerb()
-        {
-            Text = "Example Text",//Loc.GetString("chameleon-component-verb-text"),
-            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/settings.svg.192dpi.png")),
-            Act = () => TryOpenUi(uid, args.User, component)
-        });
-    }
+		args.Verbs.Add(new InteractionVerb
+		{
+			Text = Loc.GetString("cult-rune-select"),
+			Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/cutlery.svg.192dpi.png")),
+			Act = () =>
+			{
+				var carver = EnsureComp<BloodCultRuneCarverComponent>(uid);
+				carver.GrantedBySharp = true;
+				_uiSystem.SetUi(uid, RunesUiKey.Key, new InterfaceData("RunesBoundUserInterface"));
+				TryOpenUi(uid, args.User, carver);
+			},
+		});
+	}
 
 	private void OnRuneChosenMessage(Entity<BloodCultRuneCarverComponent> ent, ref RunesMessage args)
 	{
 		if (!BloodCultRuneCarverComponent.ValidRunes.Contains(args.ProtoId))
 			return;
-		ent.Comp.Rune = args.ProtoId;
-        ent.Comp.InProgress = args.ProtoId + "_drawing";
 
-		// Immediately start drawing the rune under the user
 		var user = args.Actor;
-		if (user == EntityUid.Invalid || !TryComp<BloodCultistComponent>(user, out var cultist))
+		if (user == EntityUid.Invalid ||
+			!TryComp<BloodCultistComponent>(user, out var cultist) ||
+			!_hands.IsHolding(user, ent.Owner))
+		{
 			return;
+		}
 
-		// Get the user's position
+		ent.Comp.Rune = args.ProtoId;
+		ent.Comp.InProgress = args.ProtoId + "_drawing";
+
 		var userCoords = Transform(user).Coordinates;
-		
-		// Start drawing the rune at the user's location
 		StartDrawingRuneAtLocation(ent, user, userCoords, cultist);
-    }
+	}
 
 	private void TryOpenUi(EntityUid uid, EntityUid user, BloodCultRuneCarverComponent? component = null)
 	{
-		if (!HasComp<BloodCultistComponent>(user) || !Resolve(uid, ref component) || !TryComp(user, out ActorComponent? actor))
+		if (!HasComp<BloodCultistComponent>(user) ||
+			!_hands.IsHolding(user, uid) ||
+			!Resolve(uid, ref component) ||
+			!TryComp(user, out ActorComponent? actor))
+		{
 			return;
+		}
+
 		// Use OpenUi instead of TryToggleUi to ensure the menu always opens (doesn't close if already open)
 		_uiSystem.OpenUi(uid, RunesUiKey.Key, actor.PlayerSession);
 	}
@@ -143,7 +160,7 @@ public sealed partial class BloodCultRuneCarverSystem : EntitySystem
 	#endregion
 
 	private void OnTryDrawRune(Entity<BloodCultRuneCarverComponent> ent, ref AfterInteractEvent args)
-    {
+	{
 		// First, make sure this is a valid use at all.
 		if (args.Handled
 			|| !args.CanReach
@@ -151,150 +168,55 @@ public sealed partial class BloodCultRuneCarverSystem : EntitySystem
 			|| !TryComp<BloodCultistComponent>(args.User, out var cultist) // ensure user is cultist
 			|| HasComp<ActiveDoAfterComponent>(args.User)
 			|| args.Target == null)
+		{
 			return;
-		args.Handled = true;
+		}
 
 		var target = (EntityUid) args.Target;
 
-		// Second, if clicking on a rune, trigger its normal interaction (same as clicking with open hand)
+		// Second, if clicking on a rune, trigger its normal interaction (same as clicking with open hand).
 		if (_runeQuery.HasComponent(target))
-        {
+		{
+			args.Handled = true;
 			if (TryRemoveRuneWithBlade(ent, args.User, target))
-			{
-				args.Handled = true;
 				return;
+
+			var interactHandEvent = new InteractHandEvent(args.User, target);
+			RaiseLocalEvent(target, interactHandEvent, true);
+
+			// If the hand interaction didn't handle it, also try activation (for TriggerOnActivate components).
+			if (!interactHandEvent.Handled)
+			{
+				_interaction.InteractionActivate(
+					args.User,
+					target,
+					checkCanInteract: false,
+					checkUseDelay: true,
+					checkAccess: false,
+					complexInteractions: true,
+					checkDeletion: false);
 			}
 
-            // Raise InteractHandEvent to simulate clicking with an open hand
-            var interactHandEvent = new InteractHandEvent(args.User, target);
-            RaiseLocalEvent(target, interactHandEvent, true);
-            
-            // If the hand interaction didn't handle it, also try activation (for TriggerOnActivate components)
-            if (!interactHandEvent.Handled)
-            {
-                _interaction.InteractionActivate(
-                    args.User,
-                    target,
-                    checkCanInteract: false,
-                    checkUseDelay: true,
-                    checkAccess: false,
-                    complexInteractions: true,
-                    checkDeletion: false
-                );
-            }
-            
-            args.Handled = true;
-            return;
-        }
-
-		// Third, if clicking on yourself, open the selection UI or start drawing if rune is selected
-		if (args.User == target)
-		{
-			// If a rune is already selected, start drawing it under the user
-			if (!string.IsNullOrEmpty(ent.Comp.Rune))
-			{
-				var userCoords = Transform(args.User).Coordinates;
-				StartDrawingRuneAtLocation(ent, args.User, userCoords, cultist);
-				return;
-			}
-
-			// Otherwise, open the rune selection menu
-			TryOpenUi(ent, args.User, ent.Comp);
 			return;
 		}
 
-		// Fourth, verify that a new rune can be placed here.
-		if (args.User != target
-			|| !args.ClickLocation.IsValid(EntityManager)
-			|| !CanPlaceRuneAt(args.ClickLocation, out var location))
+		// Other interactions should retain the sharp item's normal behavior.
+		if (args.User != target)
+			return;
+
+		args.Handled = true;
+
+		// If a rune is already selected, start drawing it under the user.
+		if (!string.IsNullOrEmpty(ent.Comp.Rune))
 		{
-			// Clear rune selection on failure
-			ent.Comp.Rune = "";
-			ent.Comp.InProgress = "";
+			var userCoords = Transform(args.User).Coordinates;
+			StartDrawingRuneAtLocation(ent, args.User, userCoords, cultist);
 			return;
 		}
 
-		var timeToCarve = ent.Comp.TimeToCarve;
-
-		// Third and a half, if this is a TearVeilRune, do a special location check.
-		if (ent.Comp.Rune == "TearVeilRune")
-		{
-			if (!TryGetValidVeilLocation(args.ClickLocation, out var locationForSummon))
-			{
-				_popupSystem.PopupEntity(
-					Loc.GetString("cult-veil-drawing-toostrong"),
-					args.User, args.User, PopupType.MediumCaution
-				);
-				// Clear rune selection on failure
-				ent.Comp.Rune = "";
-				ent.Comp.InProgress = "";
-				return;
-			}
-
-			cultist.LocationForSummon = locationForSummon;
-
-			// Allow multiple tear veil runes to exist (one per location)
-			// Check if a rune already exists at THIS specific location
-			var summonRunes = AllEntityQuery<TearVeilComponent, BloodCultRuneComponent, TransformComponent>();
-			while (summonRunes.MoveNext(out var existingRuneUid, out _, out var _, out var runeXform))
-			{
-				// Check if this existing rune is in range of the current location we're trying to draw at
-				if (_transform.InRange(runeXform.Coordinates, locationForSummon.Coordinates, locationForSummon.ValidRadius))
-				{
-					_popupSystem.PopupEntity(
-						Loc.GetString("cult-veil-drawing-alreadyexists-location", ("name", locationForSummon.Name)),
-						args.User, args.User, PopupType.MediumCaution
-					);
-					// Clear rune selection on failure
-					ent.Comp.Rune = "";
-					ent.Comp.InProgress = "";
-					return;
-				}
-			}
-
-			timeToCarve = 45.0f;
-		}
-
-		// Fourth, spawn the drawing rune directly
-		EntityUid? drawingRune = null;
-		if (TryGetRuneDrawingPrototype(ent.Comp.Rune, out var drawingPrototype))
-		{
-			drawingRune = Spawn(drawingPrototype, location);
-			// Anchor the drawing rune if we're on a grid
-			var gridUid = _transform.GetGrid(location);
-			if (gridUid != null && TryComp<MapGridComponent>(gridUid, out var grid))
-			{
-				var targetTile = _mapSystem.GetTileRef(gridUid.Value, grid, location);
-				var drawingRuneTransform = Transform(drawingRune.Value);
-				_transform.AnchorEntity((drawingRune.Value, drawingRuneTransform), ((EntityUid)gridUid, grid), targetTile.GridIndices);
-			}
-		}
-
-		var dargs = new DoAfterArgs(EntityManager, args.User, timeToCarve, new DrawRuneDoAfterEvent(
-			ent, drawingRune ?? EntityUid.Invalid, location, ent.Comp.Rune, ent.Comp.BleedOnCarve, ent.Comp.CarveSound, null, TimeSpan.Zero), args.User
-		)
-        {
-            BreakOnDamage = true,
-            BreakOnHandChange = true,
-            BreakOnMove = true,
-			BreakOnDropItem = true,
-            CancelDuplicate = false,
-        };
-
-		if (_protoMan.TryIndex(ent.Comp.Rune, out var ritualPrototype))
-			_popupSystem.PopupEntity(
-				Loc.GetString("cult-rune-drawing-vowel-first") +
-				("aeiou".Contains(ritualPrototype.Name.ToLower()[0]) ? "n" : "") +
-				" " + ritualPrototype.Name + " " + Loc.GetString("cult-rune-drawing-vowel-second"),
-				args.User, args.User, PopupType.MediumCaution
-			);
-		else
-			_popupSystem.PopupEntity(
-				Loc.GetString("cult-rune-drawing-novowel"),
-				args.User, args.User, PopupType.MediumCaution
-			);
-		_doAfter.TryStartDoAfter(dargs);
-    }
+		// Otherwise, open the rune selection menu.
+		TryOpenUi(ent, args.User, ent.Comp);
+	}
 
 	private bool TryRemoveRuneWithBlade(Entity<BloodCultRuneCarverComponent> ent, EntityUid user, EntityUid target)
 	{
@@ -555,7 +477,7 @@ public sealed partial class BloodCultRuneCarverSystem : EntitySystem
 
 	private void OnUseInHand(Entity<BloodCultRuneCarverComponent> ent, ref UseInHandEvent ev)
 	{
-		if (!TryComp<BloodCultistComponent>(ev.User, out var cultist))
+		if (ent.Comp.GrantedBySharp || !TryComp<BloodCultistComponent>(ev.User, out var cultist))
 			return;
 
 		ev.Handled = true;
@@ -574,16 +496,16 @@ public sealed partial class BloodCultRuneCarverSystem : EntitySystem
 
 	private void OnEquipped(EntityUid uid, BloodCultRuneCarverComponent component, GotEquippedHandEvent args)
 	{
-		if (!HasComp<BloodCultistComponent>(args.User))
-		{
-			QueueDel(uid);
+		if (component.GrantedBySharp || HasComp<BloodCultistComponent>(args.User))
+			return;
+
+		QueueDel(uid);
 		Spawn("Ash", Transform(args.User).Coordinates);
 		_popupSystem.PopupEntity(
 			Loc.GetString("cult-dagger-equip-fail"),
 			args.User, args.User, PopupType.SmallCaution
 		);
 		_audioSystem.PlayPvs(new SoundPathSpecifier("/Audio/Effects/lightburn.ogg"), Transform(args.User).Coordinates);
-		}
 	}
 
 	private bool CanPlaceRuneAt(EntityCoordinates clickedAt, out EntityCoordinates location)

--- a/Content.Pirate.Server/BloodCult/EntitySystems/BloodCultistSystem.cs
+++ b/Content.Pirate.Server/BloodCult/EntitySystems/BloodCultistSystem.cs
@@ -31,12 +31,11 @@ public sealed class BloodCultistSystem : SharedBloodCultistSystem
 		if (communeEntity == null)
 			return;
 
-		// Allow both blood cultists and juggernauts to use commune
-		// Check both separately to ensure variables are assigned
+		// Allow both blood cultists and constructs to use commune.
 		bool isCultist = TryComp<BloodCultistComponent>(communeEntity, out var cultistComp);
-		bool isJuggernaut = TryComp<JuggernautComponent>(communeEntity, out var juggernautComp);
+		bool isConstruct = HasComp<BloodCultConstructComponent>(communeEntity.Value);
 		
-		if (!isCultist && !isJuggernaut)
+		if (!isCultist && !isConstruct)
 			return;
 
 		if (!_uiSystem.HasUi(communeEntity.Value, BloodCultistCommuneUIKey.Key))
@@ -49,8 +48,8 @@ public sealed class BloodCultistSystem : SharedBloodCultistSystem
 		{
 			if (isCultist && cultistComp != null)
 				UpdateCommuneUI((communeEntity.Value, cultistComp));
-			else if (isJuggernaut && juggernautComp != null)
-				// Juggernauts use the same UI but with empty state (no stored message)
+			else
+				// Constructs use the same UI but with empty state (no stored message).
 				_uiSystem.SetUiState(communeEntity.Value, BloodCultistCommuneUIKey.Key, new BloodCultCommuneBuiState(""));
 		}
 

--- a/Content.Pirate.Server/BloodCult/EntitySystems/CultHealingSourceSystem.cs
+++ b/Content.Pirate.Server/BloodCult/EntitySystems/CultHealingSourceSystem.cs
@@ -31,6 +31,7 @@ using Content.Server.GameTicking.Rules.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Systems;
+using Content.Shared.Chemistry.EntitySystems;
 using Content.Server.Body.Components;
 using Content.Server.Body.Systems;
 
@@ -57,6 +58,7 @@ public sealed partial class CultHealingSourceSystem : EntitySystem
 	[Dependency] private readonly MobStateSystem _mobState = default!;
 	[Dependency] private readonly SharedBodySystem _bodySystem = default!;
 	[Dependency] private readonly BloodstreamSystem _bloodstreamSystem = default!;
+	[Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
 
 	/// <summary>
 	/// 	Subscribe to the cult healing system's server CCVars.
@@ -421,7 +423,11 @@ public sealed partial class CultHealingSourceSystem : EntitySystem
 					var bloodRecovery = (bloodMaxVolume / 240.0f) * time;
 					
 					// Restore blood
-					_bloodstreamSystem.TryModifyBloodLevel((uid, bloodstream), bloodRecovery);
+					if (_bloodstreamSystem.TryModifyBloodLevel((uid, bloodstream), bloodRecovery) &&
+						bloodstream.BloodSolution is { } bloodSolution)
+					{
+						_solutionContainer.UpdateChemicals(bloodSolution, false);
+					}
 				}
 			}
 		}

--- a/Content.Pirate.Server/BloodCult/EntitySystems/CultistSpellSystem.cs
+++ b/Content.Pirate.Server/BloodCult/EntitySystems/CultistSpellSystem.cs
@@ -104,7 +104,7 @@ public sealed partial class CultistSpellSystem : EntitySystem
 
 		SubscribeLocalEvent<BloodCultistComponent, EventCultistStudyVeil>(OnStudyVeil);
 		SubscribeLocalEvent<BloodCultistComponent, BloodCultCommuneSendMessage>(OnCommune);
-		SubscribeLocalEvent<JuggernautComponent, BloodCultCommuneSendMessage>(OnJuggernautCommune);
+		SubscribeLocalEvent<BloodCultConstructComponent, BloodCultCommuneSendMessage>(OnConstructCommune);
 		SubscribeLocalEvent<BloodCultistComponent, EventCultistSanguineDream>(OnSanguineDream);
 		//SubscribeLocalEvent<CultMarkedComponent, AttackedEvent>(OnMarkedAttacked);
 
@@ -321,7 +321,7 @@ public sealed partial class CultistSpellSystem : EntitySystem
 		ent.Comp.CommuningMessage = args.Message;
 	}
 
-	private void OnJuggernautCommune(Entity<JuggernautComponent> ent, ref BloodCultCommuneSendMessage args)
+	private void OnConstructCommune(Entity<BloodCultConstructComponent> ent, ref BloodCultCommuneSendMessage args)
 	{
 		// Source-level fall-through: if this entity also holds BloodCultistComponent, the
 		// cultist handler already stamped the message and the rule's Update loop will

--- a/Content.Pirate.Server/GameTicking/Rules/BloodCultRuleSystem.cs
+++ b/Content.Pirate.Server/GameTicking/Rules/BloodCultRuleSystem.cs
@@ -525,13 +525,13 @@ public sealed class BloodCultRuleSystem : GameRuleSystem<BloodCultRuleComponent>
 			// Drain the message into a local first so the slot is cleared BEFORE we dispatch.
 			// If anything inside DistributeCommune fails (precondition, cooldown, etc.) we
 			// must NOT leave the message stamped, otherwise the next Update tick would
-			// fire it again. Also clear any twin slot on JuggernautComponent so an entity
+			// fire it again. Also clear any twin slot on BloodCultConstructComponent so an entity
 			// holding both components can never queue two chants for one commune action.
 			if (cultist.CommuningMessage != null)
 			{
 				var pending = cultist.CommuningMessage;
 				cultist.CommuningMessage = null;
-				if (TryComp<JuggernautComponent>(cultistUid, out var twin))
+				if (TryComp<BloodCultConstructComponent>(cultistUid, out var twin))
 					twin.CommuningMessage = null;
 
 				DistributeCommune(component, pending, cultistUid);
@@ -600,26 +600,26 @@ public sealed class BloodCultRuleSystem : GameRuleSystem<BloodCultRuleComponent>
 			}
 		}
 
-		// Process juggernaut communes for entities that DON'T also hold BloodCultistComponent.
+		// Process construct communes for entities that DON'T also hold BloodCultistComponent.
 		// Anything that does hold both was already drained in the cultist loop above; the
-		// source-level guard in CultistSpellSystem.OnJuggernautCommune normally prevents
+		// source-level guard in CultistSpellSystem.OnConstructCommune normally prevents
 		// the slot from being stamped at all, but this is the symmetric defence in case a
 		// future caller writes to it directly.
-		var juggernauts = AllEntityQuery<JuggernautComponent>();
-		while (juggernauts.MoveNext(out var juggernautUid, out var juggernaut))
+		var constructs = AllEntityQuery<BloodCultConstructComponent>();
+		while (constructs.MoveNext(out var constructUid, out var construct))
 		{
-			if (juggernaut.CommuningMessage == null)
+			if (construct.CommuningMessage == null)
 				continue;
 
-			if (HasComp<BloodCultistComponent>(juggernautUid))
+			if (HasComp<BloodCultistComponent>(constructUid))
 			{
-				juggernaut.CommuningMessage = null;
+				construct.CommuningMessage = null;
 				continue;
 			}
 
-			var pending = juggernaut.CommuningMessage;
-			juggernaut.CommuningMessage = null;
-			DistributeCommune(component, pending, juggernautUid);
+			var pending = construct.CommuningMessage;
+			construct.CommuningMessage = null;
+			DistributeCommune(component, pending, constructUid);
 		}
 
 		// End the round
@@ -1056,7 +1056,7 @@ public sealed class BloodCultRuleSystem : GameRuleSystem<BloodCultRuleComponent>
 		if (TerminatingOrDeleted(uid))
 			return false;
 
-		if (!HasComp<BloodCultistComponent>(uid) && !HasComp<JuggernautComponent>(uid))
+		if (!HasComp<BloodCultistComponent>(uid) && !HasComp<BloodCultConstructComponent>(uid))
 			return false;
 
 		if (_mobSystem.IsDead(uid))
@@ -1083,11 +1083,11 @@ public sealed class BloodCultRuleSystem : GameRuleSystem<BloodCultRuleComponent>
 			return true;
 		}
 
-		if (TryComp<JuggernautComponent>(uid, out var jugger))
+		if (TryComp<BloodCultConstructComponent>(uid, out var construct))
 		{
-			if (now < jugger.NextChantTime)
+			if (now < construct.NextChantTime)
 				return false;
-			jugger.NextChantTime = now + ChantCooldown;
+			construct.NextChantTime = now + ChantCooldown;
 			return true;
 		}
 
@@ -1540,7 +1540,7 @@ public sealed class BloodCultRuleSystem : GameRuleSystem<BloodCultRuleComponent>
 	///   5. <see cref="TryConsumeChantCooldown"/>: claim the per-entity cooldown slot.
 	///        If this fails, we treat the commune as already-handled and bail out
 	///        WITHOUT either chanting or re-broadcasting, so a duplicate dispatch
-	///        (e.g. an entity holding both BloodCultistComponent and JuggernautComponent
+	///        (e.g. an entity holding both BloodCultistComponent and BloodCultConstructComponent
 	///        whose drain in Update wasn't atomic for some reason) collapses to one.
 	///   6. Build the chant variant for this sender (juggernaut accent vs random word).
 	///   7. Whisper the chant, then announce the typed message to the cult.

--- a/Content.Pirate.Shared/BloodCult/Components/BloodCultConstructComponent.cs
+++ b/Content.Pirate.Shared/BloodCult/Components/BloodCultConstructComponent.cs
@@ -31,6 +31,18 @@ public sealed partial class BloodCultConstructComponent : Component
 	/// </summary>
 	[DataField]
 	public bool EjectSourceOnCritical;
+
+	/// <summary>
+	/// Message waiting to be sent through the cult commune.
+	/// </summary>
+	[DataField]
+	public string? CommuningMessage;
+
+	/// <summary>
+	/// Earliest time at which this construct may be forced to chant again.
+	/// </summary>
+	[DataField]
+	public TimeSpan NextChantTime = TimeSpan.Zero;
 }
 
 public enum BloodCultConstructSourceKind : byte

--- a/Content.Pirate.Shared/BloodCult/Components/BloodCultRuneCarverComponent.cs
+++ b/Content.Pirate.Shared/BloodCult/Components/BloodCultRuneCarverComponent.cs
@@ -49,10 +49,10 @@ public sealed partial class BloodCultRuneCarverComponent : Component
     [DataField] public SoundSpecifier CarveSound = new SoundCollectionSpecifier("gib");
 
 	/// <summary>
-	/// 	Current user using the knife
+	/// Whether this component was granted to an ordinary sharp item at runtime.
 	/// </summary>
 	[ViewVariables]
-	public EntityUid? User;
+	public bool GrantedBySharp;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Pirate.Shared/BloodCult/Components/JuggernautComponent.cs
+++ b/Content.Pirate.Shared/BloodCult/Components/JuggernautComponent.cs
@@ -21,18 +21,4 @@ public sealed partial class JuggernautComponent : Component
 	/// </summary>
 	[DataField, AutoNetworkedField]
 	public bool IsInactive;
-
-	/// <summary>
-	/// Message stored for commune
-	/// </summary>
-	[DataField]
-	public string? CommuningMessage = null;
-
-	/// <summary>
-	/// Earliest time at which this juggernaut may be forced to chant again.
-	/// Mirrors the guard on <see cref="BloodCultistComponent"/> so juggernaut entities
-	/// that don't also hold a cultist component still get the same per-step fall-through.
-	/// </summary>
-	[DataField]
-	public TimeSpan NextChantTime = TimeSpan.Zero;
 }

--- a/Content.Server/Chemistry/Components/BaseSolutionInjectOnEventComponent.cs
+++ b/Content.Server/Chemistry/Components/BaseSolutionInjectOnEventComponent.cs
@@ -3,6 +3,7 @@
 using Content.Shared.Damage; // Goobstation - Armor resisting syringe gun
 using Content.Goobstation.Maths.FixedPoint;
 using Content.Shared.Inventory;
+using Content.Shared.Whitelist; // Pirate
 
 namespace Content.Server.Chemistry.Components;
 
@@ -67,6 +68,12 @@ public abstract partial class BaseSolutionInjectOnEventComponent : Component
     /// </summary>
     [DataField]
     public SlotFlags BlockSlots = SlotFlags.NONE;
+
+    /// <summary>
+    /// Entities matching this blacklist are not injected.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? TargetBlacklist; // Pirate
 
     // <Goobstation>
     /// <summary>

--- a/Content.Server/Chemistry/Components/SolutionInjectOnProjectileHitComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionInjectOnProjectileHitComponent.cs
@@ -5,6 +5,8 @@ namespace Content.Server.Chemistry.Components;
 /// <summary>
 /// Used for projectile entities that should try to inject a
 /// contained solution into a target when they hit it.
+/// Targets can be excluded through <see cref="BaseSolutionInjectOnEventComponent.TargetBlacklist"/>.
 /// </summary>
+// Pirate - target blacklist support.
 [RegisterComponent]
 public sealed partial class SolutionInjectOnProjectileHitComponent : BaseSolutionInjectOnEventComponent { }

--- a/Content.Server/Chemistry/EntitySystems/SolutionInjectOnEventSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionInjectOnEventSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.Popups;
 using Content.Shared.Projectiles;
 using Content.Shared.Tag;
 using Content.Shared.Throwing;
+using Content.Shared.Whitelist; // Pirate
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Collections;
 using Robust.Shared.Prototypes;
@@ -31,6 +32,7 @@ public sealed class SolutionInjectOnCollideSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
     [Dependency] private readonly TagSystem _tag = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!; // Pirate
 
     [Dependency] private readonly IGameTiming _timing = default!; // Goobstation
 
@@ -158,6 +160,7 @@ public sealed class SolutionInjectOnCollideSystem : EntitySystem
     ///     <item>The target does not have a bloodstream.</item>
     ///     <item><see cref="BaseSolutionInjectOnEventComponent.PierceArmor"/> is false and the target is wearing a hardsuit.</item>
     ///     <item><see cref="BaseSolutionInjectOnEventComponent.BlockSlots"/> is not NONE and the target has an item equipped in any of the specified slots.</item>
+    ///     <item>The target matches <see cref="BaseSolutionInjectOnEventComponent.TargetBlacklist"/>.</item>
     /// </list>
     /// </remarks>
     /// <returns>true if at least one target was successfully injected, otherwise false</returns>
@@ -176,6 +179,10 @@ public sealed class SolutionInjectOnCollideSystem : EntitySystem
         foreach (var target in targets)
         {
             if (Deleted(target))
+                continue;
+
+            // Pirate - allow injectors to protect specific targets from their chemical payload.
+            if (_whitelist.IsWhitelistPass(injector.Comp.TargetBlacklist, target))
                 continue;
 
             // Goobstation - Armor resisting syringe gun

--- a/Resources/Prototypes/_Pirate/BloodCult/Entities/Objects/dagger.yml
+++ b/Resources/Prototypes/_Pirate/BloodCult/Entities/Objects/dagger.yml
@@ -67,10 +67,18 @@
     transferAmount: 3
     solution: melee
     pierceArmor: true
+    targetBlacklist:
+      components:
+      - BloodCultist
+      - BloodCultConstruct
   - type: SolutionInjectOnProjectileHit
     transferAmount: 3
     solution: melee
     pierceArmor: true
+    targetBlacklist:
+      components:
+      - BloodCultist
+      - BloodCultConstruct
   - type: RefillableSolution
     solution: melee
   - type: InjectableSolution

--- a/Resources/Prototypes/_Pirate/BloodCult/Mobs/constructs.yml
+++ b/Resources/Prototypes/_Pirate/BloodCult/Mobs/constructs.yml
@@ -102,6 +102,9 @@
         Extinguish: [ Touch ]
     - type: MindContainer
     - type: Juggernaut
+    - type: ActionGrant
+      actions:
+      - ActionCultistCommune
     - type: ContainerContainer
       containers:
         juggernaut_body_container: !type:ContainerSlot
@@ -231,6 +234,9 @@
       maxBleedAmount: 0
     - type: MindContainer
     - type: Shade
+    - type: ActionGrant
+      actions:
+      - ActionCultistCommune
     - type: Physics
     - type: InputMover
     - type: MobMover
@@ -299,6 +305,15 @@
       color: "#50595C"
       activateSound: null
       deactivateSound: null
+    - type: IntrinsicUI
+      uis:
+        enum.BloodCultistCommuneUIKey.Key:
+          toggleAction: null
+    - type: UserInterface
+      interfaces:
+        enum.BloodCultistCommuneUIKey.Key:
+          type: BloodCultCommuneBoundUserInterface
+          requireInputValidation: false
     - type: GuideHelp
       guides:
       - BloodCult
@@ -385,6 +400,15 @@
     color: "#50595C"
     activateSound: null
     deactivateSound: null
+  - type: IntrinsicUI
+    uis:
+      enum.BloodCultistCommuneUIKey.Key:
+        toggleAction: null
+  - type: UserInterface
+    interfaces:
+      enum.BloodCultistCommuneUIKey.Key:
+        type: BloodCultCommuneBoundUserInterface
+        requireInputValidation: false
   - type: IsDeadIC
   - type: GuideHelp
     guides:
@@ -411,6 +435,7 @@
         Structural: 60
   - type: ActionGrant
     actions:
+    - ActionCultistCommune
     - ActionBloodCultSummonFloor
     - ActionBloodCultSummonWall
     - ActionBloodCultSummonDoor
@@ -443,4 +468,5 @@
     - PhaseShifted
   - type: ActionGrant
     actions:
+    - ActionCultistCommune
     - ActionBloodCultPhaseShift


### PR DESCRIPTION
Виправлено дружній вогонь клинків, синхронізацію лікування пілоном, спілкування конструктів і розширено інструменти для малювання рун.

:cl:
- fix: Клинки культу більше не отруюють союзних культистів і конструктів.
- fix: Відновлення крові пілоном культу коректно синхронізується з клієнтом.
- fix: Конструкти культу тепер мають дію спілкування з культом.
- tweak: Культисти можуть малювати руни будь-яким гострим предметом.