### PR TITLE
Виправлення порожньої OOC-вкладки

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -623,8 +623,16 @@ namespace Content.Client.Lobby.UI
             _allowExploitableInfo = _cfgManager.GetCVar(PirateVars.ExploitableSecrets);
             _allowRoleplayNotes = _cfgManager.GetCVar(PirateVars.OOCNotes);
 
-            ICInfoTab.Visible = _allowFlavorText || _allowCharacterSecrets || _allowExploitableInfo;
-            OOCInfoTab.Visible = _allowRoleplayNotes;
+            var showIcInfo = _allowFlavorText || _allowCharacterSecrets || _allowExploitableInfo;
+            TabContainer.SetTabVisible(6, showIcInfo); // Pirate: Keep disabled character-info tabs inaccessible.
+            TabContainer.SetTabVisible(7, _allowRoleplayNotes);
+
+            if ((!showIcInfo && TabContainer.CurrentTab == 6)
+                || (!_allowRoleplayNotes && TabContainer.CurrentTab == 7))
+            {
+                TabContainer.CurrentTab = 0;
+            }
+
             ICInfoEditor.Physical.Visible = _allowFlavorText;
             ICInfoEditor.Personality.Visible = _allowFlavorText;
             ICInfoEditor.Secrets.Visible = _allowCharacterSecrets;


### PR DESCRIPTION
Виправлено порожню OOC-вкладку в редакторі персонажа.

:cl:
- fix: Виправлено порожню OOC-вкладку опису персонажа.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Виправлення**
  * Покращено оновлення вкладок редактора профілю персонажа під час зміни налаштувань доступності.
  * Недоступні вкладки тепер коректно приховуються, а редактор автоматично переходить на першу доступну вкладку.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->