### PR TITLE
Передавати зір кортикального бурильника носію

### DIFF
--- a/Content.Server/_Pirate/CorticalBorer/CorticalBorerInfestedSystem.cs
+++ b/Content.Server/_Pirate/CorticalBorer/CorticalBorerInfestedSystem.cs
@@ -123,5 +123,6 @@ public sealed class CorticalBorerInfestedSystem : EntitySystem
         _borer.EndControl(borer, args.NewEntity);
         _borer.TryEjectBorer(borer);
         _borer.InfestTarget(borer, args.NewEntity);
+        _borer.SyncHostVision(borer);
     }
 }

--- a/Content.Server/_Pirate/CorticalBorer/CorticalBorerSystem.Abilities.cs
+++ b/Content.Server/_Pirate/CorticalBorer/CorticalBorerSystem.Abilities.cs
@@ -126,6 +126,7 @@ public sealed partial class CorticalBorerSystem
 
         _flammable.Extinguish(ent);
         InfestTarget(ent, target);
+        SyncHostVision(ent);
         args.Handled = true;
     }
 

--- a/Content.Server/_Pirate/CorticalBorer/CorticalBorerSystem.Vision.cs
+++ b/Content.Server/_Pirate/CorticalBorer/CorticalBorerSystem.Vision.cs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Goobstation.Shared.Overlays;
+using Content.Shared._Pirate.CorticalBorer;
+
+namespace Content.Server._Pirate.CorticalBorer;
+
+public sealed partial class CorticalBorerSystem
+{
+    private void SubscribeVision()
+    {
+        SubscribeLocalEvent<NightVisionComponent, SwitchableOverlayToggledEvent>(OnNightVisionToggled);
+        SubscribeLocalEvent<ThermalVisionComponent, SwitchableOverlayToggledEvent>(OnThermalVisionToggled);
+    }
+
+    private void OnNightVisionToggled(Entity<NightVisionComponent> ent, ref SwitchableOverlayToggledEvent args)
+    {
+        if (!TryComp<CorticalBorerComponent>(ent, out var borer))
+            return;
+
+        SyncHostNightVision((ent.Owner, borer), ent.Comp);
+    }
+
+    private void OnThermalVisionToggled(Entity<ThermalVisionComponent> ent, ref SwitchableOverlayToggledEvent args)
+    {
+        if (!TryComp<CorticalBorerComponent>(ent, out var borer))
+            return;
+
+        SyncHostThermalVision((ent.Owner, borer), ent.Comp);
+    }
+
+    public void SyncHostVision(Entity<CorticalBorerComponent> borer)
+    {
+        if (TryComp<NightVisionComponent>(borer, out var nightVision))
+            SyncHostNightVision(borer, nightVision);
+
+        if (TryComp<ThermalVisionComponent>(borer, out var thermalVision))
+            SyncHostThermalVision(borer, thermalVision);
+    }
+
+    private void SyncHostNightVision(Entity<CorticalBorerComponent> borer, NightVisionComponent borerVision)
+    {
+        if (!TryGetHost(borer, out var host, out var infested))
+            return;
+
+        if (!IsVisionActive(borerVision))
+        {
+            RestoreHostNightVision(host, infested);
+            return;
+        }
+
+        if (!TryComp<NightVisionComponent>(host, out var hostVision))
+        {
+            hostVision = EnsureComp<NightVisionComponent>(host);
+            infested.AddedBorerNightVision = true;
+            ConfigureGrantedVision(host, hostVision, borerVision);
+        }
+        else if (!infested.AddedBorerNightVision && infested.PreviousHostNightVisionActive is null)
+        {
+            infested.PreviousHostNightVisionActive = hostVision.IsActive;
+        }
+
+        SetVisionActive(host, hostVision, true);
+    }
+
+    private void SyncHostThermalVision(Entity<CorticalBorerComponent> borer, ThermalVisionComponent borerVision)
+    {
+        if (!TryGetHost(borer, out var host, out var infested))
+            return;
+
+        if (!IsVisionActive(borerVision))
+        {
+            RestoreHostThermalVision(host, infested);
+            return;
+        }
+
+        if (!TryComp<ThermalVisionComponent>(host, out var hostVision))
+        {
+            hostVision = EnsureComp<ThermalVisionComponent>(host);
+            infested.AddedBorerThermalVision = true;
+            ConfigureGrantedVision(host, hostVision, borerVision);
+        }
+        else if (infested.AddedControlThermalVision)
+        {
+            infested.AddedBorerThermalVision = true;
+        }
+        else if (!infested.AddedBorerThermalVision &&
+                 infested.PreviousHostThermalVisionActive is null)
+        {
+            infested.PreviousHostThermalVisionActive = hostVision.IsActive;
+        }
+
+        SetVisionActive(host, hostVision, true);
+    }
+
+    private bool TryGetHost(Entity<CorticalBorerComponent> borer,
+        out EntityUid host,
+        out CorticalBorerInfestedComponent infested)
+    {
+        if (borer.Comp.Host is { } currentHost &&
+            TryComp<CorticalBorerInfestedComponent>(currentHost, out infested) &&
+            infested.Borer.Owner == borer.Owner)
+        {
+            host = currentHost;
+            return true;
+        }
+
+        host = default;
+        infested = default!;
+        return false;
+    }
+
+    private static bool IsVisionActive(SwitchableVisionOverlayComponent vision)
+    {
+        return vision.IsActive || vision.PulseTime > 0f && vision.PulseAccumulator < vision.PulseTime;
+    }
+
+    private void ConfigureGrantedVision(EntityUid host,
+        SwitchableVisionOverlayComponent hostVision,
+        SwitchableVisionOverlayComponent borerVision)
+    {
+        Actions.RemoveAction(host, hostVision.ToggleActionEntity);
+        hostVision.ToggleActionEntity = null;
+        hostVision.ToggleAction = null;
+        hostVision.IsEquipment = false;
+        hostVision.Color = borerVision.Color;
+        hostVision.Tint = borerVision.Tint;
+        hostVision.Strength = borerVision.Strength;
+        hostVision.Noise = borerVision.Noise;
+        hostVision.DrawOverlay = borerVision.DrawOverlay;
+        hostVision.OverlayOpacity = borerVision.OverlayOpacity;
+        hostVision.FlashDurationMultiplier = borerVision.FlashDurationMultiplier;
+        hostVision.ActivateSound = null;
+        hostVision.DeactivateSound = null;
+
+        if (hostVision is ThermalVisionComponent hostThermal &&
+            borerVision is ThermalVisionComponent borerThermal)
+        {
+            hostThermal.LightRadius = borerThermal.LightRadius;
+            hostThermal.ThermalShader = borerThermal.ThermalShader;
+        }
+    }
+
+    private void SetVisionActive(EntityUid host, SwitchableVisionOverlayComponent vision, bool active)
+    {
+        vision.IsActive = active;
+        if (vision.PulseTime <= 0f)
+            Actions.SetToggled(vision.ToggleActionEntity, active);
+
+        Dirty(host, vision);
+    }
+
+    private void RestoreHostNightVision(EntityUid host, CorticalBorerInfestedComponent infested)
+    {
+        if (infested.AddedBorerNightVision)
+        {
+            infested.AddedBorerNightVision = false;
+            RemCompDeferred<NightVisionComponent>(host);
+        }
+        else if (infested.PreviousHostNightVisionActive is { } wasActive &&
+                 TryComp<NightVisionComponent>(host, out var hostVision))
+        {
+            SetVisionActive(host, hostVision, wasActive);
+        }
+
+        infested.PreviousHostNightVisionActive = null;
+    }
+
+    private void RestoreHostThermalVision(EntityUid host, CorticalBorerInfestedComponent infested)
+    {
+        if (infested.AddedBorerThermalVision)
+        {
+            infested.AddedBorerThermalVision = false;
+            if (!infested.AddedControlThermalVision)
+                RemCompDeferred<ThermalVisionComponent>(host);
+        }
+        else if (infested.PreviousHostThermalVisionActive is { } wasActive &&
+                 TryComp<ThermalVisionComponent>(host, out var hostVision))
+        {
+            SetVisionActive(host, hostVision, wasActive);
+        }
+
+        infested.PreviousHostThermalVisionActive = null;
+    }
+
+    private void ClearHostVision(EntityUid host, CorticalBorerInfestedComponent infested)
+    {
+        RestoreHostNightVision(host, infested);
+        RestoreHostThermalVision(host, infested);
+    }
+}

--- a/Content.Server/_Pirate/CorticalBorer/CorticalBorerSystem.Vision.cs
+++ b/Content.Server/_Pirate/CorticalBorer/CorticalBorerSystem.Vision.cs
@@ -98,10 +98,11 @@ public sealed partial class CorticalBorerSystem
         out CorticalBorerInfestedComponent infested)
     {
         if (borer.Comp.Host is { } currentHost &&
-            TryComp<CorticalBorerInfestedComponent>(currentHost, out infested) &&
-            infested.Borer.Owner == borer.Owner)
+            TryComp<CorticalBorerInfestedComponent>(currentHost, out var currentInfested) &&
+            currentInfested.Borer.Owner == borer.Owner)
         {
             host = currentHost;
+            infested = currentInfested;
             return true;
         }
 

--- a/Content.Server/_Pirate/CorticalBorer/CorticalBorerSystem.cs
+++ b/Content.Server/_Pirate/CorticalBorer/CorticalBorerSystem.cs
@@ -69,6 +69,7 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
         base.Initialize();
 
         SubscribeAbilities();
+        SubscribeVision();
         SubscribeLocalEvent<CorticalBorerComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<CorticalBorerComponent, CorticalBorerDispenserInjectMessage>(OnInjectReagentMessage);
         SubscribeLocalEvent<CorticalBorerComponent, CorticalBorerDispenserSetInjectAmountMessage>(OnSetInjectAmountMessage);
@@ -78,6 +79,7 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
         SubscribeLocalEvent<CorticalBorerComponent, ModifyChangedTemperatureEvent>(OnTemperatureChange);
         SubscribeLocalEvent<CorticalBorerComponent, TryIgniteEvent>(OnIgniteAttempt);
         SubscribeLocalEvent<CorticalBorerComponent, CorticalBorerEjectingEvent>(OnEjecting);
+        SubscribeLocalEvent<CorticalBorerComponent, CorticalBorerEjectedEvent>(OnEjected);
     }
 
     private void OnStartup(Entity<CorticalBorerComponent> ent, ref ComponentStartup args)
@@ -417,10 +419,20 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
         EntityUid host,
         CorticalBorerInfestedComponent infested)
     {
-        if (HasComp<ThermalVisionComponent>(host))
-            return;
+        ThermalVisionComponent thermal;
+        if (TryComp<ThermalVisionComponent>(host, out var existingThermal))
+        {
+            if (!infested.AddedBorerThermalVision)
+                return;
 
-        var thermal = EnsureComp<ThermalVisionComponent>(host);
+            thermal = existingThermal;
+        }
+        else
+        {
+            thermal = EnsureComp<ThermalVisionComponent>(host);
+        }
+
+        infested.AddedControlThermalVision = true;
         if (TryComp<ThermalVisionComponent>(worm, out var borerThermal))
         {
             thermal.Color = borerThermal.Color;
@@ -428,6 +440,7 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
             thermal.ThermalShader = borerThermal.ThermalShader;
             thermal.DrawOverlay = borerThermal.DrawOverlay;
             thermal.OverlayOpacity = borerThermal.OverlayOpacity;
+            thermal.ToggleAction = borerThermal.ToggleAction;
         }
 
         thermal.IsEquipment = false;
@@ -439,7 +452,6 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
             Actions.AddAction(host, ref thermal.ToggleActionEntity, toggleAction);
             Actions.SetToggled(thermal.ToggleActionEntity, true);
         }
-        infested.AddedControlThermalVision = true;
         Dirty(host, thermal);
     }
 
@@ -449,6 +461,16 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
             return;
 
         infested.AddedControlThermalVision = false;
+
+        if (infested.AddedBorerThermalVision &&
+            TryComp<ThermalVisionComponent>(infested.Borer, out var borerThermal) &&
+            TryComp<ThermalVisionComponent>(host, out var hostThermal))
+        {
+            ConfigureGrantedVision(host, hostThermal, borerThermal);
+            SetVisionActive(host, hostThermal, true);
+            return;
+        }
+
         RemCompDeferred<ThermalVisionComponent>(host);
     }
 
@@ -477,5 +499,14 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
 
         if (ent.Comp.ControlingHost)
             EndControl(ent);
+    }
+
+    private void OnEjected(Entity<CorticalBorerComponent> ent, ref CorticalBorerEjectedEvent args)
+    {
+        if (TryComp<CorticalBorerInfestedComponent>(args.Host, out var infested) &&
+            infested.Borer.Owner == ent.Owner)
+        {
+            ClearHostVision(args.Host, infested);
+        }
     }
 }

--- a/Content.Shared/_Pirate/CorticalBorer/Components/CorticalBorerInfestedComponent.cs
+++ b/Content.Shared/_Pirate/CorticalBorer/Components/CorticalBorerInfestedComponent.cs
@@ -48,6 +48,18 @@ public sealed partial class CorticalBorerInfestedComponent : Component
     public bool AddedControlThermalVision;
 
     [ViewVariables]
+    public bool AddedBorerNightVision;
+
+    [ViewVariables]
+    public bool? PreviousHostNightVisionActive;
+
+    [ViewVariables]
+    public bool AddedBorerThermalVision;
+
+    [ViewVariables]
+    public bool? PreviousHostThermalVisionActive;
+
+    [ViewVariables]
     public bool IsPolymorphing;
 }
 

--- a/Content.Shared/_Pirate/CorticalBorer/SharedCorticalBorerSystem.cs
+++ b/Content.Shared/_Pirate/CorticalBorer/SharedCorticalBorerSystem.cs
@@ -114,6 +114,9 @@ public abstract partial class SharedCorticalBorerSystem : EntitySystem
         if (comp.ControlingHost || !Container.TryRemoveFromContainer(uid))
             return false;
 
+        var ejected = new CorticalBorerEjectedEvent(host);
+        RaiseLocalEvent(uid, ref ejected);
+
         if (TryComp<UserInterfaceComponent>(uid, out var userInterface))
         {
             Ui.CloseUi((uid, userInterface), HealthAnalyzerUiKey.Key);
@@ -187,6 +190,9 @@ public sealed class InfestHostAttempt : CancellableEntityEventArgs
 
 [ByRefEvent]
 public record struct CorticalBorerEjectingEvent;
+
+[ByRefEvent]
+public readonly record struct CorticalBorerEjectedEvent(EntityUid Host);
 
 [Serializable, NetSerializable]
 public enum CorticalBorerDispenserUiKey


### PR DESCRIPTION
Передає активне нічне та теплове бачення кортикального бурильника його носію та відновлює попередній стан після вимкнення або виходу.

:cl:
- add: Носій кортикального бурильника тепер отримує нічне або теплове бачення, яке вмикає бурильник.