### PR TITLE
Fix bark sound index for UTF-16 characters

### DIFF
--- a/Content.Goobstation.Client/Barks/BarkSystem.cs
+++ b/Content.Goobstation.Client/Barks/BarkSystem.cs
@@ -133,7 +133,8 @@ public sealed class BarkSystem : EntitySystem
 
         if (proto.Predictable)
         {
-            var hashCode = character.GetHashCode();
+            // Pirate: Char.GetHashCode can be negative for UTF-16 surrogates, producing invalid collection indices.
+            var hashCode = character.GetHashCode() & int.MaxValue;
 
             if (sound is ResolvedCollectionSpecifier collection && collection.Collection != null)
             {


### PR DESCRIPTION
Виправляє нескінченний спам помилок bark-аудіо на повідомленнях з емодзі та іншими UTF-16 символами.

:cl:
- fix: Виправлено клієнтські лаги від bark-голосів у повідомленнях з емодзі.