### PR TITLE
Швидке відкриття меню хірургії через Alt+ЛКМ

### DIFF
--- a/Content.Shared/_Pirate/Medical/Surgery/SharedSurgerySystem.AltInteract.cs
+++ b/Content.Shared/_Pirate/Medical/Surgery/SharedSurgerySystem.AltInteract.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared._Shitmed.Medical.Surgery.Tools;
+using Content.Shared.CombatMode;
+using Content.Shared.Verbs;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._Shitmed.Medical.Surgery;
+
+public abstract partial class SharedSurgerySystem
+{
+    private const int PirateSurgeryAltInteractPriority = 10;
+
+    private void InitializePirateAltInteract()
+    {
+        SubscribeLocalEvent<SurgeryTargetComponent, GetVerbsEvent<AlternativeVerb>>(OnPirateAlternativeVerb);
+    }
+
+    private void OnPirateAlternativeVerb(Entity<SurgeryTargetComponent> target,
+        ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        var user = args.User;
+        if (!args.CanInteract
+            || !args.CanAccess
+            || args.Using is not { } tool
+            || !TryComp(tool, out SurgeryToolComponent? surgeryTool)
+            || !CanPirateQuickOpenSurgery(user))
+            return;
+
+        args.Verbs.Add(new AlternativeVerb
+        {
+            Act = () => AttemptStartSurgery((tool, surgeryTool), user, target),
+            Icon = new SpriteSpecifier.Texture(new("/Textures/_Shitmed/Interface/Examine/scalpel.png")),
+            Text = Loc.GetString("surgery-verb-text"),
+            Message = Loc.GetString("surgery-verb-message"),
+            Priority = PirateSurgeryAltInteractPriority,
+            DoContactInteraction = true,
+        });
+    }
+
+    private bool CanPirateQuickOpenSurgery(EntityUid user)
+    {
+        return !TryComp(user, out CombatModeComponent? combatMode) || !combatMode.IsInCombatMode;
+    }
+}

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Start.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Start.cs
@@ -19,6 +19,7 @@ public abstract partial class SharedSurgerySystem
         _targetQuery = GetEntityQuery<SurgeryTargetComponent>();
 
         SubscribeLocalEvent<SurgeryToolComponent, GetVerbsEvent<UtilityVerb>>(OnUtilityVerb);
+        InitializePirateAltInteract(); // Pirate - quick-open surgery with Alt+LMB.
 
         // cvar is yes var is no, invert it
         Subs.CVar(_config, SurgeryCVars.CanOperateOnSelf, x => _noSelfOperate = !x, true);
@@ -44,7 +45,8 @@ public abstract partial class SharedSurgerySystem
         var target = args.Target;
         if (!args.CanInteract
             || !args.CanAccess
-            || !_targetQuery.HasComp(target))
+            || !_targetQuery.HasComp(target)
+            || CanPirateQuickOpenSurgery(args.User)) // Pirate - the alt verb handles noncombat users.
             return;
 
         var user = args.User;


### PR DESCRIPTION
Дозволяє відкрити меню операцій через Alt+ЛКМ по пацієнту, якщо в активній руці хірургічний інструмент і бойовий режим вимкнений.

:cl:
- add: Меню операцій тепер можна швидко відкрити через Alt+ЛКМ хірургічним інструментом по пацієнту поза бойовим режимом.