### PR TITLE
Fix cassette player worn sprite sticking to the character

### DIFF
--- a/Content.Shared/_Pirate/Cassette/SharedCassetteSystem.cs
+++ b/Content.Shared/_Pirate/Cassette/SharedCassetteSystem.cs
@@ -213,6 +213,15 @@ public abstract partial class SharedCassetteSystem : EntitySystem
 
     private void OnPlayerGetEquipmentVisuals(Entity<CassettePlayerComponent> ent, ref GetEquipmentVisualsEvent args)
     {
+        // Only show the worn overlay in the slots the player is actually worn in (ears).
+        // Rendering it for pockets inserts the fixed "cassette" layer key under another
+        // slot's bookmark, orphaning the old layer and leaving it stuck on the character.
+        if (!_inventory.TryGetSlot(args.Equipee, args.Slot, out var slotDef) ||
+            (slotDef.SlotFlags & ent.Comp.Slots) == 0)
+        {
+            return;
+        }
+
         args.Layers.Add(("cassette", new PrototypeLayerData
         {
             RsiPath = ent.Comp.WornSprite.RsiPath.ToString(),


### PR DESCRIPTION
## Про запит на злиття
Виправлено баг, коли текстура навушників касетного плеєра (`mob_overlay`) залишалася на модельці персонажа на весь раунд — після зняття плеєра зі слоту навушників або після того, як плеєр поклали в кишеню.

## Чому / Баланс
Багрепорт з Discord: спрайт плеєра «застрягає» на голові персонажа і не зникає до кінця раунду.

## Технічні деталі
`SharedCassetteSystem.OnPlayerGetEquipmentVisuals` додавав шар з фіксованим ключем `"cassette"` для **будь-якого** слота інвентаря, в якому опинявся плеєр — включно з кишенями. Спрайт гуманоїда має bookmark-шари `pocket1`/`pocket2`, тому:

1. Плеєр у кишені рендерив текстуру навушників на персонажі.
2. Коли ключ `"cassette"` уже був змапований на старий шар (з вух), `LayerMapSet` у `ClientClothingSystem.RenderEquipment` перемапував його на новий шар — старий шар лишався у спрайті **без ключа в LayerMap**, і `RemoveLayer(key)` більше не міг його видалити. Звідси «застрягання» до кінця раунду.

Фікс: обробник тепер додає worn-оверлей лише коли слот має прапорець зі `CassettePlayerComponent.Slots` (типово `EARS`). Кишені (`POCKET`) та suit storage (`SUITSTORAGE`) відсікаються, тож фіксований ключ ніколи не вставляється під bookmark іншого слота і orphaning неможливий.

Баг успадкований з оригінального порту RMC-14 (там той самий код). Перевірено, що інші підписники `GetEquipmentVisualsEvent` у репозиторії slot-guarded і цього класу бага не мають.

## Медіа
Малий фікс — медіа не потрібне.

## Вимоги
- [x] Я прочитав та дотримуюсь [Правил запитів на злиття та журналу змін](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я додав медіа, **АБО** цей запит на злиття не потребує медіа.

## Зміни, що порушують сумісність
Немає.

**Журнал змін**

:cl:
- fix: Касетний плеєр більше не залишає текстуру навушників на персонажі після потрапляння в кишеню чи зняття з вух.

🤖 Generated with [Claude Code](https://claude.com/claude-code)