### PR TITLE
Fix cortical borer control and abilities

### DIFF
--- a/Content.Server/_Pirate/CorticalBorer/CorticalBorerSystem.cs
+++ b/Content.Server/_Pirate/CorticalBorer/CorticalBorerSystem.cs
@@ -25,6 +25,7 @@ using Content.Shared.Chat;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Database;
+using Content.Goobstation.Shared.Overlays;
 using Content.Shared.Inventory;
 using Content.Shared.MedicalScanner;
 using Content.Shared.Mind;
@@ -83,6 +84,8 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
     {
         foreach (var actionId in ent.Comp.InitialCorticalBorerActions)
             Actions.AddAction(ent, actionId);
+
+        EnsureThermalVisionAction(ent);
 
         _alerts.ShowAlert(ent.Owner, ent.Comp.ChemicalAlert);
         UpdateUiState(ent);
@@ -308,6 +311,7 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
         // Pirate: mark control only after moving the host's original mind. The move raises MindRemovedMessage,
         // which must not be treated as an unexpected loss of the host's mind during takeover.
         comp.ControlingHost = true;
+        AddControlThermalVision(worm, host, infested);
         _mind.TransferTo(wormMind, host);
 
         if (TryComp<GhostRoleComponent>(worm, out var ghostRole))
@@ -316,7 +320,7 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
         if (Actions.AddAction(host, EndControlAction) is { } endControl)
             infested.RemoveAbilities.Add(endControl);
 
-        if (comp.CanReproduce && infested.ControlTimeEnd is not null &&
+        if (comp.CanReproduce &&
             Actions.AddAction(host, LayEggAction) is { } layEgg)
         {
             infested.RemoveAbilities.Add(layEgg);
@@ -355,6 +359,8 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
 
         comp.ControlingHost = false;
 
+        RemoveControlThermalVision(host, infested);
+
         foreach (var ability in infested.RemoveAbilities)
             Actions.RemoveAction(host, ability);
         infested.RemoveAbilities.Clear();
@@ -386,6 +392,57 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
 
         infested.ControlTimeEnd = null;
         Container.CleanContainer(infested.ControlContainer);
+    }
+
+    private void EnsureThermalVisionAction(Entity<CorticalBorerComponent> ent)
+    {
+        if (!TryComp<ThermalVisionComponent>(ent, out var thermal) ||
+            thermal.ToggleAction is not { } toggleAction ||
+            thermal.ToggleActionEntity is not null)
+        {
+            return;
+        }
+
+        Actions.AddAction(ent, ref thermal.ToggleActionEntity, toggleAction);
+    }
+
+    private void AddControlThermalVision(EntityUid worm,
+        EntityUid host,
+        CorticalBorerInfestedComponent infested)
+    {
+        if (HasComp<ThermalVisionComponent>(host))
+            return;
+
+        var thermal = EnsureComp<ThermalVisionComponent>(host);
+        if (TryComp<ThermalVisionComponent>(worm, out var borerThermal))
+        {
+            thermal.Color = borerThermal.Color;
+            thermal.LightRadius = borerThermal.LightRadius;
+            thermal.ThermalShader = borerThermal.ThermalShader;
+            thermal.DrawOverlay = borerThermal.DrawOverlay;
+            thermal.OverlayOpacity = borerThermal.OverlayOpacity;
+        }
+
+        thermal.IsEquipment = false;
+        thermal.IsActive = true;
+        thermal.ActivateSound = null;
+        thermal.DeactivateSound = null;
+        if (thermal.ToggleAction is { } toggleAction)
+        {
+            Actions.AddAction(host, ref thermal.ToggleActionEntity, toggleAction);
+            Actions.SetToggled(thermal.ToggleActionEntity, true);
+        }
+        infested.AddedControlThermalVision = true;
+        Dirty(host, thermal);
+    }
+
+    private void RemoveControlThermalVision(EntityUid host, CorticalBorerInfestedComponent infested)
+    {
+        if (!infested.AddedControlThermalVision)
+            return;
+
+        infested.AddedControlThermalVision = false;
+        RemCompDeferred<ThermalVisionComponent>(host);
     }
 
     private void OnMindRemoved(Entity<CorticalBorerComponent> ent, ref MindRemovedMessage args)

--- a/Content.Server/_Pirate/CorticalBorer/CorticalBorerSystem.cs
+++ b/Content.Server/_Pirate/CorticalBorer/CorticalBorerSystem.cs
@@ -291,7 +291,6 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
         }
 
         infested.BorerMindId = wormMind;
-        comp.ControlingHost = true;
 
         if (_mind.TryGetMind(host, out var controlledMind, out _))
         {
@@ -306,6 +305,9 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
             infested.OriginalMindId = null;
         }
 
+        // Pirate: mark control only after moving the host's original mind. The move raises MindRemovedMessage,
+        // which must not be treated as an unexpected loss of the host's mind during takeover.
+        comp.ControlingHost = true;
         _mind.TransferTo(wormMind, host);
 
         if (TryComp<GhostRoleComponent>(worm, out var ghostRole))

--- a/Content.Shared/_Pirate/CorticalBorer/Components/CorticalBorerInfestedComponent.cs
+++ b/Content.Shared/_Pirate/CorticalBorer/Components/CorticalBorerInfestedComponent.cs
@@ -41,6 +41,9 @@ public sealed partial class CorticalBorerInfestedComponent : Component
 
     [ViewVariables]
     public ProtoId<CollectiveMindPrototype>? OldDefault;
+
+    [ViewVariables]
+    public bool AddedControlThermalVision;
 }
 
 [RegisterComponent, NetworkedComponent]

--- a/Resources/Prototypes/_Pirate/CorticalBorer/channels.yml
+++ b/Resources/Prototypes/_Pirate/CorticalBorer/channels.yml
@@ -4,11 +4,13 @@
   id: CorticalBorer
   name: collective-mind-borer
   keycode: 'z'
-  color: "#d842fc"
+  # Pirate: keep borer messages readable in the standard chat color.
+  color: "#D3D3D3"
 
 - type: radioChannel
   id: CorticalBorer
   name: chat-radio-cortical-borer
   keycode: 'z'
-  color: "#d842fc"
+  # Pirate: keep borer messages readable in the standard chat color.
+  color: "#D3D3D3"
   longRange: true

--- a/Resources/Prototypes/_Pirate/CorticalBorer/entities.yml
+++ b/Resources/Prototypes/_Pirate/CorticalBorer/entities.yml
@@ -91,6 +91,12 @@
     defaultChannel: CorticalBorer
   - type: Speech
     enabled: false
+  # Pirate: keep borer speech on the standard font; UniversalLanguageSpeaker otherwise selects Psychomantic.
+  - type: LanguageKnowledge
+    speaks:
+    - TauCetiBasic
+    understands:
+    - TauCetiBasic
   - type: HealthAnalyzer
     scanningEndSound:
       path: /Audio/Voice/Slime/slime_squish.ogg

--- a/Resources/Prototypes/_Pirate/CorticalBorer/entities.yml
+++ b/Resources/Prototypes/_Pirate/CorticalBorer/entities.yml
@@ -91,7 +91,9 @@
     defaultChannel: CorticalBorer
   - type: Speech
     enabled: false
-  # Pirate: keep borer speech on the standard font; UniversalLanguageSpeaker otherwise selects Psychomantic.
+  # Pirate: keep borer speech on the standard font while retaining universal understanding.
+  - type: LanguageSpeaker
+    currentLanguage: TauCetiBasic
   - type: LanguageKnowledge
     speaks:
     - TauCetiBasic


### PR DESCRIPTION
Виправлено контроль кортикального бурильника, тепловий зір і дію відкладання яйця. Репліки бурильника тепер використовують читабельний стандартний шрифт.

:cl:
- fix: Виправлено контроль і здібності кортикального бурильника

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Під час захоплення носія кортикальний бурильник передає йому термальне бачення з можливістю перемикання.
  * Після завершення контролю додане термальне бачення коректно прибирається.
  * Кортикальний бурильник тепер говорить і розуміє TauCetiBasic.

* **Виправлення**
  * Скориговано доступність дії розмноження під час контролю носія.
  * Повідомлення каналу бурильника отримали світліший, читабельніший колір.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->