### PR TITLE
Фікс спаму progress bar під час SSD-сну

### DIFF
--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -97,10 +97,18 @@ public abstract partial class SharedStunSystem
         while (query.MoveNext(out var uid, out var knockedDown))
         {
             // If it's null then we don't want to stand up
-            if (!knockedDown.AutoStand || knockedDown.DoAfterId.HasValue || knockedDown.NextUpdate > GameTiming.CurTime)
+            // Pirate: Debounce failed predicted stand attempts.
+            if (!knockedDown.AutoStand
+                || knockedDown.DoAfterId.HasValue
+                || knockedDown.NextUpdate > GameTiming.CurTime
+                || knockedDown.NextStandAttempt > GameTiming.CurTime)
                 continue;
 
-            TryStanding(uid);
+            if (!TryStanding(uid))
+            {
+                knockedDown.NextStandAttempt = GameTiming.CurTime + StandupRetryCooldown;
+                DirtyField(uid, knockedDown, nameof(KnockedDownComponent.NextStandAttempt));
+            }
         }
     }
 

--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -104,7 +104,7 @@ public abstract partial class SharedStunSystem
                 || knockedDown.NextStandAttempt > GameTiming.CurTime)
                 continue;
 
-            if (!TryStanding(uid))
+            if (!TryStanding((uid, knockedDown)))
             {
                 knockedDown.NextStandAttempt = GameTiming.CurTime + StandupRetryCooldown;
                 DirtyField(uid, knockedDown, nameof(KnockedDownComponent.NextStandAttempt));

--- a/Content.Shared/_Pirate/Stunnable/KnockedDownComponent.Pirate.cs
+++ b/Content.Shared/_Pirate/Stunnable/KnockedDownComponent.Pirate.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared.Stunnable;
+
+public sealed partial class KnockedDownComponent
+{
+    /// <summary>
+    /// Earliest game time at which a failed automatic stand attempt may retry.
+    /// Kept separate from <see cref="NextUpdate"/> so knockdown duration is unaffected.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan NextStandAttempt;
+}

--- a/Content.Shared/_Pirate/Stunnable/SharedStunSystem.PirateAutoStand.cs
+++ b/Content.Shared/_Pirate/Stunnable/SharedStunSystem.PirateAutoStand.cs
@@ -1,0 +1,6 @@
+namespace Content.Shared.Stunnable;
+
+public abstract partial class SharedStunSystem
+{
+    private static readonly TimeSpan StandupRetryCooldown = TimeSpan.FromMilliseconds(250);
+}


### PR DESCRIPTION
Прибрано нескінченний спам DoAfter-смуг над персонажами, які автоматично заснули в SSD.

:cl:
- fix: Над персонажами в SSD-сні більше не накопичуються смуги прогресу.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Покращення**
  * Додано затримку між повторними спробами автоматичного підйому після невдалого виходу з нокдауну.
  * Автоматичний підйом більше не запускає зайві повторні спроби під час активних відкладених дій.
  * Тривалість нокдауну тепер не змінюється через невдалі спроби піднятися.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->