### PR TITLE
Виправити втечу гост-ролей із перетягування

### DIFF
--- a/Content.Goobstation.Shared/GrabIntent/GrabIntentSystem.cs
+++ b/Content.Goobstation.Shared/GrabIntent/GrabIntentSystem.cs
@@ -64,7 +64,8 @@ public sealed partial class GrabIntentSystem : EntitySystem
 
     private void InitializeCoreEvents()
     {
-        SubscribeLocalEvent<GrabbableComponent, MoveInputEvent>(OnPullableMoveInput);
+        // Pirate: ordinary pull escape lives in PullingSystem.
+        SubscribeLocalEvent<GrabbableComponent, MoveInputEvent>(OnSoftGrabMoveInput);
         SubscribeLocalEvent<GrabbableComponent, CheckGrabbedEvent>(OnCheckGrabbed);
         SubscribeLocalEvent<GrabbableComponent, GrabAttemptEvent>(OnGrabAttempt);
         SubscribeLocalEvent<GrabbableComponent, PullStoppedMessage>(OnPullStoppedGrabbable);
@@ -123,18 +124,17 @@ public sealed partial class GrabIntentSystem : EntitySystem
             args.EscapeAttemptModifier);
     }
 
-    private void OnPullableMoveInput(EntityUid uid, GrabbableComponent component, ref MoveInputEvent args)
+    private void OnSoftGrabMoveInput(Entity<GrabbableComponent> ent, ref MoveInputEvent args)
     {
-        if (!TryComp<PullableComponent>(uid, out var pullable) || !pullable.BeingPulled)
+        if (ent.Comp.GrabStage != GrabStage.Soft
+            || !TryComp<PullableComponent>(ent, out var pullable)
+            || !pullable.BeingPulled
+            || !_blocker.CanInteract(ent, null))
+        {
             return;
+        }
 
-        if (component.GrabStage == GrabStage.Soft && _blocker.CanInteract(uid, null))
-            _pulling.TryStopPull(uid, pullable, uid);
-
-        if (!_blocker.CanMove(args.Entity))
-            return;
-
-        _pulling.TryStopPull(uid, pullable, user: uid);
+        _pulling.TryStopPull(ent, pullable, ent);
     }
 
     #endregion

--- a/Content.IntegrationTests/Tests/Puller/NonGrabbablePullEscapeTest.cs
+++ b/Content.IntegrationTests/Tests/Puller/NonGrabbablePullEscapeTest.cs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Goobstation.Shared.GrabIntent;
+using Content.IntegrationTests.Tests.Movement;
+using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.Movement.Pulling.Systems;
+using Robust.Shared.Input;
+using Robust.Shared.Maths;
+
+namespace Content.IntegrationTests.Tests.Puller;
+
+[TestFixture]
+public sealed class NonGrabbablePullEscapeTest : MovementTest
+{
+    protected override string PlayerPrototype => "NonGrabbablePullEscapeTestMob";
+
+    [TestPrototypes]
+    private const string Prototypes = """
+        - type: entity
+          id: NonGrabbablePullEscapeTestMob
+          parent: BaseMob
+          components:
+          - type: Pullable
+        """;
+
+    [Test]
+    public async Task MoveInputStopsOrdinaryPull()
+    {
+        var puller = await SpawnEntity("MobHuman", ToServer(TargetCoords));
+        var pulling = SEntMan.System<PullingSystem>();
+        var pullable = Comp<PullableComponent>(Player);
+
+        Assert.That(HasComp<GrabbableComponent>(Player), Is.False);
+
+        await Server.WaitAssertion(() =>
+        {
+            Assert.That(pulling.TryStartPull(puller, SPlayer), Is.True);
+            Assert.That(pullable.Puller, Is.EqualTo(puller));
+        });
+
+        await RunTicks(5);
+        await SetMovementKey(DirectionFlag.West, BoundKeyState.Down);
+        await RunTicks(5);
+        await SetMovementKey(DirectionFlag.West, BoundKeyState.Up);
+        await RunTicks(1);
+
+        Assert.That(pullable.Puller, Is.Null);
+    }
+}

--- a/Content.IntegrationTests/Tests/Puller/NonGrabbablePullEscapeTest.cs
+++ b/Content.IntegrationTests/Tests/Puller/NonGrabbablePullEscapeTest.cs
@@ -2,9 +2,11 @@
 
 using Content.Goobstation.Shared.GrabIntent;
 using Content.IntegrationTests.Tests.Movement;
+using Content.Shared.Input;
+using Content.Shared.Movement.Components;
+using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Components;
-using Content.Shared.Movement.Pulling.Systems;
-using Robust.Shared.Input;
+using Content.Shared.Movement.Systems;
 using Robust.Shared.Maths;
 
 namespace Content.IntegrationTests.Tests.Puller;
@@ -12,8 +14,6 @@ namespace Content.IntegrationTests.Tests.Puller;
 [TestFixture]
 public sealed class NonGrabbablePullEscapeTest : MovementTest
 {
-    protected override string PlayerPrototype => "NonGrabbablePullEscapeTestMob";
-
     [TestPrototypes]
     private const string Prototypes = """
         - type: entity
@@ -26,24 +26,29 @@ public sealed class NonGrabbablePullEscapeTest : MovementTest
     [Test]
     public async Task MoveInputStopsOrdinaryPull()
     {
-        var puller = await SpawnEntity("MobHuman", ToServer(TargetCoords));
-        var pulling = SEntMan.System<PullingSystem>();
-        var pullable = Comp<PullableComponent>(Player);
+        await SpawnTarget("NonGrabbablePullEscapeTestMob");
 
-        Assert.That(HasComp<GrabbableComponent>(Player), Is.False);
+        var puller = Comp<PullerComponent>(Player);
+        var pullable = Comp<PullableComponent>(Target);
+        var target = STarget!.Value;
 
-        await Server.WaitAssertion(() =>
+        Assert.That(HasComp<GrabbableComponent>(Target), Is.False);
+
+        await PressKey(ContentKeyFunctions.TryPullObject);
+        await RunTicks(5);
+
+        Assert.That(puller.Pulling, Is.EqualTo(target));
+        Assert.That(pullable.Puller, Is.EqualTo(SPlayer));
+
+        await Server.WaitPost(() =>
         {
-            Assert.That(pulling.TryStartPull(puller, SPlayer), Is.True);
-            Assert.That(pullable.Puller, Is.EqualTo(puller));
+            var mover = SEntMan.GetComponent<InputMoverComponent>(target);
+            var ev = new MoveInputEvent((target, mover), mover.HeldMoveButtons, Direction.West, true);
+            SEntMan.EventBus.RaiseLocalEvent(target, ref ev);
         });
-
         await RunTicks(5);
-        await SetMovementKey(DirectionFlag.West, BoundKeyState.Down);
-        await RunTicks(5);
-        await SetMovementKey(DirectionFlag.West, BoundKeyState.Up);
-        await RunTicks(1);
 
         Assert.That(pullable.Puller, Is.Null);
+        Assert.That(puller.Pulling, Is.Null);
     }
 }

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -69,6 +69,8 @@ public sealed partial class PullingSystem : EntitySystem // DOWNSTREAM-TPirates:
         UpdatesAfter.Add(typeof(SharedPhysicsSystem));
         UpdatesOutsidePrediction = true;
 
+        // Pirate: restore ordinary pull escape after the Goob grab-intent split.
+        SubscribeLocalEvent<PullableComponent, MoveInputEvent>(OnPullableMoveInput);
         SubscribeLocalEvent<PullableComponent, CollisionChangeEvent>(OnPullableCollisionChange);
         SubscribeLocalEvent<PullableComponent, JointRemovedEvent>(OnJointRemoved);
         SubscribeLocalEvent<PullableComponent, GetVerbsEvent<Verb>>(AddPullVerbs);
@@ -318,6 +320,14 @@ public sealed partial class PullingSystem : EntitySystem // DOWNSTREAM-TPirates:
             };
             args.Verbs.Add(verb);
         }
+    }
+
+    private void OnPullableMoveInput(Entity<PullableComponent> ent, ref MoveInputEvent args)
+    {
+        if (!ent.Comp.BeingPulled || !_blocker.CanMove(args.Entity))
+            return;
+
+        TryStopPull(ent, ent.Comp, ent);
     }
 
     private void OnPullableCollisionChange(EntityUid uid, PullableComponent component, ref CollisionChangeEvent args)


### PR DESCRIPTION
Відновлює звільнення рухом зі звичайного перетягування для сутностей без Grabbable, не змінюючи механіку бойових захватів.

:cl:
- fix: Гост-ролі та фауна знову можуть вирватися зі звичайного перетягування рухом.