### PR TITLE
Обмежити кортикального бурильника одним яйцем

### DIFF
--- a/Content.Server/_Pirate/CorticalBorer/CorticalBorerSystem.Abilities.cs
+++ b/Content.Server/_Pirate/CorticalBorer/CorticalBorerSystem.Abilities.cs
@@ -207,6 +207,9 @@ public sealed partial class CorticalBorerSystem
             return;
 
         var borer = host.Comp.Borer;
+        if (!borer.Comp.CanReproduce || borer.Comp.HasLaidEgg)
+            return;
+
         if (borer.Comp.EggCost > borer.Comp.ChemicalPoints)
         {
             Popup.PopupEntity(Loc.GetString("cortical-borer-not-enough-chem"), host, host, PopupType.Medium);
@@ -215,7 +218,16 @@ public sealed partial class CorticalBorerSystem
 
         _vomit.Vomit(host, -20, -20);
         LayEgg(borer);
+        borer.Comp.HasLaidEgg = true;
         UpdateChems(borer, -borer.Comp.EggCost);
+
+        if (host.Comp.LayEggAction is { } layEggAction)
+        {
+            Actions.RemoveAction(host.Owner, layEggAction);
+            host.Comp.RemoveAbilities.Remove(layEggAction);
+            host.Comp.LayEggAction = null;
+        }
+
         args.Handled = true;
     }
 }

--- a/Content.Server/_Pirate/CorticalBorer/CorticalBorerSystem.cs
+++ b/Content.Server/_Pirate/CorticalBorer/CorticalBorerSystem.cs
@@ -320,9 +320,10 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
         if (Actions.AddAction(host, EndControlAction) is { } endControl)
             infested.RemoveAbilities.Add(endControl);
 
-        if (comp.CanReproduce &&
+        if (comp.CanReproduce && !comp.HasLaidEgg &&
             Actions.AddAction(host, LayEggAction) is { } layEgg)
         {
+            infested.LayEggAction = layEgg;
             infested.RemoveAbilities.Add(layEgg);
         }
 
@@ -364,6 +365,7 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
         foreach (var ability in infested.RemoveAbilities)
             Actions.RemoveAction(host, ability);
         infested.RemoveAbilities.Clear();
+        infested.LayEggAction = null;
 
         if (infested.RemovedReformAction is not null && TryComp<ReformComponent>(host, out var reform))
         {

--- a/Content.Shared/_Pirate/CorticalBorer/Components/CorticalBorerComponent.cs
+++ b/Content.Shared/_Pirate/CorticalBorer/Components/CorticalBorerComponent.cs
@@ -45,6 +45,9 @@ public sealed partial class CorticalBorerComponent : Component
     [ViewVariables(VVAccess.ReadWrite), DataField]
     public bool CanReproduce = true;
 
+    [ViewVariables]
+    public bool HasLaidEgg;
+
     [ViewVariables(VVAccess.ReadWrite), DataField]
     public EntProtoId EggProto = "CorticalBorerEgg";
 

--- a/Content.Shared/_Pirate/CorticalBorer/Components/CorticalBorerInfestedComponent.cs
+++ b/Content.Shared/_Pirate/CorticalBorer/Components/CorticalBorerInfestedComponent.cs
@@ -34,6 +34,8 @@ public sealed partial class CorticalBorerInfestedComponent : Component
 
     public List<EntityUid> RemoveAbilities = new();
 
+    public EntityUid? LayEggAction;
+
     public EntityUid? RemovedReformAction;
 
     [ViewVariables]


### PR DESCRIPTION
Кортикальний бурильник тепер може відкласти лише одне яйце за життя.

:cl:
- tweak: Кортикальні бурильники можуть відкладати лише одне яйце.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Виправлення помилок**
  * Запобігано повторному відкладанню яйця одним кортикальним бурильником.
  * Здатність відкладання яйця більше не надається після її використання.
  * Після завершення контролю тимчасова здатність коректно видаляється.
  * Після відкладання яйця оновлюється хімія та прибирається пов’язана здатність у носія.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->