### PR TITLE
Додати банківську програму в КПК мантіса

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Objects/Devices/pda.yml
@@ -15,3 +15,4 @@
      - NanoChatCartridge
      - PsiWatchCartridge
      - NanoTaskCartridge
+     - WalletCartridge # Pirate banking


### PR DESCRIPTION
Додає банківську програму до переліку встановлених програм КПК мантіса.

:cl:
- fix: Додано банківську програму до КПК мантіса.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Нові можливості**
  - До наукового КПК додано попередньо встановлений картридж гаманця для підтримки піратського банкінгу.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->