### PR TITLE
Окреме налаштування гучності StationRadioReceiver

### DIFF
--- a/Content.Client/Options/UI/Tabs/AudioTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AudioTab.xaml
@@ -17,6 +17,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                 <ui:OptionSlider Name="SliderVolumeAmbience" Title="{Loc 'ui-options-ambience-volume'}" />
                 <ui:OptionSlider Name="SliderVolumeLobby" Title="{Loc 'ui-options-lobby-volume'}" />
                 <ui:OptionSlider Name="SliderVolumeCassettes" Title="{Loc 'rmc-ui-options-cassettes-volume'}" /> <!-- Pirate: CMU cassettes -->
+                <ui:OptionSlider Name="SliderVolumeStationRadio" Title="{Loc 'ui-options-station-radio-volume'}" /> <!-- Pirate: station radio receiver volume -->
                 <ui:OptionSlider Name="SliderVolumeInterface" Title="{Loc 'ui-options-interface-volume'}" />
                 <ui:OptionSlider Name="SliderVolumeVoiceChat" Title="{Loc 'ui-options-voice-chat-volume'}" />
                 <ui:OptionSlider Name="SliderVolumeBarks" Title="{Loc 'ui-options-barks-volume'}" /><!-- Goob Station - Barks -->

--- a/Content.Client/Options/UI/Tabs/AudioTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AudioTab.xaml.cs
@@ -66,6 +66,10 @@ public sealed partial class AudioTab : Control
             SliderVolumeCassettes);
 
         Control.AddOptionPercentSlider(
+            PirateVars.StationRadioReceiverVolume,
+            SliderVolumeStationRadio); // Pirate: station radio receiver volume
+
+        Control.AddOptionPercentSlider(
             CCVars.InterfaceVolume,
             SliderVolumeInterface,
             scale: ContentAudioSystem.InterfaceMultiplier);

--- a/Content.Pirate.Client/_Pirate/Audio/StationRadioReceiverVolumeSystem.cs
+++ b/Content.Pirate.Client/_Pirate/Audio/StationRadioReceiverVolumeSystem.cs
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 Pirate
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Goobstation.Shared.StationRadio.Components;
+using Content.Shared._Pirate.Audio;
+using Content.Shared._Pirate.CCVars;
+using Robust.Client.Audio;
+using Robust.Shared.Audio.Components;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
+
+namespace Content.Pirate.Client._Pirate.Audio;
+
+/// <summary>
+/// Applies a client-side volume setting only to station radio receiver audio.
+/// </summary>
+public sealed class StationRadioReceiverVolumeSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _configuration = default!;
+
+    private float _volumeOffsetDb;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        UpdatesOutsidePrediction = true;
+        UpdatesAfter.Add(typeof(AudioSystem));
+
+        Subs.CVar(
+            _configuration,
+            PirateVars.StationRadioReceiverVolume,
+            gain => _volumeOffsetDb = SharedAudioSystem.GainToVolume(gain),
+            true);
+    }
+
+    public override void FrameUpdate(float frameTime)
+    {
+        var query = EntityQueryEnumerator<AudioComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var audio, out var xform))
+        {
+            if (!HasComp<StationRadioReceiverAudioComponent>(uid) &&
+                !HasComp<StationRadioReceiverComponent>(xform.ParentUid))
+            {
+                continue;
+            }
+
+            audio.Volume = audio.Params.Volume + _volumeOffsetDb;
+        }
+    }
+}

--- a/Content.Server/_Pirate/ZLevels/Audio/CMUZLevelsAudioSystem.cs
+++ b/Content.Server/_Pirate/ZLevels/Audio/CMUZLevelsAudioSystem.cs
@@ -11,6 +11,8 @@
 //   * Tracks projections per source so looped audio's projections die with the source.
 
 using System.Numerics;
+using Content.Goobstation.Shared.StationRadio.Components;
+using Content.Shared._Pirate.Audio;
 using Content.Shared._Pirate.ZLevels.Core.Components;
 using Content.Shared._Pirate.ZLevels.Core.EntitySystems;
 using Content.Shared.CCVar;
@@ -235,6 +237,12 @@ public sealed class CMUZLevelsAudioSystem : EntitySystem
 
             if (projectedAudio is not { } projected)
                 return;
+
+            if (HasComp<StationRadioReceiverAudioComponent>(source.Owner) ||
+                HasComp<StationRadioReceiverComponent>(Transform(source.Owner).ParentUid))
+            {
+                EnsureComp<StationRadioReceiverAudioComponent>(projected.Entity);
+            }
 
             _projections.Add(projected.Entity);
             projected.Component.Flags = source.Comp.Flags;

--- a/Content.Shared/_Pirate/Audio/StationRadioReceiverAudioComponent.cs
+++ b/Content.Shared/_Pirate/Audio/StationRadioReceiverAudioComponent.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Pirate
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Pirate.Audio;
+
+/// <summary>
+/// Marks station radio audio projected away from its receiver by multiz audio.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class StationRadioReceiverAudioComponent : Component;

--- a/Content.Shared/_Pirate/CCVars/PirateVars.StationRadio.cs
+++ b/Content.Shared/_Pirate/CCVars/PirateVars.StationRadio.cs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Pirate
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._Pirate.CCVars;
+
+public sealed partial class PirateVars
+{
+    /// <summary>
+    /// Client-side gain applied to audio emitted by station radio receivers.
+    /// </summary>
+    public static readonly CVarDef<float> StationRadioReceiverVolume =
+        CVarDef.Create("pirate.station_radio_receiver_volume", 0.5f, CVar.ARCHIVE | CVar.CLIENTONLY);
+}

--- a/Resources/Locale/uk-UA/_Pirate/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/uk-UA/_Pirate/escape-menu/ui/options-menu.ftl
@@ -1,2 +1,4 @@
 ui-options-hud-theme-halloween = Гелловін
 ui-options-hud-theme-purple = Пурпуровий
+
+ui-options-station-radio-volume = Гучність станційних радіоприймачів:


### PR DESCRIPTION
Додає окремий повзунок гучності станційних радіоприймачів у налаштуваннях аудіо.

:cl:
- tweak: Додано окреме налаштування гучності станційних радіоприймачів.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Додано окремий повзунок гучності для станційних радіоприймачів у налаштуваннях аудіо.
  * Гучність радіоприймачів тепер регулюється незалежно від інших звуків.
* **Локалізація**
  * Додано український переклад нового параметра гучності.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->