### PR TITLE
Посилення меча ГСБ Justice

### DIFF
--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Belt/belts.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Belt/belts.yml
@@ -91,7 +91,7 @@
   components:
   - type: ContainerFill
     containers:
-      item:
+      storagebase: # Pirate: avoid a second container on the storage-enabled sheath.
       - Justice
 
 - type: entityTable

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Belt/belts.yml
@@ -166,7 +166,7 @@
 
 
 - type: entity
-  parent: ClothingBeltSheath
+  parent: [ClothingBeltStorageBase, BaseCommandContraband] # Pirate: use one storage container for Justice and belt gear.
   id: ClothingBeltSheathHeadOfSecurity
   name: head of security's sheath
   description: A rugged sheath, designed to hold the Head of Security's custom energy sword.
@@ -180,12 +180,16 @@
     size: Ginormous
   # Pirate: keep limited security storage so carrying Justice does not replace the whole duty belt.
   - type: Storage
-    maxItemSize: Normal
+    maxItemSize: Ginormous
     defaultStorageOrientation: Vertical
     grid:
     - 0,0,3,1
+    - 5,0,5,5
+    storageInsertSound: /Audio/Items/sheath.ogg
+    storageRemoveSound: /Audio/Items/unsheath.ogg
     whitelist:
       tags:
+      - Justice
       - CigPack
       - Taser
       - SecBeltEquip
@@ -212,27 +216,9 @@
       - Whistle
       - BalloonPopper
       - ScatteringGrenade
-  - type: ContainerContainer
-    containers:
-      item: !type:ContainerSlot
-      storagebase: !type:Container
-        ents: []
-  - type: UserInterface
-    interfaces:
-      enum.StorageUiKey.Key:
-        type: StorageBoundUserInterface
-  - type: ItemSlots
-    slots:
-      item:
-        name: Sabre
-        insertVerbText: sheath-insert-verb
-        ejectVerbText: sheath-eject-verb
-        insertSound: /Audio/Items/sheath.ogg
-        ejectSound: /Audio/Items/unsheath.ogg
-        whitelist:
-          tags:
-          - Justice
   - type: ItemMapper
+    containerWhitelist:
+    - storagebase
     mapLayers:
       sheath-sabre:
         whitelist:

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Belt/belts.yml
@@ -178,6 +178,49 @@
     sprite: _Goobstation/Clothing/Belt/hossheath.rsi
   - type: Item
     size: Ginormous
+  # Pirate: keep limited security storage so carrying Justice does not replace the whole duty belt.
+  - type: Storage
+    maxItemSize: Normal
+    defaultStorageOrientation: Vertical
+    grid:
+    - 0,0,3,1
+    whitelist:
+      tags:
+      - CigPack
+      - Taser
+      - SecBeltEquip
+      - Radio
+      - Sidearm
+      - MagazinePistol
+      - MagazineMagnum
+      - CombatKnife
+      - Truncheon
+      - BolaEnergy
+      - EnergySpeedloader
+      - MilitaryPowerCell
+      - EnergyMagAmmo
+      - HandGrenade
+      components:
+      - Stunbaton
+      - FlashOnTrigger
+      - SmokeOnTrigger
+      - Flash
+      - Handcuff
+      - BallisticAmmoProvider
+      - CartridgeAmmo
+      - DoorRemote
+      - Whistle
+      - BalloonPopper
+      - ScatteringGrenade
+  - type: ContainerContainer
+    containers:
+      item: !type:ContainerSlot
+      storagebase: !type:Container
+        ents: []
+  - type: UserInterface
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
   - type: ItemSlots
     slots:
       item:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/justice.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/justice.yml
@@ -9,6 +9,8 @@
   - type: Item
     sprite: _Goobstation/Objects/Weapons/Melee/justice.rsi
     size: Ginormous # Use your sheath.
+    shape:
+    - 0,0,0,5 # Pirate: reserve a narrow sheath region without adding general-purpose storage.
     heldPrefix: off
   - type: Sprite
     sprite: _Goobstation/Objects/Weapons/Melee/justice.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/justice.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/justice.yml
@@ -18,8 +18,8 @@
     startingCharge: 1000
   - type: ExaminableBattery # Pirate
   - type: BatterySelfRecharger
-    autoRechargeRate: 50
-    autoRechargePauseTime: 40
+    autoRechargeRate: 20 # Pirate: restores 12% charge every 6 seconds.
+    autoRechargePauseTime: 6 # Pirate
   - type: DisarmMalus
   - type: Tag
     tags:
@@ -35,6 +35,7 @@
   - type: MeleeWeapon
     wideAnimationRotation: -135
     attackRate: 1.5
+    clickDamageModifier: 1.5 # Pirate: reward precise strikes without buffing wide swings.
     damage:
       types:
         Slash: 12
@@ -82,6 +83,7 @@
         - type: MeleeWeapon
           wideAnimationRotation: -135
           attackRate: 1.5
+          clickDamageModifier: 1.5 # Pirate
           damage:
             types:
               Slash: 12
@@ -112,6 +114,8 @@
         - type: StaminaDamageOnHit
           damage: 20
           overtime: 15
+          lightAttackDamageMultiplier: 2 # Pirate: stronger precise stun strikes, as used downstream.
+          lightAttackOvertimeDamageMultiplier: 1 # Pirate
         soundStateActivate:
           collection: sparks
           params:
@@ -150,6 +154,7 @@
         - type: MeleeWeapon
           wideAnimationRotation: -135
           attackRate: 1.5
+          clickDamageModifier: 1.5 # Pirate
           damage:
             types:
               Slash: 6
@@ -167,7 +172,7 @@
 
       empowered: !type:ItemSwitchState
         verb: empowered
-        energyPerUse: 999
+        energyPerUse: 800 # Pirate: retain emergency charge after the empowered strike.
         sprite:
           sprite: _Goobstation/Objects/Weapons/Melee/justice.rsi
           state: empowered-icon
@@ -184,6 +189,7 @@
         - type: MeleeWeapon
           canWideSwing: false
           attackRate: 0.5
+          clickDamageModifier: 1.5 # Pirate
           animation: WeaponArcThrust
           damage:
             types:


### PR DESCRIPTION
Посилено Justice: швидший самозаряд, сильніші прицільні й стан-удари та запас заряду після вибухового режиму. Піхви отримали обмежене сховище для спорядження СБ.

:cl:
- tweak: Посилено меч ГСБ Justice та додано невелике сховище до його піхов.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Ножни голови служби безпеки тепер підтримують обмежене сховище для меча та спорядження, із коректним розміщенням предметів.
  * DT-2 «Justice» отримав окрему область резервних ножен.

* **Зміни балансу**
  * Переналаштовано автоматичне відновлення заряду «Justice».
  * Оновлено шкоду легких атак і натискання кнопки атаки.
  * Зменшено витрати енергії в посиленому режимі меча.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->