### PR TITLE
Fix radiation holobarrier tile alignment

### DIFF
--- a/Resources/Prototypes/_Pirate/Nuclear/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/_Pirate/Nuclear/Entities/Structures/Holographic/projections.yml
@@ -13,6 +13,8 @@
         shape:
           !type:PhysShapeAabb
             bounds: "-0.5,-0.5,0.5,0.5"
+  - type: Transform
+    noRot: true
   - type: Occluder
     enabled: false # Pirate: enabled only while deployed; stored projections are not on a grid.
   - type: RadiationBlocker


### PR DESCRIPTION
Виправлено поворот голографічних радіаційних бар'єрів: тепер вони завжди вирівнюються по тайлах.

:cl:
- fix: Голографічні радіаційні бар'єри тепер коректно вирівнюються по тайлах.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Покращення**
  * Проєкції `HolosignRadiationBlocking` тепер зберігають фіксовану орієнтацію та не обертаються.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->