### PR TITLE
Prevent FPV drones from taking collision damage

### DIFF
--- a/Content.Shared/Damage/Components/DamageOnHighSpeedImpactComponent.cs
+++ b/Content.Shared/Damage/Components/DamageOnHighSpeedImpactComponent.cs
@@ -13,6 +13,9 @@ namespace Content.Shared.Damage.Components;
 [RegisterComponent, NetworkedComponent, Access(typeof(DamageOnHighSpeedImpactSystem))]
 public sealed partial class DamageOnHighSpeedImpactComponent : Component
 {
+    [DataField("enabled"), ViewVariables(VVAccess.ReadWrite)]
+    public bool Enabled = true; // Pirate: Allow FPV drones to opt out of collision damage.
+
     [DataField("minimumSpeed"), ViewVariables(VVAccess.ReadWrite)]
     public float MinimumSpeed = 20f;
 

--- a/Content.Shared/Damage/Systems/DamageOnHighSpeedImpactSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageOnHighSpeedImpactSystem.cs
@@ -29,6 +29,9 @@ public sealed class DamageOnHighSpeedImpactSystem : EntitySystem
 
     private void HandleCollide(EntityUid uid, DamageOnHighSpeedImpactComponent component, ref StartCollideEvent args)
     {
+        if (!component.Enabled) // Pirate: FPV drones retain normal combat damage while ignoring collisions.
+            return;
+
         if (!args.OurFixture.Hard || !args.OtherFixture.Hard)
             return;
 

--- a/Resources/Prototypes/_Pirate/Entities/Objects/Misc/remote_drone.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Objects/Misc/remote_drone.yml
@@ -86,6 +86,7 @@
     sound:
       path: /Audio/_Pirate/Effects/fpv_drone_flyby.ogg
   - type: DamageOnHighSpeedImpact
+    enabled: false # Pirate: FPV drones should not take damage from flying into obstacles.
     damage:
       types:
         Blunt: 40


### PR DESCRIPTION
FPV-дрони більше не отримують шкоду від зіткнень, але досі ламаються від атак.

:cl:
- fix: FPV-дрони більше не ламаються від зіткнень зі стінами та іншими об'єктами.