### PR TITLE
Виправлення плазмового ядра при складанні MOD-костюма

### DIFF
--- a/Resources/Prototypes/_Pirate/Entities/Objects/Specific/Robotics/modularsuits.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Objects/Specific/Robotics/modularsuits.yml
@@ -78,9 +78,6 @@
     storedRotation: -90
   - type: Sprite
     sprite: *mod-rsi
-  - type: Tag
-    tags:
-    - ModularSuitCore
 
 - type: entity
   parent: BaseModularSuitCore
@@ -94,6 +91,9 @@
     verbIcon:
       sprite: *mod-rsi
       state: mod-core-standard
+  - type: Tag
+    tags:
+    - ModularSuitCore
 
 - type: entity
   parent: BaseModularSuitCore
@@ -110,6 +110,9 @@
     verbIcon:
       sprite: *mod-rsi
       state: mod-core-plasma
+  - type: Tag
+    tags:
+    - ModularSuitCore
 
 - type: entity
   parent: BaseModularSuitCore

--- a/Resources/Prototypes/_Pirate/Entities/Objects/Specific/Robotics/modularsuits.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Objects/Specific/Robotics/modularsuits.yml
@@ -78,6 +78,9 @@
     storedRotation: -90
   - type: Sprite
     sprite: *mod-rsi
+  - type: Tag
+    tags:
+    - ModularSuitCore
 
 - type: entity
   parent: BaseModularSuitCore
@@ -91,9 +94,6 @@
     verbIcon:
       sprite: *mod-rsi
       state: mod-core-standard
-  - type: Tag
-    tags:
-    - ModularSuitCore
 
 - type: entity
   parent: BaseModularSuitCore


### PR DESCRIPTION
Плазмове ядро MOD-костюма тепер має тег, потрібний для складання каркаса.

:cl:
- fix: Плазмове ядро тепер можна використовувати під час складання MOD-костюма.