### PR TITLE
Fix movement speed after releasing grabs

### DIFF
--- a/Content.Goobstation.Shared/GrabIntent/GrabIntentSystem.cs
+++ b/Content.Goobstation.Shared/GrabIntent/GrabIntentSystem.cs
@@ -105,6 +105,7 @@ public sealed partial class GrabIntentSystem : EntitySystem
         }
 
         Dirty(uid, component);
+        _modifierSystem.RefreshMovementSpeedModifiers(uid); // Pirate: clear cached grab slowdown after resetting the stage.
     }
 
     private void OnCheckGrabbed(EntityUid uid, GrabbableComponent component, ref CheckGrabbedEvent args)


### PR DESCRIPTION
Після завершення grab коректно оновлюється швидкість руху вже зі скинутою стадією захоплення.

:cl:
- fix: Виправлено постійне сповільнення після завершення захоплення.