### PR TITLE
Fix medical stack limits

### DIFF
--- a/Resources/Prototypes/Stacks/Specific/medical.yml
+++ b/Resources/Prototypes/Stacks/Specific/medical.yml
@@ -8,6 +8,7 @@
   name: stack-ointment
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: ointment }
   spawn: Ointment
+  maxCount: 15 # Pirate - match the full item count
 
 - type: stack
   parent: BaseSmallStack
@@ -15,6 +16,7 @@
   name: stack-aloe-cream
   icon: { sprite: "/Textures/Objects/Specific/Hydroponics/aloe.rsi", state: cream }
   spawn: AloeCream
+  maxCount: 15 # Pirate - match the full item count
 
 - type: stack
   parent: BaseSmallStack
@@ -22,6 +24,7 @@
   name: stack-gauze
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: gauze }
   spawn: Gauze
+  maxCount: 15 # Pirate - match the full item count
 
 - type: stack
   parent: BaseSmallStack
@@ -29,6 +32,7 @@
   name: stack-brutepack
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: gauze }
   spawn: Brutepack
+  maxCount: 15 # Pirate - match the full item count
 
 - type: stack
   parent: BaseSmallStack
@@ -36,6 +40,7 @@
   name: stack-bloodpack
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: bloodpack }
   spawn: Bloodpack
+  maxCount: 15 # Pirate - match the full item count
 
 - type: stack
   parent: BaseSmallStack
@@ -43,6 +48,7 @@
   name: stack-medicated-suture
   icon: {sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: medicated-suture }
   spawn: MedicatedSuture
+  maxCount: 15 # Pirate - match the full item count
 
 - type: stack
   parent: BaseSmallStack
@@ -50,4 +56,5 @@
   name: stack-regenerative-mesh
   icon: {sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: regenerative-mesh}
   spawn: RegenerativeMesh
+  maxCount: 15 # Pirate - match the full item count
 


### PR DESCRIPTION
Максимальний розмір стосу семи лікувальних предметів збільшено до 15 відповідно до кількості у повному предметі.

:cl:
- fix: Повні стоси марлі та інших лікувальних предметів тепер коректно містять усі 15 одиниць.