### PR TITLE
Виправити терагерцовий сканер дронів

### DIFF
--- a/Resources/Prototypes/_Imp/_Drone/Mobs_Player_silicon.yml
+++ b/Resources/Prototypes/_Imp/_Drone/Mobs_Player_silicon.yml
@@ -284,6 +284,10 @@
     range: 3
   - type: InputMover
   - type: MobMover
+  - type: Eye # Pirate - preserve built-in T-ray subfloor vision through ghost role takeover.
+    visMask:
+    - Normal
+    - Subfloor
   - type: ContentEye
     maxZoom: 1.2, 1.2
   - type: Tag


### PR DESCRIPTION
Відновлює відображення кабелів і труб терагерцовим сканером у дронів після захоплення ghost role.

:cl:
- fix: Терагерцовий сканер дронів знову показує кабелі та труби під підлогою.