### PR TITLE
Прибрати віддачу від паперу НТтаску

### DIFF
--- a/Content.Shared/_Pirate/CartridgeLoader/Cartridges/NanoTaskPrintedThrowingSystem.cs
+++ b/Content.Shared/_Pirate/CartridgeLoader/Cartridges/NanoTaskPrintedThrowingSystem.cs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.CartridgeLoader.Cartridges;
+using Content.Shared.Throwing;
+
+namespace Content.Shared._Pirate.CartridgeLoader.Cartridges;
+
+public sealed class NanoTaskPrintedThrowingSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<NanoTaskPrintedComponent, ThrowPushbackAttemptEvent>(OnThrowPushbackAttempt);
+    }
+
+    private void OnThrowPushbackAttempt(
+        EntityUid uid,
+        NanoTaskPrintedComponent component,
+        ThrowPushbackAttemptEvent args)
+    {
+        args.Cancel();
+    }
+}


### PR DESCRIPTION
Прибрано можливість пересуватися у невагомості, кидаючи нескінченний папір із НТтаску.

:cl:
- fix: Папір, надрукований НТтаском, більше не можна використовувати для пересування у невагомості.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Додано захист надрукованих NanoTask від відкидання під час взаємодії.

* **Виправлення**
  * Спроби відкинути надруковані NanoTask тепер коректно скасовуються.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->