### PR TITLE
Balance FPV drone survivability

### DIFF
--- a/Resources/Prototypes/_Pirate/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Pirate/Catalog/uplink_catalog.yml
@@ -13,7 +13,6 @@
       blacklist:
         tags:
           - ContractorUplink
-          - NukeOpsUplink
 
 - type: listing
   id: UplinkAdderBundle

--- a/Resources/Prototypes/_Pirate/Entities/Objects/Misc/remote_drone.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Objects/Misc/remote_drone.yml
@@ -171,6 +171,11 @@
     - 0,0,1,1
 
   # Damage
+  - type: Reflect
+    reflectProb: 0.5
+    spread: 270
+    reflects:
+    - NonEnergy
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Metallic
@@ -178,7 +183,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 200
+        damage: 60
       behaviors:
       - !type:EmptyContainersBehaviour
         containers:


### PR DESCRIPTION
Зменшує міцність FPV-дрона до 60, додає 50% шанс рикошету балістичних куль і відкриває набір для аплінків ядерних оперативників.

:cl:
- tweak: FPV-дрони тепер мають 60 міцності та 50% шанс відбити кулю.
- add: Набір FPV-дрона додано до аплінків ядерних оперативників.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Нові можливості**
  - FPV-дрон тепер може відбивати частину отриманих атак із заданою ймовірністю та розсіюванням.

- **Зміни ігрового балансу**
  - Дрон знищується після отримання меншої кількості пошкоджень.
  - Комплект FPV-дрона тепер доступний у каталозі для підрядницького спорядження, але не для ядерних оперативників.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->