### PR TITLE
Виправити перевантаження APC на шатлах піратів і найманців

### DIFF
--- a/Resources/Maps/_Goobstation/Shuttles/pirates_irs.yml
+++ b/Resources/Maps/_Goobstation/Shuttles/pirates_irs.yml
@@ -604,7 +604,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 10.5,-14.5
       parent: 2
-- proto: APCBasic
+# Pirate: raise the breaker limit for this legacy shared LV network.
+- proto: PirateShuttleAPCBasic
   entities:
   - uid: 697
     components:

--- a/Resources/Maps/_Pirate/Shuttles/Qazmlp/st_merc.yml
+++ b/Resources/Maps/_Pirate/Shuttles/Qazmlp/st_merc.yml
@@ -1919,7 +1919,7 @@ entities:
     - type: Transform
       pos: -14.5,2.5
       parent: 2
-- proto: APCBasic
+- proto: PirateShuttleAPCBasic
   entities:
   - uid: 949
     components:
@@ -1927,7 +1927,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 1.5,5.5
       parent: 823
-- proto: APCHighCapacity
+- proto: PirateShuttleAPCHighCapacity
   entities:
   - uid: 129
     components:

--- a/Resources/Prototypes/_Pirate/Entities/Structures/Shuttles/power.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Structures/Shuttles/power.yml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Pirate: legacy single-LV-network shuttles need a substation-sized breaker limit
+# after upstream added APC overload tripping.
+- type: entity
+  parent: APCBasic
+  id: PirateShuttleAPCBasic
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Apc
+    maxLoad: 150000
+
+- type: entity
+  parent: APCHighCapacity
+  id: PirateShuttleAPCHighCapacity
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Apc
+    maxLoad: 150000


### PR DESCRIPTION
Виправлено спрацювання APC на шатлах піратів IRS та найманців після апстрімного обмеження навантаження. Зміна обмежена цими двома мапами.

:cl:
- fix: APC на шатлах піратів і найманців більше не вимикаються через штатне навантаження.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Покращення**
  - Оновлено електричні системи піратських шатлів для стабільнішої роботи в мережах із одним контуром живлення.
  - Збільшено допустиме навантаження APC на піратських шатлах.
  - Оновлені карти піратських шатлів використовують відповідні налаштування електроживлення.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->