### PR TITLE
Fix limb fixation surgery order

### DIFF
--- a/Content.IntegrationTests/Tests/_Pirate/Medical/LimbFixationTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Medical/LimbFixationTest.cs
@@ -16,6 +16,7 @@ using Content.Shared._Shitmed.Medical.Surgery.Wounds.Systems;
 using Content.Shared._Shitmed.Targeting;
 using Content.Shared.Body.Part;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
 
 namespace Content.IntegrationTests.Tests._Pirate.Medical;
 
@@ -130,6 +131,148 @@ public sealed class LimbFixationTest
             entMan.EventBus.RaiseLocalEvent(arm.Id, ref integrityChanged);
 
             Assert.That(entMan.HasComponent<LimbFixationDamageComponent>(arm.Id), Is.True);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task RestoreFunctionLeavesPartCriticallyDamaged()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = false,
+            InLobby = false,
+        });
+
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var body = entMan.System<BodySystem>();
+        var surgery = entMan.System<SurgerySystem>();
+        var wounds = entMan.System<WoundSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            var human = entMan.Spawn("MobHuman");
+            entMan.EnsureComponent<LimbFixationComponent>(human);
+
+            var leg = body.GetBodyChildrenOfType(
+                    human,
+                    BodyPartType.Leg,
+                    symmetry: BodyPartSymmetry.Left)
+                .Single();
+            var woundable = entMan.GetComponent<WoundableComponent>(leg.Id);
+
+            Assert.That(
+                wounds.TryInduceWound(leg.Id, "Blunt", woundable.IntegrityCap, out _, woundable),
+                Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(woundable.WoundableIntegrity, Is.EqualTo(FixedPoint2.Zero));
+                Assert.That(entMan.HasComponent<LimbFixationDamageComponent>(leg.Id), Is.True);
+                Assert.That(
+                    entMan.GetComponent<TargetingComponent>(human).BodyStatus[TargetBodyPart.LeftLeg],
+                    Is.EqualTo(WoundableSeverity.Disabled));
+            });
+
+            var restoreStep = surgery.GetSingleton("SurgeryStepRestoreLimbFunction");
+            Assert.That(restoreStep, Is.Not.Null);
+
+            var restore = new SurgeryStepEvent(
+                human,
+                human,
+                leg.Id,
+                human,
+                EntityUid.Invalid,
+                restoreStep!.Value,
+                false);
+            entMan.EventBus.RaiseLocalEvent(restoreStep.Value, ref restore);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.HasComponent<LimbFixationDamageComponent>(leg.Id), Is.False);
+                Assert.That(
+                    woundable.WoundableIntegrity,
+                    Is.EqualTo(woundable.Thresholds[WoundableSeverity.Critical]));
+                Assert.That(woundable.WoundableSeverity, Is.EqualTo(WoundableSeverity.Critical));
+                Assert.That(
+                    entMan.GetComponent<TargetingComponent>(human).BodyStatus[TargetBodyPart.LeftLeg],
+                    Is.EqualTo(WoundableSeverity.Critical));
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task DisabledPartBlocksHealingSurgeriesButAllowsAmputation()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = false,
+            InLobby = false,
+        });
+
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var body = entMan.System<BodySystem>();
+        var surgery = entMan.System<SurgerySystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            var human = entMan.Spawn("MobHuman");
+            entMan.EnsureComponent<LimbFixationComponent>(human);
+
+            var leg = body.GetBodyChildrenOfType(
+                    human,
+                    BodyPartType.Leg,
+                    symmetry: BodyPartSymmetry.Left)
+                .Single();
+            entMan.EnsureComponent<LimbFixationDamageComponent>(leg.Id);
+
+            foreach (var surgeryId in new[]
+                     {
+                         "SurgeryMendBones",
+                         "SurgeryTendWoundsBrute",
+                         "SurgeryTendWoundsBurn",
+                     })
+            {
+                var healingSurgery = surgery.GetSingleton(surgeryId);
+                Assert.That(healingSurgery, Is.Not.Null);
+                Assert.That(
+                    entMan.HasComponent<SurgeryFunctionalPartConditionComponent>(healingSurgery!.Value),
+                    Is.True,
+                    $"{surgeryId} should require a functional body part");
+            }
+
+            foreach (var surgeryId in new[] { "SurgeryRemovePart", "SurgeryAttachLeftLeg" })
+            {
+                var unaffectedSurgery = surgery.GetSingleton(surgeryId);
+                Assert.That(unaffectedSurgery, Is.Not.Null);
+                Assert.That(
+                    entMan.HasComponent<SurgeryFunctionalPartConditionComponent>(unaffectedSurgery!.Value),
+                    Is.False,
+                    $"{surgeryId} should remain available for disabled parts");
+            }
+
+            var condition = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            entMan.EnsureComponent<SurgeryFunctionalPartConditionComponent>(condition);
+
+            var blocked = new SurgeryValidEvent(human, leg.Id);
+            entMan.EventBus.RaiseLocalEvent(condition, ref blocked);
+            Assert.That(blocked.Cancelled, Is.True);
+
+            var amputation = surgery.GetSingleton("SurgeryRemovePart");
+            Assert.That(amputation, Is.Not.Null);
+            var amputationValid = new SurgeryValidEvent(human, leg.Id);
+            entMan.EventBus.RaiseLocalEvent(amputation!.Value, ref amputationValid);
+            Assert.That(amputationValid.Cancelled, Is.False);
+
+            entMan.RemoveComponent<LimbFixationDamageComponent>(leg.Id);
+
+            var unblocked = new SurgeryValidEvent(human, leg.Id);
+            entMan.EventBus.RaiseLocalEvent(condition, ref unblocked);
+            Assert.That(unblocked.Cancelled, Is.False);
         });
 
         await pair.CleanReturnAsync();

--- a/Content.IntegrationTests/Tests/_Pirate/Medical/LimbFixationTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Medical/LimbFixationTest.cs
@@ -205,7 +205,7 @@ public sealed class LimbFixationTest
     }
 
     [Test]
-    public async Task DisabledPartBlocksHealingSurgeriesButAllowsAmputation()
+    public async Task DisabledPartsBlockHealingSurgeriesButAllowAmputation()
     {
         await using var pair = await PoolManager.GetServerClient(new PoolSettings
         {
@@ -228,7 +228,14 @@ public sealed class LimbFixationTest
                     BodyPartType.Leg,
                     symmetry: BodyPartSymmetry.Left)
                 .Single();
+            var foot = body.GetBodyChildrenOfType(
+                    human,
+                    BodyPartType.Foot,
+                    symmetry: BodyPartSymmetry.Left)
+                .Single();
             entMan.EnsureComponent<LimbFixationDamageComponent>(leg.Id);
+
+            Assert.That(entMan.HasComponent<LimbFixationDisabledComponent>(foot.Id), Is.True);
 
             foreach (var surgeryId in new[]
                      {
@@ -262,6 +269,10 @@ public sealed class LimbFixationTest
             entMan.EventBus.RaiseLocalEvent(condition, ref blocked);
             Assert.That(blocked.Cancelled, Is.True);
 
+            var indirectlyBlocked = new SurgeryValidEvent(human, foot.Id);
+            entMan.EventBus.RaiseLocalEvent(condition, ref indirectlyBlocked);
+            Assert.That(indirectlyBlocked.Cancelled, Is.True);
+
             var amputation = surgery.GetSingleton("SurgeryRemovePart");
             Assert.That(amputation, Is.Not.Null);
             var amputationValid = new SurgeryValidEvent(human, leg.Id);
@@ -273,6 +284,28 @@ public sealed class LimbFixationTest
             var unblocked = new SurgeryValidEvent(human, leg.Id);
             entMan.EventBus.RaiseLocalEvent(condition, ref unblocked);
             Assert.That(unblocked.Cancelled, Is.False);
+
+            var indirectlyUnblocked = new SurgeryValidEvent(human, foot.Id);
+            entMan.EventBus.RaiseLocalEvent(condition, ref indirectlyUnblocked);
+            Assert.That(indirectlyUnblocked.Cancelled, Is.False);
+
+            var rightFoot = body.GetBodyChildrenOfType(
+                    human,
+                    BodyPartType.Foot,
+                    symmetry: BodyPartSymmetry.Right)
+                .Single();
+            var rightLeg = body.GetBodyChildrenOfType(
+                    human,
+                    BodyPartType.Leg,
+                    symmetry: BodyPartSymmetry.Right)
+                .Single();
+            entMan.EnsureComponent<LimbFixationDamageComponent>(rightFoot.Id);
+
+            Assert.That(entMan.HasComponent<LimbFixationDisabledComponent>(rightLeg.Id), Is.True);
+
+            var legDisabledByFoot = new SurgeryValidEvent(human, rightLeg.Id);
+            entMan.EventBus.RaiseLocalEvent(condition, ref legDisabledByFoot);
+            Assert.That(legDisabledByFoot.Cancelled, Is.True);
         });
 
         await pair.CleanReturnAsync();

--- a/Content.Shared/_Pirate/Medical/LimbFixation/LimbFixationComponent.cs
+++ b/Content.Shared/_Pirate/Medical/LimbFixation/LimbFixationComponent.cs
@@ -29,6 +29,12 @@ public sealed partial class LimbFixationDisabledComponent : Component;
 public sealed partial class SurgeryRestoreLimbFunctionStepComponent : Component;
 
 /// <summary>
+/// Prevents a surgery from being performed before limb fixation damage is restored.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SurgeryFunctionalPartConditionComponent : Component;
+
+/// <summary>
 /// Raised before a damaging or otherwise traumatic amputation. Surgical removal uses the safe amputation path.
 /// </summary>
 [ByRefEvent]

--- a/Content.Shared/_Pirate/Medical/LimbFixation/LimbFixationSystem.cs
+++ b/Content.Shared/_Pirate/Medical/LimbFixation/LimbFixationSystem.cs
@@ -3,6 +3,7 @@
 using System.Linq;
 using Content.Shared._Shitmed.Body.Events;
 using Content.Shared._Shitmed.Medical.Surgery;
+using Content.Shared._Shitmed.Medical.Surgery.Conditions;
 using Content.Shared._Shitmed.Medical.Surgery.Steps;
 using Content.Shared._Shitmed.Medical.Surgery.Traumas;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds;

--- a/Content.Shared/_Pirate/Medical/LimbFixation/LimbFixationSystem.cs
+++ b/Content.Shared/_Pirate/Medical/LimbFixation/LimbFixationSystem.cs
@@ -41,6 +41,7 @@ public sealed class LimbFixationSystem : EntitySystem
         SubscribeLocalEvent<LimbFixationComponent, StandUpAttemptEvent>(OnStandUpAttempt);
         SubscribeLocalEvent<SurgeryRestoreLimbFunctionStepComponent, SurgeryStepEvent>(OnRestoreLimbFunction);
         SubscribeLocalEvent<SurgeryRestoreLimbFunctionStepComponent, SurgeryStepCompleteCheckEvent>(OnRestoreLimbFunctionCheck);
+        SubscribeLocalEvent<SurgeryFunctionalPartConditionComponent, SurgeryValidEvent>(OnFunctionalPartCondition);
     }
 
     private void OnBeforeTraumaInduced(Entity<WoundableComponent> ent, ref BeforeTraumaInducedEvent args)
@@ -126,8 +127,13 @@ public sealed class LimbFixationSystem : EntitySystem
         Entity<SurgeryRestoreLimbFunctionStepComponent> ent,
         ref SurgeryStepEvent args)
     {
-        if (TryComp<BodyPartComponent>(args.Part, out var part) && part.Body == args.Body)
-            RemComp<LimbFixationDamageComponent>(args.Part);
+        if (!TryComp<BodyPartComponent>(args.Part, out var part)
+            || part.Body != args.Body
+            || !TryComp<WoundableComponent>(args.Part, out var woundable))
+            return;
+
+        RestoreCriticalIntegrity((args.Part, woundable));
+        RemComp<LimbFixationDamageComponent>(args.Part);
     }
 
     private void OnRestoreLimbFunctionCheck(
@@ -136,6 +142,36 @@ public sealed class LimbFixationSystem : EntitySystem
     {
         if (HasActiveDamage(args.Part) || HasDisabledTargetingStatus(args.Body, args.Part))
             args.Cancelled = true;
+    }
+
+    private void OnFunctionalPartCondition(
+        Entity<SurgeryFunctionalPartConditionComponent> ent,
+        ref SurgeryValidEvent args)
+    {
+        args.Cancelled |= HasActiveDamage(args.Part);
+    }
+
+    private void RestoreCriticalIntegrity(Entity<WoundableComponent> part)
+    {
+        if (!part.Comp.Thresholds.TryGetValue(WoundableSeverity.Critical, out var criticalIntegrity)
+            || part.Comp.WoundableIntegrity >= criticalIntegrity)
+            return;
+
+        var attempts = part.Comp.Wounds.Count + 1;
+        while (part.Comp.WoundableIntegrity < criticalIntegrity && attempts-- > 0)
+        {
+            var previousIntegrity = part.Comp.WoundableIntegrity;
+            _wounds.TryHealWoundsOnWoundable(
+                part.Owner,
+                criticalIntegrity - previousIntegrity,
+                out _,
+                part.Comp,
+                ignoreMultipliers: true,
+                ignoreBlockers: true);
+
+            if (part.Comp.WoundableIntegrity <= previousIntegrity)
+                break;
+        }
     }
 
     private bool HasDisabledTargetingStatus(EntityUid body, EntityUid part)

--- a/Content.Shared/_Pirate/Medical/LimbFixation/LimbFixationSystem.cs
+++ b/Content.Shared/_Pirate/Medical/LimbFixation/LimbFixationSystem.cs
@@ -133,7 +133,9 @@ public sealed class LimbFixationSystem : EntitySystem
             || !TryComp<WoundableComponent>(args.Part, out var woundable))
             return;
 
-        RestoreCriticalIntegrity((args.Part, woundable));
+        if (!RestoreCriticalIntegrity((args.Part, woundable)))
+            return;
+
         RemComp<LimbFixationDamageComponent>(args.Part);
     }
 
@@ -149,14 +151,17 @@ public sealed class LimbFixationSystem : EntitySystem
         Entity<SurgeryFunctionalPartConditionComponent> ent,
         ref SurgeryValidEvent args)
     {
-        args.Cancelled |= HasActiveDamage(args.Part);
+        args.Cancelled |= HasActiveDamage(args.Part)
+            || HasComp<LimbFixationDisabledComponent>(args.Part);
     }
 
-    private void RestoreCriticalIntegrity(Entity<WoundableComponent> part)
+    private bool RestoreCriticalIntegrity(Entity<WoundableComponent> part)
     {
-        if (!part.Comp.Thresholds.TryGetValue(WoundableSeverity.Critical, out var criticalIntegrity)
-            || part.Comp.WoundableIntegrity >= criticalIntegrity)
-            return;
+        if (!part.Comp.Thresholds.TryGetValue(WoundableSeverity.Critical, out var criticalIntegrity))
+            return false;
+
+        if (part.Comp.WoundableIntegrity >= criticalIntegrity)
+            return true;
 
         var attempts = part.Comp.Wounds.Count + 1;
         while (part.Comp.WoundableIntegrity < criticalIntegrity && attempts-- > 0)
@@ -173,6 +178,8 @@ public sealed class LimbFixationSystem : EntitySystem
             if (part.Comp.WoundableIntegrity <= previousIntegrity)
                 break;
         }
+
+        return part.Comp.WoundableIntegrity >= criticalIntegrity;
     }
 
     private bool HasDisabledTargetingStatus(EntityUid body, EntityUid part)

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
@@ -182,6 +182,8 @@
     inverted: true
   - type: SurgeryTraumaPresentCondition
     trauma: BoneDamage
+  # Pirate: restore a disabled part before treating its bones.
+  - type: SurgeryFunctionalPartCondition
 
 - type: entity
   parent: BasePartSurgery
@@ -501,6 +503,8 @@
     - SurgeryStepSealTendWound
   - type: SurgeryWoundedCondition
     damageGroup: Brute
+  # Pirate: restore a disabled part before treating its tissues.
+  - type: SurgeryFunctionalPartCondition
 
 - type: entity
   parent: SurgeryBase
@@ -514,6 +518,8 @@
     - SurgeryStepSealTendWound
   - type: SurgeryWoundedCondition
     damageGroup: Burn
+  # Pirate: restore a disabled part before treating its tissues.
+  - type: SurgeryFunctionalPartCondition
 
 - type: entity
   parent: SurgeryBase


### PR DESCRIPTION
Відновлення функції залишає частину тіла у критичному стані та має виконуватися до лікування тканин або кісток.

:cl:
- fix: Виправлено порядок лікування нефункціональних частин тіла для трейту «Фіксація кінцівок».

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Нові можливості**
  - Відновлення функціональності кінцівки тепер усуває пошкодження фіксації, зберігаючи критичний стан тканин.
  - Хірургічні операції з лікування кісток, рваних і опікових ран блокуються для нефункціональних частин тіла.
  - Ампутаційні операції залишаються доступними для таких частин.

- **Виправлення**
  - Після усунення пошкодження фіксації лікувальні операції знову стають доступними.
  - Додано перевірки для запобігання відновленню невідповідної або некоректної частини тіла.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->