### PR TITLE
Fix Pirate shared Debug type check

### DIFF
--- a/Content.Pirate.Server/Nuclear/Reactor/NuclearReactorSystem.cs
+++ b/Content.Pirate.Server/Nuclear/Reactor/NuclearReactorSystem.cs
@@ -247,7 +247,7 @@ public sealed partial class NuclearReactorSystem : SharedNuclearReactorSystem
                     var ymod = ((dir >> 2) & 1) - (dir & 1);
 
                     if (x + xmod >= 0 && y + ymod >= 0 && x + xmod <= gridWidth - 1 && y + ymod <= gridHeight - 1)
-                        comp.GetFlux(x + xmod, y + ymod).Add(neutron);
+                        comp.FluxGrid[comp.GridIndex(x + xmod, y + ymod)].Add(neutron);
                     else
                         tempRads++; // neutrons hitting the casing become radiation, too much and it will bypass shielding
                     comp.FluxGrid[index].Remove(neutron);

--- a/Content.Pirate.Shared/Nuclear/Reactor/NuclearReactorComponent.cs
+++ b/Content.Pirate.Shared/Nuclear/Reactor/NuclearReactorComponent.cs
@@ -81,14 +81,6 @@ public sealed partial class NuclearReactorComponent : Component
     public NetEntity? GetPart(int x, int y)
         => IsInBounds(x, y) ? PartGrid[GridIndex(x, y)] : null;
 
-    public ref ValueList<ReactorNeutron> GetFlux(int x, int y)
-    {
-        if (!IsInBounds(x, y))
-            throw new ArgumentOutOfRangeException(nameof(x), $"Reactor grid position {x},{y} is out of bounds for {GridWidth}x{GridHeight}.");
-
-        return ref FluxGrid[GridIndex(x, y)];
-    }
-
     public void SetPart(int x, int y, NetEntity? part)
     {
         if (!IsInBounds(x, y))


### PR DESCRIPTION
Прибирає проблемне ref-повернення зі спільного компонента ядерного реактора, через яке Debug-клієнт падав під час IL-перевірки Content.Pirate.Shared.