### PR TITLE
Fix старих хімдиспенсерів на мапах

### DIFF
--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -971,7 +971,7 @@ GhostBarSpawner: null
 DVSmartFridgeMedical: SmartFridgeMedical
 
 ## 2026-01-10 Goobstation Change Mapped Chem to Energy Chem by default
-#ChemDispenser: EnergyChemDispenser
+ChemDispenser: EnergyChemDispenser # Pirate
 # Edit: this was un-done at some point. wow.
 
 


### PR DESCRIPTION
Повертає міграцію `ChemDispenser` на `EnergyChemDispenser` для старих мап.

:cl:
- fix: Старі хімічні диспенсери на мапах замінено на енергетичні.