### PR TITLE
fix: виправити індикацію керувальних стрижнів

### DIFF
--- a/Content.Pirate.Client/Nuclear/Reactor/UI/NuclearReactorWindow.xaml
+++ b/Content.Pirate.Client/Nuclear/Reactor/UI/NuclearReactorWindow.xaml
@@ -114,19 +114,24 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					<PanelContainer SetHeight="2" VerticalAlignment="Top" SetWidth="200" Margin="2 5" />
 
 
-					<BoxContainer Name="ControlRodsText" Orientation="Horizontal">
+					<BoxContainer Name="ControlRodsText" Orientation="Vertical">
 						<Label Name="ControlRodsLabel" Text="{Loc comp-nuclear-reactor-ui-reactor-control}" StyleClasses="StatusFieldTitle"  HorizontalExpand="True"/>
-						<Label Name="ControlRodsValue" Text="100%" HorizontalAlignment="Right"/>
+						<Label Name="ControlRodsValue" Text="100% -> 100%" HorizontalAlignment="Right"
+							ToolTip="{Loc comp-nuclear-reactor-ui-control-format-tooltip}"/>
 					</BoxContainer>
 					<BoxContainer Name="ControlRods" Orientation="Horizontal">
 						<ProgressBar Name="ControlRodsActual" MaxValue="2" SetSize="5 100" Margin="5" Vertical="True" />
 						<ProgressBar Name="ControlRodsSet" MaxValue="2" SetSize="5 100" Margin="5" Vertical="True" />
 						<controls:StripeBack>
 							<BoxContainer Name="ControlRodsButtons" Orientation="Vertical">
-								<Button Name="ControlRodsInsertLarge" Text="+ +"/>
-								<Button Name="ControlRodsInsert" Text=" + "/>
-								<Button Name="ControlRodsRemove" Text=" - "/>
-								<Button Name="ControlRodsRemoveLarge" Text="- -"/>
+								<Button Name="ControlRodsInsertLarge" Text="++"
+									ToolTip="{Loc comp-nuclear-reactor-ui-control-insert-large}"/>
+								<Button Name="ControlRodsInsert" Text="+"
+									ToolTip="{Loc comp-nuclear-reactor-ui-control-insert}"/>
+								<Button Name="ControlRodsRemove" Text="-"
+									ToolTip="{Loc comp-nuclear-reactor-ui-control-remove}"/>
+								<Button Name="ControlRodsRemoveLarge" Text="--"
+									ToolTip="{Loc comp-nuclear-reactor-ui-control-remove-large}"/>
 							</BoxContainer>
 							<Label Name="ControlRodsLock" Text="{Loc comp-nuclear-reactor-ui-locked}" Visible="false" HorizontalAlignment="Center" VerticalAlignment="Center" />
 						</controls:StripeBack>

--- a/Content.Pirate.Client/Nuclear/Reactor/UI/NuclearReactorWindow.xaml.cs
+++ b/Content.Pirate.Client/Nuclear/Reactor/UI/NuclearReactorWindow.xaml.cs
@@ -133,11 +133,33 @@ public sealed partial class NuclearReactorWindow : FancyWindow
         ReactorThermBar.Value = comp.ThermalPower;
         _powerBar.BackgroundColor = GetSteppedColor(ReactorThermBar.MaxValue * 0.75, ReactorThermBar.MaxValue, comp.ThermalPower);
 
-        ControlRodsValue.Text = Math.Round(comp.AvgInsertion * 50, 1).ToString() + "%";
+        var actualInsertion = Math.Round(comp.AvgInsertion * 50, 1);
+        var targetInsertion = Math.Round(comp.ControlRodInsertion * 50, 1);
+        ControlRodsValue.Text = Loc.GetString("comp-nuclear-reactor-ui-control-format",
+            ("actual", actualInsertion),
+            ("target", targetInsertion));
         ControlRodsActual.Value = comp.AvgInsertion;
         ControlRodsSet.Value = comp.ControlRodInsertion;
 
-        var locktarget = _monitor ?? _reactor.Owner;
+        var cannotInsert = comp.ControlRodInsertion >= ControlRodsSet.MaxValue;
+        var cannotRemove = comp.ControlRodInsertion <= 0f;
+        ControlRodsInsertLarge.Disabled = cannotInsert;
+        ControlRodsInsert.Disabled = cannotInsert;
+        ControlRodsRemove.Disabled = cannotRemove;
+        ControlRodsRemoveLarge.Disabled = cannotRemove;
+
+        if (cannotInsert)
+        {
+            _repeatQueue.Remove(ControlRodsInsertLarge);
+            _repeatQueue.Remove(ControlRodsInsert);
+        }
+
+        if (cannotRemove)
+        {
+            _repeatQueue.Remove(ControlRodsRemove);
+            _repeatQueue.Remove(ControlRodsRemoveLarge);
+        }
+
         var locked = _lock.IsLocked(_monitor ?? _reactor.Owner);
 
         ControlRodsButtons.Visible = !locked;

--- a/Resources/Locale/uk-UA/_Pirate/nuclear/nuclear.ftl
+++ b/Resources/Locale/uk-UA/_Pirate/nuclear/nuclear.ftl
@@ -57,6 +57,12 @@ comp-nuclear-reactor-ui-reactor-temp = Температура
 comp-nuclear-reactor-ui-reactor-rads = Радіація
 comp-nuclear-reactor-ui-reactor-therm = Теплова потужність
 comp-nuclear-reactor-ui-reactor-control = Керувальні стрижні
+comp-nuclear-reactor-ui-control-format = {$actual}% -> {$target}%
+comp-nuclear-reactor-ui-control-format-tooltip = Фактичний рівень введення -> заданий рівень введення
+comp-nuclear-reactor-ui-control-insert-large = Ввести керувальні стрижні на 5%
+comp-nuclear-reactor-ui-control-insert = Ввести керувальні стрижні на 0,5%
+comp-nuclear-reactor-ui-control-remove = Вивести керувальні стрижні на 0,5%
+comp-nuclear-reactor-ui-control-remove-large = Вивести керувальні стрижні на 5%
 comp-nuclear-reactor-ui-therm-format = { POWERWATTS($power) }
 
 comp-nuclear-reactor-ui-footer-left = Небезпека: висока радіація.


### PR DESCRIPTION
Показує фактичний і заданий рівні стрижнів, блокує недоступний напрямок на межах та додає підказки до кнопок.

:cl:
- fix: Керування стрижнями ядерного реактора тепер чітко показує заданий рівень і недоступні напрямки.