### PR TITLE
Fix throwing items from inactive hands

### DIFF
--- a/Content.IntegrationTests/Tests/_Pirate/Hands/ThrowHeldItemTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Hands/ThrowHeldItemTest.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Linq;
+using Content.IntegrationTests.Tests.Interaction;
+
+namespace Content.IntegrationTests.Tests._Pirate.Hands;
+
+public sealed class ThrowHeldItemTest : InteractionTest
+{
+    protected override string PlayerPrototype => "MobHuman";
+
+    [Test]
+    public async Task ManualThrowUsesOnlyActiveHandWhileDisarmCanFallback()
+    {
+        var item = ToServer(await PlaceInHands("Crowbar"));
+        var heldHand = Hands!.ActiveHandId!;
+        var emptyHand = Hands.SortedHands.First(hand => hand != heldHand);
+
+        await Server.WaitPost(() =>
+        {
+            Assert.That(HandSys.TrySetActiveHand((SPlayer, Hands), emptyHand), Is.True);
+        });
+        await RunTicks(1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(HandSys.GetActiveItem((SPlayer, Hands)), Is.Null);
+            Assert.That(HandSys.GetHeldItem((SPlayer, Hands), heldHand), Is.EqualTo(item));
+        });
+
+        Assert.That(await ThrowItem(), Is.False);
+        Assert.That(HandSys.GetHeldItem((SPlayer, Hands), heldHand), Is.EqualTo(item));
+
+        var disarmThrow = false;
+        await Server.WaitPost(() =>
+        {
+            disarmThrow = HandSys.ThrowHeldItem(
+                SPlayer,
+                ToServer(TargetCoords),
+                minDistance: 4f,
+                allowInactiveHand: true);
+        });
+        await RunTicks(1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(disarmThrow, Is.True);
+            Assert.That(HandSys.GetHeldItem((SPlayer, Hands), heldHand), Is.Null);
+        });
+    }
+}

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -117,7 +117,8 @@ namespace Content.Server.Hands.Systems
                 _pullingSystem.TryStopPull(puller.Pulling.Value, pullable, ignoreGrab: true); // Goobstation edit added check for grab
 
             var offsetRandomCoordinates = _transformSystem.GetMoverCoordinates(args.Target).Offset(_random.NextVector2(1f, 1.5f));
-            if (!ThrowHeldItem(args.Target, offsetRandomCoordinates))
+            // Pirate: Disarms can affect inactive hands.
+            if (!ThrowHeldItem(args.Target, offsetRandomCoordinates, allowInactiveHand: true))
                 return;
 
             args.Handled = true; // Successful disarm
@@ -196,15 +197,36 @@ namespace Content.Server.Hands.Systems
         }
 
         /// <summary>
-        /// Throw the player's currently held item.
+        /// Throw the item in the player's active hand.
         /// </summary>
-        public bool ThrowHeldItem(EntityUid player, EntityCoordinates coordinates, float minDistance = 0.1f)
+        /// <param name="allowInactiveHand">
+        /// Whether to fall back to another occupied hand when the active hand is empty.
+        /// </param>
+        public bool ThrowHeldItem(
+            EntityUid player,
+            EntityCoordinates coordinates,
+            float minDistance = 0.1f,
+            bool allowInactiveHand = false)
         {
             if (ContainerSystem.IsEntityInContainer(player) ||
-                !TryComp(player, out HandsComponent? hands) ||
-                !TryGetHeldItem((player, hands), out var throwEnt) || // DOWNSTREAM-TPirates: combat actions
-                !_actionBlockerSystem.CanThrow(player, throwEnt.Value))
+                !TryComp(player, out HandsComponent? hands))
                 return false;
+
+            // Pirate: Manual throws only use the active hand; disarms may fall back to another occupied hand.
+            EntityUid? throwEnt;
+            if (allowInactiveHand)
+            {
+                if (!TryGetHeldItem((player, hands), out throwEnt))
+                    return false;
+            }
+            else if (!TryGetActiveItem((player, hands), out throwEnt))
+            {
+                return false;
+            }
+
+            if (!_actionBlockerSystem.CanThrow(player, throwEnt.Value))
+                return false;
+
             // Goobstation start added throwing for grabbed mobs, mnoved direction.
             var direction = _transformSystem.ToMapCoordinates(coordinates).Position - _transformSystem.GetWorldPosition(player);
 


### PR DESCRIPTION
Ctrl+Q тепер кидає предмет лише з активної руки; fallback для disarm збережено.

:cl:
- fix: Ctrl+Q більше не кидає предмети з неактивної руки.