### PR TITLE
Виправлення лікування реагентами по частинах тіла

### DIFF
--- a/Content.Shared/EntityEffects/Effects/EvenHealthChangeEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/EvenHealthChangeEntityEffectSystem.cs
@@ -1,6 +1,7 @@
 ﻿using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Goobstation.Maths.FixedPoint;
+using Content.Shared._Shitmed.Damage;
 using Content.Shared._Shitmed.EntityEffects.Effects;
 using Content.Shared.Localizations;
 using Content.Shared.Temperature.Components;
@@ -37,7 +38,12 @@ public sealed partial class EvenHealthChangeEntityEffectSystem : EntityEffectSys
             {
                 spec.DamageDict[type] = healing / groupProto.DamageTypes.Count;
             }
-            _damageable.TryChangeDamage(entity, spec, ignoreResistances: args.Effect.IgnoreResistances);
+            _damageable.TryChangeDamage(
+                entity,
+                spec,
+                ignoreResistances: args.Effect.IgnoreResistances,
+                interruptsDoAfters: false,
+                splitDamage: args.Effect.SplitDamage);
             // </Goob>
         }
     }
@@ -57,6 +63,10 @@ public sealed partial class EvenHealthChange : EntityEffectBase<EvenHealthChange
     /// </summary>
     [DataField]
     public bool IgnoreResistances = true;
+
+    // Pirate: Restore Shitmed body-part routing lost during the entity effects refactor.
+    [DataField]
+    public SplitDamageBehavior SplitDamage = SplitDamageBehavior.SplitEnsureAllOrganic;
 
     /// <summary>
     /// Shitmed - How to scale the effect based on the temperature of the target entity.

--- a/Content.Shared/EntityEffects/Effects/HealthChangeEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/HealthChangeEntityEffectSystem.cs
@@ -1,7 +1,9 @@
 ﻿using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Goobstation.Maths.FixedPoint;
+using Content.Shared._Shitmed.Damage;
 using Content.Shared._Shitmed.EntityEffects.Effects;
+using Content.Shared._Shitmed.Targeting;
 using Content.Shared.Localizations;
 using Content.Shared.Temperature.Components;
 using Robust.Shared.Prototypes;
@@ -31,13 +33,16 @@ public sealed partial class HealthChangeEntityEffectSystem : EntityEffectSystem<
 
             damageSpec *= scaleTemp.GetEfficiencyMultiplier(temp.CurrentTemperature, args.Scale, false);
         }
-        // Goobstation End
 
         _damageable.TryChangeDamage(
                 entity,
                 damageSpec,
                 args.Effect.IgnoreResistances,
-                interruptsDoAfters: false);
+                interruptsDoAfters: false,
+                targetPart: args.Effect.UseTargeting ? args.Effect.TargetPart : null,
+                ignoreBlockers: args.Effect.IgnoreBlockers,
+                splitDamage: args.Effect.SplitDamage);
+        // Goobstation End
     }
 }
 
@@ -52,6 +57,19 @@ public sealed partial class HealthChange : EntityEffectBase<HealthChange>
 
     [DataField]
     public bool IgnoreResistances = true;
+
+    // Pirate: Restore Shitmed body-part routing lost during the entity effects refactor.
+    [DataField]
+    public SplitDamageBehavior SplitDamage = SplitDamageBehavior.SplitEnsureAllOrganic;
+
+    [DataField]
+    public bool UseTargeting = true;
+
+    [DataField]
+    public TargetBodyPart TargetPart = TargetBodyPart.All;
+
+    [DataField]
+    public bool IgnoreBlockers = true;
 
     [DataField]
     public TemperatureScaling? ScaleByTemperature;


### PR DESCRIPTION
Відновлює коректний розподіл лікування реагентами між пошкодженими органічними частинами тіла. Оксандролон більше не витрачається на неушкоджені частини.

:cl:
- fix: Оксандролон та інші лікувальні реагенти більше не втрачають ефект на неушкоджених частинах тіла.