### PR TITLE
Fix xenoborg construction materials and vision

### DIFF
--- a/Content.Client/UserInterface/Systems/DamageOverlays/DamageOverlayUiController.cs
+++ b/Content.Client/UserInterface/Systems/DamageOverlays/DamageOverlayUiController.cs
@@ -76,6 +76,7 @@ public sealed class DamageOverlayUiController : UIController
 
     private void ClearOverlay()
     {
+        _overlay.State = MobState.Alive; // Pirate: Do not retain critical vision after transferring to a borg.
         _overlay.DeadLevel = 0f;
         _overlay.CritLevel = 0f;
         _overlay.PainLevel = 0f;

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -80,6 +80,7 @@
     - Sheet
     - Metal
     - Steel
+    - ConstructionMaterial # Pirate: Keep steel usable by cyborg construction modules.
 
 - type: entity
   parent: SheetSteel


### PR DESCRIPTION
Виправлено використання сталі будівельним модулем ксеноборга та зависання критичного затемнення після перенесення мозку.

:cl:
- fix: Ксеноборги знову можуть брати сталь і не зберігають критичне затемнення після перенесення мозку.