### PR TITLE
Додати аварійну зупинку реактора й турбіни

### DIFF
--- a/Content.Pirate.Client/Nuclear/Reactor/UI/NuclearReactorBUI.cs
+++ b/Content.Pirate.Client/Nuclear/Reactor/UI/NuclearReactorBUI.cs
@@ -24,6 +24,7 @@ public sealed class NuclearReactorBUI(EntityUid owner, Enum uiKey) : BoundUserIn
         _window.OnSwapPart += pos => SendPredictedMessage(new ReactorSwapPartMessage(pos));
         _window.OnEjectItem += () => SendPredictedMessage(new ReactorEjectItemMessage());
         _window.OnAdjustControlRods += change => SendPredictedMessage(new ReactorAdjustControlRodsMessage(change));
+        _window.OnEmergencyShutdown += () => SendPredictedMessage(new ReactorAdjustControlRodsMessage(2f));
 
         if (State is NuclearReactorBuiState state)
             _window.Update(state);

--- a/Content.Pirate.Client/Nuclear/Reactor/UI/NuclearReactorWindow.xaml
+++ b/Content.Pirate.Client/Nuclear/Reactor/UI/NuclearReactorWindow.xaml
@@ -127,6 +127,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 								<Button Name="ControlRodsInsert" Text=" + "/>
 								<Button Name="ControlRodsRemove" Text=" - "/>
 								<Button Name="ControlRodsRemoveLarge" Text="- -"/>
+								<Button Name="EmergencyShutdown" Text="{Loc nuclear-machine-ui-emergency-shutdown}"
+										StyleClasses="Caution" Margin="0 5 0 0"/>
 							</BoxContainer>
 							<Label Name="ControlRodsLock" Text="{Loc comp-nuclear-reactor-ui-locked}" Visible="false" HorizontalAlignment="Center" VerticalAlignment="Center" />
 						</controls:StripeBack>

--- a/Content.Pirate.Client/Nuclear/Reactor/UI/NuclearReactorWindow.xaml.cs
+++ b/Content.Pirate.Client/Nuclear/Reactor/UI/NuclearReactorWindow.xaml.cs
@@ -57,6 +57,7 @@ public sealed partial class NuclearReactorWindow : FancyWindow
     public event Action<Vector2i>? OnSwapPart;
     public event Action? OnEjectItem;
     public event Action<float>? OnAdjustControlRods;
+    public event Action? OnEmergencyShutdown;
 
     private readonly float _repeatDelay = 0.5f;
     private readonly Dictionary<Button, float> _repeatQueue = [];
@@ -96,6 +97,8 @@ public sealed partial class NuclearReactorWindow : FancyWindow
         ControlRodsRemoveLarge.OnButtonDown += _ => _repeatQueue[ControlRodsRemoveLarge] = _repeatDelay;
         ControlRodsRemoveLarge.OnButtonUp += _ => _repeatQueue.Remove(ControlRodsRemoveLarge);
 
+        EmergencyShutdown.OnPressed += _ => OnEmergencyShutdown?.Invoke();
+
         TargetTemperature.OnPressed += _ => ChangeTemp();
     }
 
@@ -133,6 +136,7 @@ public sealed partial class NuclearReactorWindow : FancyWindow
         ControlRodsValue.Text = Math.Round(msg.AverageControlRodInsertion * 50, 1).ToString() + "%";
         ControlRodsActual.Value = msg.AverageControlRodInsertion;
         ControlRodsSet.Value = msg.ControlRodInsertion;
+        EmergencyShutdown.Disabled = msg.ControlRodInsertion >= 2f;
 
         _hasItem = msg.PartSlotItemName != null;
         ItemName.Text = msg.PartSlotItemName ?? Loc.GetString("comp-nuclear-reactor-ui-empty");

--- a/Content.Pirate.Client/Nuclear/Turbine/UI/TurbineBUI.cs
+++ b/Content.Pirate.Client/Nuclear/Turbine/UI/TurbineBUI.cs
@@ -23,6 +23,7 @@ public sealed partial class TurbineBUI(EntityUid owner, Enum uiKey) : BoundUserI
 
         _window.OnChangeFlowRate += val => SendPredictedMessage(new TurbineChangeFlowRateMessage(val));
         _window.OnChangeStatorLoad += val => SendPredictedMessage(new TurbineChangeStatorLoadMessage(val));
+        _window.OnEmergencyShutdown += () => SendPredictedMessage(new TurbineChangeFlowRateMessage(0f));
 
         if (State is TurbineBuiState state)
             _window.Update(state);

--- a/Content.Pirate.Client/Nuclear/Turbine/UI/TurbineWindow.xaml
+++ b/Content.Pirate.Client/Nuclear/Turbine/UI/TurbineWindow.xaml
@@ -74,6 +74,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 									</BoxContainer>
 								</BoxContainer>
 							</PanelContainer>
+
+							<Button Name="EmergencyShutdown" Text="{Loc nuclear-machine-ui-emergency-shutdown}"
+									StyleClasses="Caution"/>
 						</BoxContainer>
 						<Label Name="LockedMessage" Text="{Loc comp-turbine-ui-locked-message}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
 					</controls:StripeBack>

--- a/Content.Pirate.Client/Nuclear/Turbine/UI/TurbineWindow.xaml.cs
+++ b/Content.Pirate.Client/Nuclear/Turbine/UI/TurbineWindow.xaml.cs
@@ -63,6 +63,7 @@ public sealed partial class TurbineWindow : FancyWindow
     #region Events
     public event Action<float>? OnChangeFlowRate;
     public event Action<float>? OnChangeStatorLoad;
+    public event Action? OnEmergencyShutdown;
     #endregion
 
     public TurbineWindow()
@@ -112,6 +113,8 @@ public sealed partial class TurbineWindow : FancyWindow
         StatorLoadIncreaseLarge.OnPressed += _ => OnChangeStatorLoad?.Invoke(_statorLoad + 1000);
         StatorLoadIncreaseLarge.OnButtonDown += _ => _repeatQueue[StatorLoadIncreaseLarge] = _repeatDelay;
         StatorLoadIncreaseLarge.OnButtonUp += _ => _repeatQueue.Remove(StatorLoadIncreaseLarge);
+
+        EmergencyShutdown.OnPressed += _ => OnEmergencyShutdown?.Invoke();
 
         CTabContainer.SetTabTitle(0, Loc.GetString("comp-turbine-ui-tab-main"));
         CTabContainer.SetTabTitle(1, Loc.GetString("comp-turbine-ui-tab-parts"));
@@ -200,6 +203,7 @@ public sealed partial class TurbineWindow : FancyWindow
         TurbineFlowRateSlider.MaxValue = state.MaximumFlowRate;
         TurbineFlowRateSlider.Value = state.FlowRate;
         _suppressSliderEvents = false;
+        EmergencyShutdown.Disabled = state.FlowRate <= 0f;
 
         _speedLevel = ContentHelpers.RoundToNearestLevels(state.Rpm, state.BestRpm * 1.2, _speedMeter.Length);
 

--- a/Resources/Locale/uk-UA/_Pirate/nuclear/nuclear.ftl
+++ b/Resources/Locale/uk-UA/_Pirate/nuclear/nuclear.ftl
@@ -3,6 +3,7 @@
 nuclear-reactor-window-title = Ядерний реактор
 gas-turbine-window-title = Газова турбіна
 nuclear-machine-invalid-anchoring = Неможливо закріпити машину в цьому положенні!
+nuclear-machine-ui-emergency-shutdown = Аварійна зупинка
 
 ### Ядерна центрифуга
 


### PR DESCRIPTION
Додано окремі кнопки аварійної зупинки: реактор повністю вводить керувальні стрижні, а турбіна перекриває потік. Команди працюють і через підключені консолі.

:cl:
- add: Консолі реактора й турбіни отримали дистанційну аварійну зупинку.