### PR TITLE
Фікс приймання матеріалів силосом

### DIFF
--- a/Content.IntegrationTests/Tests/_Pirate/MaterialSiloTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/MaterialSiloTest.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Materials;
+
+namespace Content.IntegrationTests.Tests._Pirate;
+
+[TestFixture]
+[TestOf(typeof(SharedMaterialStorageSystem))]
+public sealed class MaterialSiloTest
+{
+    [Test]
+    public async Task AcceptsStandardMaterials()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.EntMan;
+        var materialStorage = server.System<SharedMaterialStorageSystem>();
+        var map = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var silo = entityManager.SpawnEntity("MachineMaterialSilo", map.GridCoords);
+            var materials = new[]
+            {
+                "SheetSteel1",
+                "SheetPlasma1",
+                "IngotGold1",
+                "MaterialDiamond1",
+                "MaterialCloth1",
+            };
+
+            Assert.Multiple(() =>
+            {
+                foreach (var prototype in materials)
+                {
+                    var material = entityManager.SpawnEntity(prototype, map.GridCoords);
+                    Assert.That(materialStorage.CanInsertMaterialEntity(material, silo),
+                        Is.True,
+                        $"Material silo does not accept {prototype}");
+                }
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -114,6 +114,9 @@
   - type: Tag # Goobstation
     tags:
     - SheetPlasma # Goobstation
+    - Sheet # Pirate: Preserve SheetOtherBase tags when adding SheetPlasma.
+    - ConstructionMaterial
+    - DroneUsable
 
 - type: entity
   parent: SheetPlasma

--- a/Resources/Prototypes/Entities/Structures/Machines/silo.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/silo.yml
@@ -21,6 +21,7 @@
     whitelist:
       tags:
       - Sheet
+      - RawMaterial # Pirate: Allow refined materials such as diamonds and cloth.
       - Ingot
   - type: ActivatableUI
     key: enum.OreSiloUiKey.Key


### PR DESCRIPTION
Силос матеріалів знову приймає плазму та сирі матеріали на кшталт алмазів і тканини.

:cl:
- fix: Силос матеріалів знову приймає плазму та інші валідні матеріали.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Матеріальний силос тепер приймає сировинні матеріали, зокрема перероблені матеріали.
  * Плазмові листи позначено як будівельні матеріали, придатні для використання дронами.

* **Тести**
  * Додано інтеграційні перевірки приймання стандартних матеріалів матеріальним силосом.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->