### PR TITLE
Прискорити debug-тести додатковим розподілом

### DIFF
--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -17,7 +17,7 @@ on:
 env:
   # Pirate: mapped groups run independently; every other integration test falls through to the unmapped shard.
   ENTITY_TEST_PATTERNS: Content.IntegrationTests.Tests.EntityTest
-  ATMOS_VALIDATION_TEST_PATTERNS: >-
+  ATMOS_SERIALIZATION_TEST_PATTERNS: >-
     Content.IntegrationTests.Tests.Atmos.AirtightTest
     Content.IntegrationTests.Tests.Atmos.AlarmThresholdTest
     Content.IntegrationTests.Tests.Atmos.AtmosMonitoringTest
@@ -28,17 +28,10 @@ env:
     Content.IntegrationTests.Tests.Atmos.GridJoinTest
     Content.IntegrationTests.Tests.Atmos.RoomSpacingTest
     Content.IntegrationTests.Tests.Atmos.SharedGasSpecificHeatsTest
-    Content.IntegrationTests.Tests.ConfigPresetTests
-    Content.IntegrationTests.Tests.Guidebook
-    Content.IntegrationTests.Tests.Linter
-    Content.IntegrationTests.Tests.Localization
     Content.IntegrationTests.Tests.Mapping
     Content.IntegrationTests.Tests.PrototypeSaveTest
     Content.IntegrationTests.Tests.PrototypeTests
     Content.IntegrationTests.Tests.SaveLoad
-    Content.IntegrationTests.Tests.Sprite
-    Content.IntegrationTests.Tests.StartTest
-    Content.IntegrationTests.Tests.WizdenContentFreeze
   VALIDATION_MAP_TEST_PATTERNS: Content.IntegrationTests.Tests.PostMapInitTest
   WORLD_TEST_PATTERNS: >-
     Content.IntegrationTests.Tests.Atmos.TileAtmosphereTest
@@ -61,7 +54,14 @@ env:
     Content.IntegrationTests.Tests.Weldable
     Content.IntegrationTests.Tests.Wires
   MIND_TEST_PATTERNS: Content.IntegrationTests.Tests.Minds
-  GAMEPLAY_TEST_PATTERNS: >-
+  GAMEPLAY_VALIDATION_TEST_PATTERNS: >-
+    Content.IntegrationTests.Tests.ConfigPresetTests
+    Content.IntegrationTests.Tests.Guidebook
+    Content.IntegrationTests.Tests.Linter
+    Content.IntegrationTests.Tests.Localization
+    Content.IntegrationTests.Tests.Sprite
+    Content.IntegrationTests.Tests.StartTest
+    Content.IntegrationTests.Tests.WizdenContentFreeze
     Content.IntegrationTests.Tests.Actions
     Content.IntegrationTests.Tests.Body
     Content.IntegrationTests.Tests.Buckle
@@ -95,9 +95,9 @@ jobs:
           - name: Entity integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: entity
-          - name: Atmos and validation integration tests
+          - name: Atmos and serialization integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: atmos-validation
+            shard: atmos-serialization
           - name: Validation map integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: validation-map
@@ -107,9 +107,9 @@ jobs:
           - name: Mind integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: minds
-          - name: Gameplay integration tests
+          - name: Gameplay and core validation integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: gameplay
+            shard: gameplay-validation
           - name: Unmapped integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: unmapped
@@ -156,11 +156,11 @@ jobs:
         nunit_args=(NUnit.ConsoleOut=0)
 
         read -r -a entity_patterns <<< "$ENTITY_TEST_PATTERNS"
-        read -r -a atmos_validation_patterns <<< "$ATMOS_VALIDATION_TEST_PATTERNS"
+        read -r -a atmos_serialization_patterns <<< "$ATMOS_SERIALIZATION_TEST_PATTERNS"
         read -r -a validation_map_patterns <<< "$VALIDATION_MAP_TEST_PATTERNS"
         read -r -a world_patterns <<< "$WORLD_TEST_PATTERNS"
         read -r -a mind_patterns <<< "$MIND_TEST_PATTERNS"
-        read -r -a gameplay_patterns <<< "$GAMEPLAY_TEST_PATTERNS"
+        read -r -a gameplay_validation_patterns <<< "$GAMEPLAY_VALIDATION_TEST_PATTERNS"
 
         case "$TEST_SHARD" in
           entity)
@@ -168,8 +168,8 @@ jobs:
             comparison="~"
             separator="|"
             ;;
-          atmos-validation)
-            patterns=("${atmos_validation_patterns[@]}")
+          atmos-serialization)
+            patterns=("${atmos_serialization_patterns[@]}")
             comparison="~"
             separator="|"
             ;;
@@ -188,19 +188,19 @@ jobs:
             comparison="~"
             separator="|"
             ;;
-          gameplay)
-            patterns=("${gameplay_patterns[@]}")
+          gameplay-validation)
+            patterns=("${gameplay_validation_patterns[@]}")
             comparison="~"
             separator="|"
             ;;
           unmapped)
             patterns=(
               "${entity_patterns[@]}"
-              "${atmos_validation_patterns[@]}"
+              "${atmos_serialization_patterns[@]}"
               "${validation_map_patterns[@]}"
               "${world_patterns[@]}"
               "${mind_patterns[@]}"
-              "${gameplay_patterns[@]}"
+              "${gameplay_validation_patterns[@]}"
             )
             comparison="!~"
             separator="&"

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -42,7 +42,13 @@ env:
     Content.IntegrationTests.Tests.Sprite
     Content.IntegrationTests.Tests.StartTest
     Content.IntegrationTests.Tests.WizdenContentFreeze
-  VALIDATION_MAP_TEST_PATTERNS: Content.IntegrationTests.Tests.PostMapInitTest
+  VALIDATION_GAME_MAP_TEST_PATTERNS: Content.IntegrationTests.Tests.PostMapInitTest.GameMapsLoadableTest
+  VALIDATION_OTHER_MAP_TEST_PATTERNS: >-
+    Content.IntegrationTests.Tests.PostMapInitTest.AllMapsTested
+    Content.IntegrationTests.Tests.PostMapInitTest.GridsLoadableTest
+    Content.IntegrationTests.Tests.PostMapInitTest.NoSavedPostMapInitTest
+    Content.IntegrationTests.Tests.PostMapInitTest.NonGameMapsLoadableTest
+    Content.IntegrationTests.Tests.PostMapInitTest.ShuttlesLoadableTest
   VALIDATION_SERIALIZATION_TEST_PATTERNS: >-
     Content.IntegrationTests.Tests.Mapping
     Content.IntegrationTests.Tests.PrototypeSaveTest
@@ -145,9 +151,12 @@ jobs:
           - name: Validation core integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: validation-core
-          - name: Validation map integration tests
+          - name: Validation game map integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: validation-map
+            shard: validation-game-map
+          - name: Validation other map integration tests
+            project: Content.IntegrationTests/Content.IntegrationTests.csproj
+            shard: validation-other-map
           - name: Validation serialization integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: validation-serialization
@@ -219,7 +228,8 @@ jobs:
         read -r -a atmos_tile_patterns <<< "$ATMOS_TILE_TEST_PATTERNS"
         read -r -a atmos_core_patterns <<< "$ATMOS_CORE_TEST_PATTERNS"
         read -r -a validation_core_patterns <<< "$VALIDATION_CORE_TEST_PATTERNS"
-        read -r -a validation_map_patterns <<< "$VALIDATION_MAP_TEST_PATTERNS"
+        read -r -a validation_game_map_patterns <<< "$VALIDATION_GAME_MAP_TEST_PATTERNS"
+        read -r -a validation_other_map_patterns <<< "$VALIDATION_OTHER_MAP_TEST_PATTERNS"
         read -r -a validation_serialization_patterns <<< "$VALIDATION_SERIALIZATION_TEST_PATTERNS"
         read -r -a world_patterns <<< "$WORLD_TEST_PATTERNS"
         read -r -a action_patterns <<< "$ACTION_TEST_PATTERNS"
@@ -257,8 +267,13 @@ jobs:
             comparison="~"
             separator="|"
             ;;
-          validation-map)
-            patterns=("${validation_map_patterns[@]}")
+          validation-game-map)
+            patterns=("${validation_game_map_patterns[@]}")
+            comparison="~"
+            separator="|"
+            ;;
+          validation-other-map)
+            patterns=("${validation_other_map_patterns[@]}")
             comparison="~"
             separator="|"
             ;;
@@ -304,7 +319,8 @@ jobs:
               "${atmos_tile_patterns[@]}"
               "${atmos_core_patterns[@]}"
               "${validation_core_patterns[@]}"
-              "${validation_map_patterns[@]}"
+              "${validation_game_map_patterns[@]}"
+              "${validation_other_map_patterns[@]}"
               "${validation_serialization_patterns[@]}"
               "${world_patterns[@]}"
               "${action_patterns[@]}"

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -16,11 +16,12 @@ on:
 
 env:
   # Pirate: mapped groups run independently; every other integration test falls through to the unmapped shard.
-  ENTITY_HEAVY_TEST_PATTERNS: Content.IntegrationTests.Tests.EntityTest.SpawnAndDeleteAllEntitiesInTheSameSpot
+  ENTITY_HEAVY_TEST_PATTERNS: >-
+    Content.IntegrationTests.Tests.EntityTest.SpawnAndDeleteAllEntitiesInTheSameSpot
+    Content.IntegrationTests.Tests.EntityTest.SpawnAndDeleteAllEntitiesOnDifferentMaps
   ENTITY_REMAINING_TEST_PATTERNS: >-
     Content.IntegrationTests.Tests.EntityTest.AllComponentsOneToOneDeleteTest
     Content.IntegrationTests.Tests.EntityTest.SpawnAndDeleteEntityCountTest
-    Content.IntegrationTests.Tests.EntityTest.SpawnAndDeleteAllEntitiesOnDifferentMaps
   ATMOS_TILE_TEST_PATTERNS: Content.IntegrationTests.Tests.Atmos.TileAtmosphereTest
   ATMOS_CORE_TEST_PATTERNS: >-
     Content.IntegrationTests.Tests.Atmos.AirtightTest
@@ -41,9 +42,9 @@ env:
     Content.IntegrationTests.Tests.Sprite
     Content.IntegrationTests.Tests.StartTest
     Content.IntegrationTests.Tests.WizdenContentFreeze
-  VALIDATION_DATA_TEST_PATTERNS: >-
+  VALIDATION_MAP_TEST_PATTERNS: Content.IntegrationTests.Tests.PostMapInitTest
+  VALIDATION_SERIALIZATION_TEST_PATTERNS: >-
     Content.IntegrationTests.Tests.Mapping
-    Content.IntegrationTests.Tests.PostMapInitTest
     Content.IntegrationTests.Tests.PrototypeSaveTest
     Content.IntegrationTests.Tests.PrototypeTests
     Content.IntegrationTests.Tests.SaveLoad
@@ -67,7 +68,11 @@ env:
     Content.IntegrationTests.Tests.Weldable
     Content.IntegrationTests.Tests.Wires
   ACTION_TEST_PATTERNS: Content.IntegrationTests.Tests.Actions
-  MIND_TEST_PATTERNS: Content.IntegrationTests.Tests.Minds
+  GHOST_ROLE_TEST_PATTERNS: Content.IntegrationTests.Tests.Minds.GhostRoleTests
+  MIND_CORE_TEST_PATTERNS: >-
+    Content.IntegrationTests.Tests.Minds.GhostTests
+    Content.IntegrationTests.Tests.Minds.MindTests
+    Content.IntegrationTests.Tests.Minds.RoleTests
   GAMEPLAY_CORE_TEST_PATTERNS: >-
     Content.IntegrationTests.Tests.Body
     Content.IntegrationTests.Tests.Buckle
@@ -87,6 +92,32 @@ env:
     Content.IntegrationTests.Tests.Storage
     Content.IntegrationTests.Tests.Strip
     Content.IntegrationTests.Tests.Weapons
+  SUPPORT_TEST_PATTERNS: >-
+    Content.IntegrationTests.Tests.Access
+    Content.IntegrationTests.Tests.Chameleon
+    Content.IntegrationTests.Tests.Cleanup
+    Content.IntegrationTests.Tests.Cloning
+    Content.IntegrationTests.Tests.Commands
+    Content.IntegrationTests.Tests.DoAfter
+    Content.IntegrationTests.Tests.Embedding
+    Content.IntegrationTests.Tests.EncryptionKeys
+    Content.IntegrationTests.Tests.Engineering
+    Content.IntegrationTests.Tests.Goobstation
+    Content.IntegrationTests.Tests.Internals
+    Content.IntegrationTests.Tests.Lathe
+    Content.IntegrationTests.Tests.Lobby
+    Content.IntegrationTests.Tests.Materials
+    Content.IntegrationTests.Tests.Networking
+    Content.IntegrationTests.Tests.Payload
+    Content.IntegrationTests.Tests.Preferences
+    Content.IntegrationTests.Tests.Replays
+    Content.IntegrationTests.Tests.Serialization
+    Content.IntegrationTests.Tests.SmartFridge
+    Content.IntegrationTests.Tests.Tag
+    Content.IntegrationTests.Tests.Toolshed
+    Content.IntegrationTests.Tests.UserInterface
+    Content.IntegrationTests.Tests.Utility
+    Content.IntegrationTests.Tests.Vending
 
 jobs:
   tests:
@@ -114,21 +145,30 @@ jobs:
           - name: Validation core integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: validation-core
-          - name: Validation data integration tests
+          - name: Validation map integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: validation-data
+            shard: validation-map
+          - name: Validation serialization integration tests
+            project: Content.IntegrationTests/Content.IntegrationTests.csproj
+            shard: validation-serialization
           - name: World integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: world
           - name: Action integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: actions
-          - name: Mind integration tests
+          - name: Ghost role integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: minds
+            shard: ghost-role
+          - name: Mind core integration tests
+            project: Content.IntegrationTests/Content.IntegrationTests.csproj
+            shard: mind-core
           - name: Gameplay core integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: gameplay-core
+          - name: Support integration tests
+            project: Content.IntegrationTests/Content.IntegrationTests.csproj
+            shard: support
           - name: Unmapped integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: unmapped
@@ -179,11 +219,14 @@ jobs:
         read -r -a atmos_tile_patterns <<< "$ATMOS_TILE_TEST_PATTERNS"
         read -r -a atmos_core_patterns <<< "$ATMOS_CORE_TEST_PATTERNS"
         read -r -a validation_core_patterns <<< "$VALIDATION_CORE_TEST_PATTERNS"
-        read -r -a validation_data_patterns <<< "$VALIDATION_DATA_TEST_PATTERNS"
+        read -r -a validation_map_patterns <<< "$VALIDATION_MAP_TEST_PATTERNS"
+        read -r -a validation_serialization_patterns <<< "$VALIDATION_SERIALIZATION_TEST_PATTERNS"
         read -r -a world_patterns <<< "$WORLD_TEST_PATTERNS"
         read -r -a action_patterns <<< "$ACTION_TEST_PATTERNS"
-        read -r -a mind_patterns <<< "$MIND_TEST_PATTERNS"
+        read -r -a ghost_role_patterns <<< "$GHOST_ROLE_TEST_PATTERNS"
+        read -r -a mind_core_patterns <<< "$MIND_CORE_TEST_PATTERNS"
         read -r -a gameplay_core_patterns <<< "$GAMEPLAY_CORE_TEST_PATTERNS"
+        read -r -a support_patterns <<< "$SUPPORT_TEST_PATTERNS"
 
         case "$TEST_SHARD" in
           unit)
@@ -214,8 +257,13 @@ jobs:
             comparison="~"
             separator="|"
             ;;
-          validation-data)
-            patterns=("${validation_data_patterns[@]}")
+          validation-map)
+            patterns=("${validation_map_patterns[@]}")
+            comparison="~"
+            separator="|"
+            ;;
+          validation-serialization)
+            patterns=("${validation_serialization_patterns[@]}")
             comparison="~"
             separator="|"
             ;;
@@ -229,13 +277,23 @@ jobs:
             comparison="~"
             separator="|"
             ;;
-          minds)
-            patterns=("${mind_patterns[@]}")
+          ghost-role)
+            patterns=("${ghost_role_patterns[@]}")
+            comparison="~"
+            separator="|"
+            ;;
+          mind-core)
+            patterns=("${mind_core_patterns[@]}")
             comparison="~"
             separator="|"
             ;;
           gameplay-core)
             patterns=("${gameplay_core_patterns[@]}")
+            comparison="~"
+            separator="|"
+            ;;
+          support)
+            patterns=("${support_patterns[@]}")
             comparison="~"
             separator="|"
             ;;
@@ -246,11 +304,14 @@ jobs:
               "${atmos_tile_patterns[@]}"
               "${atmos_core_patterns[@]}"
               "${validation_core_patterns[@]}"
-              "${validation_data_patterns[@]}"
+              "${validation_map_patterns[@]}"
+              "${validation_serialization_patterns[@]}"
               "${world_patterns[@]}"
               "${action_patterns[@]}"
-              "${mind_patterns[@]}"
+              "${ghost_role_patterns[@]}"
+              "${mind_core_patterns[@]}"
               "${gameplay_core_patterns[@]}"
+              "${support_patterns[@]}"
             )
             comparison="!~"
             separator="&"

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -16,7 +16,11 @@ on:
 
 env:
   # Pirate: mapped groups run independently; every other integration test falls through to the unmapped shard.
-  ENTITY_TEST_PATTERNS: Content.IntegrationTests.Tests.EntityTest
+  ENTITY_HEAVY_TEST_PATTERNS: Content.IntegrationTests.Tests.EntityTest.SpawnAndDeleteAllEntitiesInTheSameSpot
+  ENTITY_REMAINING_TEST_PATTERNS: >-
+    Content.IntegrationTests.Tests.EntityTest.AllComponentsOneToOneDeleteTest
+    Content.IntegrationTests.Tests.EntityTest.SpawnAndDeleteEntityCountTest
+    Content.IntegrationTests.Tests.EntityTest.SpawnAndDeleteAllEntitiesOnDifferentMaps
   ATMOS_TILE_TEST_PATTERNS: Content.IntegrationTests.Tests.Atmos.TileAtmosphereTest
   ATMOS_CORE_TEST_PATTERNS: >-
     Content.IntegrationTests.Tests.Atmos.AirtightTest
@@ -29,19 +33,20 @@ env:
     Content.IntegrationTests.Tests.Atmos.GridJoinTest
     Content.IntegrationTests.Tests.Atmos.RoomSpacingTest
     Content.IntegrationTests.Tests.Atmos.SharedGasSpecificHeatsTest
-  VALIDATION_TEST_PATTERNS: >-
+  VALIDATION_CORE_TEST_PATTERNS: >-
     Content.IntegrationTests.Tests.ConfigPresetTests
     Content.IntegrationTests.Tests.Guidebook
     Content.IntegrationTests.Tests.Linter
     Content.IntegrationTests.Tests.Localization
+    Content.IntegrationTests.Tests.Sprite
+    Content.IntegrationTests.Tests.StartTest
+    Content.IntegrationTests.Tests.WizdenContentFreeze
+  VALIDATION_DATA_TEST_PATTERNS: >-
     Content.IntegrationTests.Tests.Mapping
     Content.IntegrationTests.Tests.PostMapInitTest
     Content.IntegrationTests.Tests.PrototypeSaveTest
     Content.IntegrationTests.Tests.PrototypeTests
     Content.IntegrationTests.Tests.SaveLoad
-    Content.IntegrationTests.Tests.Sprite
-    Content.IntegrationTests.Tests.StartTest
-    Content.IntegrationTests.Tests.WizdenContentFreeze
   WORLD_TEST_PATTERNS: >-
     Content.IntegrationTests.Tests.Chasm
     Content.IntegrationTests.Tests.Climbing
@@ -61,8 +66,9 @@ env:
     Content.IntegrationTests.Tests.Tiles
     Content.IntegrationTests.Tests.Weldable
     Content.IntegrationTests.Tests.Wires
-  GAMEPLAY_TEST_PATTERNS: >-
-    Content.IntegrationTests.Tests.Actions
+  ACTION_TEST_PATTERNS: Content.IntegrationTests.Tests.Actions
+  MIND_TEST_PATTERNS: Content.IntegrationTests.Tests.Minds
+  GAMEPLAY_CORE_TEST_PATTERNS: >-
     Content.IntegrationTests.Tests.Body
     Content.IntegrationTests.Tests.Buckle
     Content.IntegrationTests.Tests.Chemistry
@@ -72,7 +78,6 @@ env:
     Content.IntegrationTests.Tests.GameRules
     Content.IntegrationTests.Tests.Hands
     Content.IntegrationTests.Tests.Interaction
-    Content.IntegrationTests.Tests.Minds
     Content.IntegrationTests.Tests.Mousetrap
     Content.IntegrationTests.Tests.Movement
     Content.IntegrationTests.Tests.NPC
@@ -94,24 +99,36 @@ jobs:
           - name: Unit tests
             project: Content.Tests/Content.Tests.csproj
             shard: unit
-          - name: Entity integration tests
+          - name: Entity heavy integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: entity
+            shard: entity-heavy
+          - name: Entity remaining integration tests
+            project: Content.IntegrationTests/Content.IntegrationTests.csproj
+            shard: entity-remaining
           - name: Atmos tile integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: atmos-tile
           - name: Atmos core integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: atmos-core
-          - name: Validation integration tests
+          - name: Validation core integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: validation
+            shard: validation-core
+          - name: Validation data integration tests
+            project: Content.IntegrationTests/Content.IntegrationTests.csproj
+            shard: validation-data
           - name: World integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: world
-          - name: Gameplay integration tests
+          - name: Action integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: gameplay
+            shard: actions
+          - name: Mind integration tests
+            project: Content.IntegrationTests/Content.IntegrationTests.csproj
+            shard: minds
+          - name: Gameplay core integration tests
+            project: Content.IntegrationTests/Content.IntegrationTests.csproj
+            shard: gameplay-core
           - name: Unmapped integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: unmapped
@@ -157,19 +174,28 @@ jobs:
         test_args=(--no-build --configuration DebugOpt "$TEST_PROJECT")
         nunit_args=(NUnit.ConsoleOut=0)
 
-        read -r -a entity_patterns <<< "$ENTITY_TEST_PATTERNS"
+        read -r -a entity_heavy_patterns <<< "$ENTITY_HEAVY_TEST_PATTERNS"
+        read -r -a entity_remaining_patterns <<< "$ENTITY_REMAINING_TEST_PATTERNS"
         read -r -a atmos_tile_patterns <<< "$ATMOS_TILE_TEST_PATTERNS"
         read -r -a atmos_core_patterns <<< "$ATMOS_CORE_TEST_PATTERNS"
-        read -r -a validation_patterns <<< "$VALIDATION_TEST_PATTERNS"
+        read -r -a validation_core_patterns <<< "$VALIDATION_CORE_TEST_PATTERNS"
+        read -r -a validation_data_patterns <<< "$VALIDATION_DATA_TEST_PATTERNS"
         read -r -a world_patterns <<< "$WORLD_TEST_PATTERNS"
-        read -r -a gameplay_patterns <<< "$GAMEPLAY_TEST_PATTERNS"
+        read -r -a action_patterns <<< "$ACTION_TEST_PATTERNS"
+        read -r -a mind_patterns <<< "$MIND_TEST_PATTERNS"
+        read -r -a gameplay_core_patterns <<< "$GAMEPLAY_CORE_TEST_PATTERNS"
 
         case "$TEST_SHARD" in
           unit)
             patterns=()
             ;;
-          entity)
-            patterns=("${entity_patterns[@]}")
+          entity-heavy)
+            patterns=("${entity_heavy_patterns[@]}")
+            comparison="~"
+            separator="|"
+            ;;
+          entity-remaining)
+            patterns=("${entity_remaining_patterns[@]}")
             comparison="~"
             separator="|"
             ;;
@@ -183,8 +209,13 @@ jobs:
             comparison="~"
             separator="|"
             ;;
-          validation)
-            patterns=("${validation_patterns[@]}")
+          validation-core)
+            patterns=("${validation_core_patterns[@]}")
+            comparison="~"
+            separator="|"
+            ;;
+          validation-data)
+            patterns=("${validation_data_patterns[@]}")
             comparison="~"
             separator="|"
             ;;
@@ -193,19 +224,33 @@ jobs:
             comparison="~"
             separator="|"
             ;;
-          gameplay)
-            patterns=("${gameplay_patterns[@]}")
+          actions)
+            patterns=("${action_patterns[@]}")
+            comparison="~"
+            separator="|"
+            ;;
+          minds)
+            patterns=("${mind_patterns[@]}")
+            comparison="~"
+            separator="|"
+            ;;
+          gameplay-core)
+            patterns=("${gameplay_core_patterns[@]}")
             comparison="~"
             separator="|"
             ;;
           unmapped)
             patterns=(
-              "${entity_patterns[@]}"
+              "${entity_heavy_patterns[@]}"
+              "${entity_remaining_patterns[@]}"
               "${atmos_tile_patterns[@]}"
               "${atmos_core_patterns[@]}"
-              "${validation_patterns[@]}"
+              "${validation_core_patterns[@]}"
+              "${validation_data_patterns[@]}"
               "${world_patterns[@]}"
-              "${gameplay_patterns[@]}"
+              "${action_patterns[@]}"
+              "${mind_patterns[@]}"
+              "${gameplay_core_patterns[@]}"
             )
             comparison="!~"
             separator="&"

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -88,13 +88,10 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
-      # Pirate: leave two runner slots for packaging and map-renderer checks.
-      max-parallel: 8
+      # Pirate: leave runner slots for packaging, map-renderer, and short validation checks.
+      max-parallel: 7
       matrix:
         include:
-          - name: Unit tests
-            project: Content.Tests/Content.Tests.csproj
-            shard: unit
           - name: Entity integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: entity
@@ -104,9 +101,9 @@ jobs:
           - name: Validation map integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: validation-map
-          - name: World and atmos tile integration tests
+          - name: World, atmos tile, and unit tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: world
+            shard: world-unit
           - name: Mind integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: minds
@@ -166,9 +163,6 @@ jobs:
         read -r -a gameplay_patterns <<< "$GAMEPLAY_TEST_PATTERNS"
 
         case "$TEST_SHARD" in
-          unit)
-            patterns=()
-            ;;
           entity)
             patterns=("${entity_patterns[@]}")
             comparison="~"
@@ -184,7 +178,7 @@ jobs:
             comparison="~"
             separator="|"
             ;;
-          world)
+          world-unit)
             patterns=("${world_patterns[@]}")
             comparison="~"
             separator="|"
@@ -228,12 +222,14 @@ jobs:
           test_args+=(--filter "$test_filter")
         fi
 
-        if [[ "$TEST_SHARD" != "unit" ]]; then
-          test_args+=(--logger "console;verbosity=detailed")
-          nunit_args+=(NUnit.MapWarningTo=Failed)
-        fi
+        test_args+=(--logger "console;verbosity=detailed")
+        nunit_args+=(NUnit.MapWarningTo=Failed)
 
         dotnet test "${test_args[@]}" -- "${nunit_args[@]}"
+
+        if [[ "$TEST_SHARD" == "world-unit" ]]; then
+          dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0
+        fi
   ci-success:
     name: Build & Test Debug
     needs:

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -16,14 +16,8 @@ on:
 
 env:
   # Pirate: mapped groups run independently; every other integration test falls through to the unmapped shard.
-  ENTITY_HEAVY_TEST_PATTERNS: >-
-    Content.IntegrationTests.Tests.EntityTest.SpawnAndDeleteAllEntitiesInTheSameSpot
-    Content.IntegrationTests.Tests.EntityTest.SpawnAndDeleteAllEntitiesOnDifferentMaps
-  ENTITY_REMAINING_TEST_PATTERNS: >-
-    Content.IntegrationTests.Tests.EntityTest.AllComponentsOneToOneDeleteTest
-    Content.IntegrationTests.Tests.EntityTest.SpawnAndDeleteEntityCountTest
-  ATMOS_TILE_TEST_PATTERNS: Content.IntegrationTests.Tests.Atmos.TileAtmosphereTest
-  ATMOS_CORE_TEST_PATTERNS: >-
+  ENTITY_TEST_PATTERNS: Content.IntegrationTests.Tests.EntityTest
+  ATMOS_VALIDATION_TEST_PATTERNS: >-
     Content.IntegrationTests.Tests.Atmos.AirtightTest
     Content.IntegrationTests.Tests.Atmos.AlarmThresholdTest
     Content.IntegrationTests.Tests.Atmos.AtmosMonitoringTest
@@ -34,27 +28,20 @@ env:
     Content.IntegrationTests.Tests.Atmos.GridJoinTest
     Content.IntegrationTests.Tests.Atmos.RoomSpacingTest
     Content.IntegrationTests.Tests.Atmos.SharedGasSpecificHeatsTest
-  VALIDATION_CORE_TEST_PATTERNS: >-
     Content.IntegrationTests.Tests.ConfigPresetTests
     Content.IntegrationTests.Tests.Guidebook
     Content.IntegrationTests.Tests.Linter
     Content.IntegrationTests.Tests.Localization
-    Content.IntegrationTests.Tests.Sprite
-    Content.IntegrationTests.Tests.StartTest
-    Content.IntegrationTests.Tests.WizdenContentFreeze
-  VALIDATION_GAME_MAP_TEST_PATTERNS: Content.IntegrationTests.Tests.PostMapInitTest.GameMapsLoadableTest
-  VALIDATION_OTHER_MAP_TEST_PATTERNS: >-
-    Content.IntegrationTests.Tests.PostMapInitTest.AllMapsTested
-    Content.IntegrationTests.Tests.PostMapInitTest.GridsLoadableTest
-    Content.IntegrationTests.Tests.PostMapInitTest.NoSavedPostMapInitTest
-    Content.IntegrationTests.Tests.PostMapInitTest.NonGameMapsLoadableTest
-    Content.IntegrationTests.Tests.PostMapInitTest.ShuttlesLoadableTest
-  VALIDATION_SERIALIZATION_TEST_PATTERNS: >-
     Content.IntegrationTests.Tests.Mapping
     Content.IntegrationTests.Tests.PrototypeSaveTest
     Content.IntegrationTests.Tests.PrototypeTests
     Content.IntegrationTests.Tests.SaveLoad
+    Content.IntegrationTests.Tests.Sprite
+    Content.IntegrationTests.Tests.StartTest
+    Content.IntegrationTests.Tests.WizdenContentFreeze
+  VALIDATION_MAP_TEST_PATTERNS: Content.IntegrationTests.Tests.PostMapInitTest
   WORLD_TEST_PATTERNS: >-
+    Content.IntegrationTests.Tests.Atmos.TileAtmosphereTest
     Content.IntegrationTests.Tests.Chasm
     Content.IntegrationTests.Tests.Climbing
     Content.IntegrationTests.Tests.Construction
@@ -73,13 +60,9 @@ env:
     Content.IntegrationTests.Tests.Tiles
     Content.IntegrationTests.Tests.Weldable
     Content.IntegrationTests.Tests.Wires
-  ACTION_TEST_PATTERNS: Content.IntegrationTests.Tests.Actions
-  GHOST_ROLE_TEST_PATTERNS: Content.IntegrationTests.Tests.Minds.GhostRoleTests
-  MIND_CORE_TEST_PATTERNS: >-
-    Content.IntegrationTests.Tests.Minds.GhostTests
-    Content.IntegrationTests.Tests.Minds.MindTests
-    Content.IntegrationTests.Tests.Minds.RoleTests
-  GAMEPLAY_CORE_TEST_PATTERNS: >-
+  MIND_TEST_PATTERNS: Content.IntegrationTests.Tests.Minds
+  GAMEPLAY_TEST_PATTERNS: >-
+    Content.IntegrationTests.Tests.Actions
     Content.IntegrationTests.Tests.Body
     Content.IntegrationTests.Tests.Buckle
     Content.IntegrationTests.Tests.Chemistry
@@ -98,32 +81,6 @@ env:
     Content.IntegrationTests.Tests.Storage
     Content.IntegrationTests.Tests.Strip
     Content.IntegrationTests.Tests.Weapons
-  SUPPORT_TEST_PATTERNS: >-
-    Content.IntegrationTests.Tests.Access
-    Content.IntegrationTests.Tests.Chameleon
-    Content.IntegrationTests.Tests.Cleanup
-    Content.IntegrationTests.Tests.Cloning
-    Content.IntegrationTests.Tests.Commands
-    Content.IntegrationTests.Tests.DoAfter
-    Content.IntegrationTests.Tests.Embedding
-    Content.IntegrationTests.Tests.EncryptionKeys
-    Content.IntegrationTests.Tests.Engineering
-    Content.IntegrationTests.Tests.Goobstation
-    Content.IntegrationTests.Tests.Internals
-    Content.IntegrationTests.Tests.Lathe
-    Content.IntegrationTests.Tests.Lobby
-    Content.IntegrationTests.Tests.Materials
-    Content.IntegrationTests.Tests.Networking
-    Content.IntegrationTests.Tests.Payload
-    Content.IntegrationTests.Tests.Preferences
-    Content.IntegrationTests.Tests.Replays
-    Content.IntegrationTests.Tests.Serialization
-    Content.IntegrationTests.Tests.SmartFridge
-    Content.IntegrationTests.Tests.Tag
-    Content.IntegrationTests.Tests.Toolshed
-    Content.IntegrationTests.Tests.UserInterface
-    Content.IntegrationTests.Tests.Utility
-    Content.IntegrationTests.Tests.Vending
 
 jobs:
   tests:
@@ -131,53 +88,31 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
+      # Pirate: leave two runner slots for packaging and map-renderer checks.
+      max-parallel: 8
       matrix:
         include:
           - name: Unit tests
             project: Content.Tests/Content.Tests.csproj
             shard: unit
-          - name: Entity heavy integration tests
+          - name: Entity integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: entity-heavy
-          - name: Entity remaining integration tests
+            shard: entity
+          - name: Atmos and validation integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: entity-remaining
-          - name: Atmos tile integration tests
+            shard: atmos-validation
+          - name: Validation map integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: atmos-tile
-          - name: Atmos core integration tests
-            project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: atmos-core
-          - name: Validation core integration tests
-            project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: validation-core
-          - name: Validation game map integration tests
-            project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: validation-game-map
-          - name: Validation other map integration tests
-            project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: validation-other-map
-          - name: Validation serialization integration tests
-            project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: validation-serialization
-          - name: World integration tests
+            shard: validation-map
+          - name: World and atmos tile integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: world
-          - name: Action integration tests
+          - name: Mind integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: actions
-          - name: Ghost role integration tests
+            shard: minds
+          - name: Gameplay integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: ghost-role
-          - name: Mind core integration tests
-            project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: mind-core
-          - name: Gameplay core integration tests
-            project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: gameplay-core
-          - name: Support integration tests
-            project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: support
+            shard: gameplay
           - name: Unmapped integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: unmapped
@@ -223,62 +158,29 @@ jobs:
         test_args=(--no-build --configuration DebugOpt "$TEST_PROJECT")
         nunit_args=(NUnit.ConsoleOut=0)
 
-        read -r -a entity_heavy_patterns <<< "$ENTITY_HEAVY_TEST_PATTERNS"
-        read -r -a entity_remaining_patterns <<< "$ENTITY_REMAINING_TEST_PATTERNS"
-        read -r -a atmos_tile_patterns <<< "$ATMOS_TILE_TEST_PATTERNS"
-        read -r -a atmos_core_patterns <<< "$ATMOS_CORE_TEST_PATTERNS"
-        read -r -a validation_core_patterns <<< "$VALIDATION_CORE_TEST_PATTERNS"
-        read -r -a validation_game_map_patterns <<< "$VALIDATION_GAME_MAP_TEST_PATTERNS"
-        read -r -a validation_other_map_patterns <<< "$VALIDATION_OTHER_MAP_TEST_PATTERNS"
-        read -r -a validation_serialization_patterns <<< "$VALIDATION_SERIALIZATION_TEST_PATTERNS"
+        read -r -a entity_patterns <<< "$ENTITY_TEST_PATTERNS"
+        read -r -a atmos_validation_patterns <<< "$ATMOS_VALIDATION_TEST_PATTERNS"
+        read -r -a validation_map_patterns <<< "$VALIDATION_MAP_TEST_PATTERNS"
         read -r -a world_patterns <<< "$WORLD_TEST_PATTERNS"
-        read -r -a action_patterns <<< "$ACTION_TEST_PATTERNS"
-        read -r -a ghost_role_patterns <<< "$GHOST_ROLE_TEST_PATTERNS"
-        read -r -a mind_core_patterns <<< "$MIND_CORE_TEST_PATTERNS"
-        read -r -a gameplay_core_patterns <<< "$GAMEPLAY_CORE_TEST_PATTERNS"
-        read -r -a support_patterns <<< "$SUPPORT_TEST_PATTERNS"
+        read -r -a mind_patterns <<< "$MIND_TEST_PATTERNS"
+        read -r -a gameplay_patterns <<< "$GAMEPLAY_TEST_PATTERNS"
 
         case "$TEST_SHARD" in
           unit)
             patterns=()
             ;;
-          entity-heavy)
-            patterns=("${entity_heavy_patterns[@]}")
+          entity)
+            patterns=("${entity_patterns[@]}")
             comparison="~"
             separator="|"
             ;;
-          entity-remaining)
-            patterns=("${entity_remaining_patterns[@]}")
+          atmos-validation)
+            patterns=("${atmos_validation_patterns[@]}")
             comparison="~"
             separator="|"
             ;;
-          atmos-tile)
-            patterns=("${atmos_tile_patterns[@]}")
-            comparison="~"
-            separator="|"
-            ;;
-          atmos-core)
-            patterns=("${atmos_core_patterns[@]}")
-            comparison="~"
-            separator="|"
-            ;;
-          validation-core)
-            patterns=("${validation_core_patterns[@]}")
-            comparison="~"
-            separator="|"
-            ;;
-          validation-game-map)
-            patterns=("${validation_game_map_patterns[@]}")
-            comparison="~"
-            separator="|"
-            ;;
-          validation-other-map)
-            patterns=("${validation_other_map_patterns[@]}")
-            comparison="~"
-            separator="|"
-            ;;
-          validation-serialization)
-            patterns=("${validation_serialization_patterns[@]}")
+          validation-map)
+            patterns=("${validation_map_patterns[@]}")
             comparison="~"
             separator="|"
             ;;
@@ -287,47 +189,24 @@ jobs:
             comparison="~"
             separator="|"
             ;;
-          actions)
-            patterns=("${action_patterns[@]}")
+          minds)
+            patterns=("${mind_patterns[@]}")
             comparison="~"
             separator="|"
             ;;
-          ghost-role)
-            patterns=("${ghost_role_patterns[@]}")
-            comparison="~"
-            separator="|"
-            ;;
-          mind-core)
-            patterns=("${mind_core_patterns[@]}")
-            comparison="~"
-            separator="|"
-            ;;
-          gameplay-core)
-            patterns=("${gameplay_core_patterns[@]}")
-            comparison="~"
-            separator="|"
-            ;;
-          support)
-            patterns=("${support_patterns[@]}")
+          gameplay)
+            patterns=("${gameplay_patterns[@]}")
             comparison="~"
             separator="|"
             ;;
           unmapped)
             patterns=(
-              "${entity_heavy_patterns[@]}"
-              "${entity_remaining_patterns[@]}"
-              "${atmos_tile_patterns[@]}"
-              "${atmos_core_patterns[@]}"
-              "${validation_core_patterns[@]}"
-              "${validation_game_map_patterns[@]}"
-              "${validation_other_map_patterns[@]}"
-              "${validation_serialization_patterns[@]}"
+              "${entity_patterns[@]}"
+              "${atmos_validation_patterns[@]}"
+              "${validation_map_patterns[@]}"
               "${world_patterns[@]}"
-              "${action_patterns[@]}"
-              "${ghost_role_patterns[@]}"
-              "${mind_core_patterns[@]}"
-              "${gameplay_core_patterns[@]}"
-              "${support_patterns[@]}"
+              "${mind_patterns[@]}"
+              "${gameplay_patterns[@]}"
             )
             comparison="!~"
             separator="&"

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -17,7 +17,7 @@ on:
 env:
   # Pirate: mapped groups run independently; every other integration test falls through to the unmapped shard.
   ENTITY_TEST_PATTERNS: Content.IntegrationTests.Tests.EntityTest
-  ATMOS_SERIALIZATION_TEST_PATTERNS: >-
+  ATMOS_CORE_TEST_PATTERNS: >-
     Content.IntegrationTests.Tests.Atmos.AirtightTest
     Content.IntegrationTests.Tests.Atmos.AlarmThresholdTest
     Content.IntegrationTests.Tests.Atmos.AtmosMonitoringTest
@@ -28,6 +28,7 @@ env:
     Content.IntegrationTests.Tests.Atmos.GridJoinTest
     Content.IntegrationTests.Tests.Atmos.RoomSpacingTest
     Content.IntegrationTests.Tests.Atmos.SharedGasSpecificHeatsTest
+  VALIDATION_SERIALIZATION_TEST_PATTERNS: >-
     Content.IntegrationTests.Tests.Mapping
     Content.IntegrationTests.Tests.PrototypeSaveTest
     Content.IntegrationTests.Tests.PrototypeTests
@@ -88,16 +89,19 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
-      # Pirate: leave runner slots for packaging, map-renderer, and short validation checks.
-      max-parallel: 7
+      # Pirate: leave two runner slots for packaging and map-renderer checks.
+      max-parallel: 8
       matrix:
         include:
           - name: Entity integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: entity
-          - name: Atmos and serialization integration tests
+          - name: Atmos core integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
-            shard: atmos-serialization
+            shard: atmos-core
+          - name: Validation serialization integration tests
+            project: Content.IntegrationTests/Content.IntegrationTests.csproj
+            shard: validation-serialization
           - name: Validation map integration tests
             project: Content.IntegrationTests/Content.IntegrationTests.csproj
             shard: validation-map
@@ -156,7 +160,8 @@ jobs:
         nunit_args=(NUnit.ConsoleOut=0)
 
         read -r -a entity_patterns <<< "$ENTITY_TEST_PATTERNS"
-        read -r -a atmos_serialization_patterns <<< "$ATMOS_SERIALIZATION_TEST_PATTERNS"
+        read -r -a atmos_core_patterns <<< "$ATMOS_CORE_TEST_PATTERNS"
+        read -r -a validation_serialization_patterns <<< "$VALIDATION_SERIALIZATION_TEST_PATTERNS"
         read -r -a validation_map_patterns <<< "$VALIDATION_MAP_TEST_PATTERNS"
         read -r -a world_patterns <<< "$WORLD_TEST_PATTERNS"
         read -r -a mind_patterns <<< "$MIND_TEST_PATTERNS"
@@ -168,8 +173,13 @@ jobs:
             comparison="~"
             separator="|"
             ;;
-          atmos-serialization)
-            patterns=("${atmos_serialization_patterns[@]}")
+          atmos-core)
+            patterns=("${atmos_core_patterns[@]}")
+            comparison="~"
+            separator="|"
+            ;;
+          validation-serialization)
+            patterns=("${validation_serialization_patterns[@]}")
             comparison="~"
             separator="|"
             ;;
@@ -196,7 +206,8 @@ jobs:
           unmapped)
             patterns=(
               "${entity_patterns[@]}"
-              "${atmos_serialization_patterns[@]}"
+              "${atmos_core_patterns[@]}"
+              "${validation_serialization_patterns[@]}"
               "${validation_map_patterns[@]}"
               "${world_patterns[@]}"
               "${mind_patterns[@]}"


### PR DESCRIPTION
Перерозподіляє debug-тести на 8 збалансованих jobs із лімітом паралельності, щоб скоротити активний час і не забивати чергу runner-ів.

Unit-тести виконуються на вже зайнятому runner-і, а fallback shard зберігає покриття нових integration-тестів.