### PR TITLE
Виправлення застосування трейтів

### DIFF
--- a/Content.Server/_EinsteinEngines/Language/TranslatorSystem.cs
+++ b/Content.Server/_EinsteinEngines/Language/TranslatorSystem.cs
@@ -118,7 +118,7 @@ public sealed class TranslatorSystem : SharedTranslatorSystem
         var hasPower = _powerCell.HasDrawCharge(translator);
         var isEnabled = !translatorComp.Enabled && hasPower;
 
-        Entity<LanguageSpeakerComponent>? holderEntity = null;
+        Entity<LanguageSpeakerComponent?>? holderEntity = null;
         var firstNewLanguage = default(ProtoId<LanguagePrototype>);
 
         if (_containers.TryGetContainingContainer(translator, out var holderCont)

--- a/Content.Server/_EinsteinEngines/Language/TranslatorSystem.cs
+++ b/Content.Server/_EinsteinEngines/Language/TranslatorSystem.cs
@@ -97,6 +97,18 @@ public sealed class TranslatorSystem : SharedTranslatorSystem
         });
     }
 
+    // Pirate: Centralize translator state side effects for external configuration and event handlers.
+    public void SetEnabled(Entity<HandheldTranslatorComponent> translator, bool enabled)
+    {
+        translator.Comp.Enabled = enabled;
+        _powerCell.SetDrawEnabled(translator.Owner, enabled);
+        OnAppearanceChange(translator, translator.Comp);
+
+        if (_containers.TryGetContainingContainer(translator.Owner, out var holderCont)
+            && HasComp<LanguageSpeakerComponent>(holderCont.Owner))
+            _language.UpdateEntityLanguages(holderCont.Owner);
+    }
+
     private void OnTranslatorToggle(EntityUid translator, HandheldTranslatorComponent translatorComp, ActivateInWorldEvent args)
     {
         if (!translatorComp.ToggleOnInteract)
@@ -106,23 +118,26 @@ public sealed class TranslatorSystem : SharedTranslatorSystem
         var hasPower = _powerCell.HasDrawCharge(translator);
         var isEnabled = !translatorComp.Enabled && hasPower;
 
-        translatorComp.Enabled = isEnabled;
-        _powerCell.SetDrawEnabled(translator, isEnabled);
+        Entity<LanguageSpeakerComponent>? holderEntity = null;
+        var firstNewLanguage = default(ProtoId<LanguagePrototype>);
 
         if (_containers.TryGetContainingContainer(translator, out var holderCont)
             && holderCont.Owner is var holder
             && TryComp<LanguageSpeakerComponent>(holder, out var languageComp))
         {
             // The first new spoken language added by this translator, or null
-            var firstNewLanguage = translatorComp.SpokenLanguages.FirstOrDefault(it => !languageComp.SpokenLanguages.Contains(it));
-            _language.UpdateEntityLanguages(holder);
-
-            // Update the current language of the entity if necessary
-            if (isEnabled && translatorComp.SetLanguageOnInteract && firstNewLanguage is {})
-                _language.SetLanguage((holder, languageComp), firstNewLanguage);
+            firstNewLanguage = translatorComp.SpokenLanguages.FirstOrDefault(it => !languageComp.SpokenLanguages.Contains(it));
+            holderEntity = (holder, languageComp);
         }
 
-        OnAppearanceChange(translator, translatorComp);
+        SetEnabled((translator, translatorComp), isEnabled);
+
+        // Update the current language of the entity if necessary
+        if (isEnabled
+            && translatorComp.SetLanguageOnInteract
+            && firstNewLanguage is {}
+            && holderEntity is {} languageHolder)
+            _language.SetLanguage(languageHolder, firstNewLanguage);
 
         if (hasPower)
         {
@@ -134,23 +149,13 @@ public sealed class TranslatorSystem : SharedTranslatorSystem
 
     private void OnPowerCellSlotEmpty(EntityUid translator, HandheldTranslatorComponent component, PowerCellSlotEmptyEvent args)
     {
-        component.Enabled = false;
-        _powerCell.SetDrawEnabled(translator, false);
-        OnAppearanceChange(translator, component);
-
-        if (_containers.TryGetContainingContainer(translator, out var holderCont) && HasComp<LanguageSpeakerComponent>(holderCont.Owner))
-            _language.UpdateEntityLanguages(holderCont.Owner);
+        SetEnabled((translator, component), false);
     }
 
     private void OnPowerCellChanged(EntityUid translator, HandheldTranslatorComponent component, PowerCellChangedEvent args)
     {
         var hasCharge = _powerCell.HasActivatableCharge(translator);
-        component.Enabled = hasCharge;
-        _powerCell.SetDrawEnabled(translator, hasCharge);
-        OnAppearanceChange(translator, component);
-
-        if (_containers.TryGetContainingContainer((translator, null, null), out var holderCont) && HasComp<LanguageSpeakerComponent>(holderCont.Owner))
-            _language.UpdateEntityLanguages(holderCont.Owner);
+        SetEnabled((translator, component), hasCharge);
     }
 
     private void OnItemToggled(EntityUid translator, HandheldTranslatorComponent component, ItemToggledEvent args)
@@ -158,12 +163,7 @@ public sealed class TranslatorSystem : SharedTranslatorSystem
         var hasCharge = _powerCell.HasActivatableCharge(translator);
         var shouldEnable = args.Activated && hasCharge;
 
-        component.Enabled = shouldEnable;
-        _powerCell.SetDrawEnabled(translator, shouldEnable);
-        OnAppearanceChange(translator, component);
-
-        if (_containers.TryGetContainingContainer((translator, null, null), out var holderCont) && HasComp<LanguageSpeakerComponent>(holderCont.Owner))
-            _language.UpdateEntityLanguages(holderCont.Owner);
+        SetEnabled((translator, component), shouldEnable);
     }
 
     private void CopyLanguages(BaseTranslatorComponent from, DetermineEntityLanguagesEvent to, LanguageKnowledgeComponent knowledge)

--- a/Content.Server/_EinsteinEngines/Traits/Assorted/ForeignerTraitSystem.cs
+++ b/Content.Server/_EinsteinEngines/Traits/Assorted/ForeignerTraitSystem.cs
@@ -20,6 +20,7 @@ public sealed partial class ForeignerTraitSystem : EntitySystem
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly LanguageSystem _languages = default!;
     [Dependency] private readonly StorageSystem _storage = default!;
+    [Dependency] private readonly TranslatorSystem _translator = default!; // Pirate: Configure spawned translators through their system.
 
     public override void Initialize()
     {
@@ -78,6 +79,7 @@ public sealed partial class ForeignerTraitSystem : EntitySystem
         handheld.SpokenLanguages = [translatorLanguage];
         handheld.UnderstoodLanguages = [translatorLanguage];
         handheld.RequiredLanguages = [entityLanguage];
+        _translator.SetEnabled((translator, handheld), false);
 
         // Try to put it in entities hand
         if (_hands.TryPickupAnyHand(uid, translator, false, false, false))

--- a/Content.Server/_Pirate/Traits/TraitSystem.cs
+++ b/Content.Server/_Pirate/Traits/TraitSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Roles;
 using Content.Shared.Traits;
+using Content.Shared.Whitelist;
 using Content.Shared._Pirate.Traits;
 using Content.Shared._Pirate.Traits.Conditions;
 using Content.Shared._Pirate.Traits.Effects;
@@ -15,6 +16,7 @@ public sealed class TraitSystem : SharedTraitSystem
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly SharedHandsSystem _sharedHandsSystem = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private readonly IComponentFactory _factory = default!;
     [Dependency] private readonly ILogManager _log = default!;
 
@@ -75,6 +77,10 @@ public sealed class TraitSystem : SharedTraitSystem
         foreach (var traitId in selectedTraits)
         {
             if (!_prototypeManager.TryIndex(traitId, out var trait))
+                continue;
+
+            if (_whitelistSystem.IsWhitelistFail(trait.Whitelist, player) ||
+                _whitelistSystem.IsWhitelistPass(trait.Blacklist, player))
                 continue;
 
             if (speciesId is { } selectedSpecies && (trait.ExcludedSpecies.Contains(selectedSpecies) ||
@@ -141,6 +147,11 @@ public sealed class TraitSystem : SharedTraitSystem
 
         EntityManager.AddComponents(player, trait.Components, false);
 
+        foreach (var special in trait.Specials)
+        {
+            special.AfterEquip(player);
+        }
+
         var language = EntityManager.System<LanguageSystem>();
 
         if (trait.RemoveLanguagesSpoken is not null)
@@ -178,6 +189,13 @@ public sealed class TraitSystem : SharedTraitSystem
 
         foreach (var effect in trait.Effects)
         {
+            if (effect is SpawnItemInHandEffect spawnItemEffect)
+            {
+                var item = Spawn(spawnItemEffect.Item, Transform(player).Coordinates);
+                _sharedHandsSystem.TryPickupAnyHand(player, item);
+                continue;
+            }
+
             effect.Apply(context);
         }
     }


### PR DESCRIPTION
Виправлено застосування ефектів трейтів і стартовий стан перекладача іноземця.

:cl:
- fix: Виправлено застосування трейтів і мовне обмеження іноземця.