### PR TITLE
Fix cyberdeck projection visibility for robots and ghosts

### DIFF
--- a/Content.Pirate.Shared/Cyberdeck/SharedCyberdeckSystem.Projection.cs
+++ b/Content.Pirate.Shared/Cyberdeck/SharedCyberdeckSystem.Projection.cs
@@ -18,6 +18,23 @@ public abstract partial class SharedCyberdeckSystem
     {
         SubscribeLocalEvent<CyberdeckUserComponent, CyberdeckVisionEvent>(OnCyberVisionUsed);
         SubscribeLocalEvent<CyberdeckUserComponent, CyberdeckVisionReturnEvent>(OnCyberVisionReturn);
+        SubscribeLocalEvent<CyberdeckSiliconTargetComponent, GetVisMaskEvent>(OnSiliconGetVisMask);
+        SubscribeLocalEvent<CyberdeckSiliconTargetComponent, MapInitEvent>(OnSiliconMapInit);
+    }
+
+    private static void OnSiliconGetVisMask(
+        Entity<CyberdeckSiliconTargetComponent> ent,
+        ref GetVisMaskEvent args)
+    {
+        args.VisibilityMask |= (int) VisibilityFlags.StationAiNetwork;
+    }
+
+    private void OnSiliconMapInit(Entity<CyberdeckSiliconTargetComponent> ent, ref MapInitEvent args)
+    {
+        if (_net.IsClient || !TryComp(ent, out EyeComponent? eye))
+            return;
+
+        _eye.RefreshVisibilityMask((ent.Owner, eye));
     }
 
     private void AttachToProjection(Entity<CyberdeckUserComponent> user)

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -139,6 +139,7 @@ namespace Content.Server.Ghost
             if (ent.Comp.LifeStage <= ComponentLifeStage.Running)
             {
                 args.VisibilityMask |= (int)VisibilityFlags.Ghost;
+                args.VisibilityMask |= (int)VisibilityFlags.StationAiNetwork; // Pirate - Cyberdeck projections
                 // Begin DeltaV additions
                 args.VisibilityMask |= (int)VisibilityFlags.CosmicCultMonument;
                 // End DeltaV additions


### PR DESCRIPTION
Виправлено маски видимості проєкції кібердека для роботів і привидів.

:cl:
- fix: Роботи та привиди тепер бачать проєкцію кібердека в режимі камер.