### PR TITLE
fix: Перекладач більше не працює з розрядженою батарейкою

### DIFF
--- a/Content.Server/_EinsteinEngines/Language/TranslatorSystem.cs
+++ b/Content.Server/_EinsteinEngines/Language/TranslatorSystem.cs
@@ -32,6 +32,7 @@ public sealed class TranslatorSystem : SharedTranslatorSystem
         SubscribeLocalEvent<IntrinsicTranslatorComponent, DetermineEntityLanguagesEvent>(OnDetermineLanguages);
         SubscribeLocalEvent<HoldsTranslatorComponent, DetermineEntityLanguagesEvent>(OnProxyDetermineLanguages);
 
+        SubscribeLocalEvent<HandheldTranslatorComponent, MapInitEvent>(OnTranslatorMapInit);
         SubscribeLocalEvent<HandheldTranslatorComponent, EntGotInsertedIntoContainerMessage>(OnTranslatorInserted);
         SubscribeLocalEvent<HandheldTranslatorComponent, EntParentChangedMessage>(OnTranslatorParentChanged);
         SubscribeLocalEvent<HandheldTranslatorComponent, ActivateInWorldEvent>(OnTranslatorToggle);
@@ -45,7 +46,7 @@ public sealed class TranslatorSystem : SharedTranslatorSystem
         if (!component.Enabled
             || component.LifeStage >= ComponentLifeStage.Removing
             || !TryComp<LanguageKnowledgeComponent>(uid, out var knowledge)
-            || !_powerCell.HasActivatableCharge(uid))
+            || !_powerCell.HasDrawCharge(uid))
             return;
 
         CopyLanguages(component, ev, knowledge);
@@ -58,7 +59,9 @@ public sealed class TranslatorSystem : SharedTranslatorSystem
 
         foreach (var (translator, translatorComp) in component.Translators.ToArray())
         {
-            if (!translatorComp.Enabled || !_powerCell.HasActivatableCharge(uid))
+            // Pirate: The power check must target the translator itself, not its holder - checking the holder
+            // always succeeded, which let translators with a dead cell keep translating forever.
+            if (!translatorComp.Enabled || !_powerCell.HasDrawCharge(translator))
                 continue;
 
             if (!_containers.TryGetContainingContainer(translator, out var container) || container.Owner != uid)
@@ -69,6 +72,13 @@ public sealed class TranslatorSystem : SharedTranslatorSystem
 
             CopyLanguages(translatorComp, ev, knowledge);
         }
+    }
+
+    // Pirate: PowerCellDraw.Enabled defaults to true, so translators spawned turned-off would still
+    // drain their cell from round start. Align the draw state with the translator state on spawn.
+    private void OnTranslatorMapInit(Entity<HandheldTranslatorComponent> translator, ref MapInitEvent args)
+    {
+        _powerCell.SetDrawEnabled(translator.Owner, translator.Comp.Enabled);
     }
 
     private void OnTranslatorInserted(EntityUid translator, HandheldTranslatorComponent component, EntGotInsertedIntoContainerMessage args)
@@ -115,7 +125,7 @@ public sealed class TranslatorSystem : SharedTranslatorSystem
             return;
 
         // This will show a popup if false
-        var hasPower = _powerCell.HasDrawCharge(translator);
+        var hasPower = _powerCell.HasDrawCharge(translator, args.User);
         var isEnabled = !translatorComp.Enabled && hasPower;
 
         Entity<LanguageSpeakerComponent?>? holderEntity = null;
@@ -154,13 +164,16 @@ public sealed class TranslatorSystem : SharedTranslatorSystem
 
     private void OnPowerCellChanged(EntityUid translator, HandheldTranslatorComponent component, PowerCellChangedEvent args)
     {
-        var hasCharge = _powerCell.HasActivatableCharge(translator);
+        // Pirate: HasActivatableCharge checks UseCharge (0 for translators), so it passed even for a fully
+        // drained cell - re-inserting a dead cell force-enabled the translator, and since an already-empty
+        // battery never transitions to Empty, PowerCellSlotEmptyEvent never fired to turn it back off.
+        var hasCharge = _powerCell.HasDrawCharge(translator);
         SetEnabled((translator, component), hasCharge);
     }
 
     private void OnItemToggled(EntityUid translator, HandheldTranslatorComponent component, ItemToggledEvent args)
     {
-        var hasCharge = _powerCell.HasActivatableCharge(translator);
+        var hasCharge = _powerCell.HasDrawCharge(translator);
         var shouldEnable = args.Activated && hasCharge;
 
         SetEnabled((translator, component), shouldEnable);


### PR DESCRIPTION
## Про запит на злиття
Фікс бага, про який повідомили гравці: ручний перекладач (зокрема «перекладач іноземців») продовжував працювати з повністю розрядженою батарейкою. Достатньо було вийняти та вставити назад розряджену батарейку — перекладач вмикався і працював до кінця раунду з зарядом 0 %.

## Чому / Баланс
Перекладач має споживати заряд батарейки — це його єдиний ресурс. Через баг гравці отримували безкоштовний вічний переклад, і чесна заміна батарейки втрачала сенс.

## Технічні деталі
Три причини, всі в `TranslatorSystem`:

1. **Увімкнення від порожньої батарейки.** `OnPowerCellChanged` та `OnItemToggled` перевіряли `HasActivatableCharge`, який порівнює заряд з `UseCharge` (у перекладачів = 0). Порожня батарейка проходила перевірку `0 >= 0`, тож вставляння розрядженої батарейки примусово вмикало перекладач. Вимкнути його назад не було кому: `PowerCellSlotEmptyEvent` рейзиться лише при *переході* батареї в стан `Empty` (`BatteryStateChangedEvent`), а вже порожня батарейка переходу не робить. Тепер використовується `HasDrawCharge`, який перевіряє заряд відносно `DrawRate`.

2. **Перевірка заряду не тієї сутності.** `OnProxyDetermineLanguages` викликав `HasActivatableCharge(uid)`, де `uid` — це *носій* перекладача, а не сам перекладач. У носія немає `PowerCellDrawComponent`, тож перевірка завжди повертала `true` — мови видавалися незалежно від заряду. Тепер перевіряється сам перекладач.

3. **Пасивна розрядка вимкненого перекладача.** `PowerCellDraw.Enabled` за замовчуванням `true`, а перекладачі спавняться вимкненими (`enabled: false`) — тож перекладачі з мап і вендорів тихо зʼїдали батарейку з початку раунду, навіть якщо їх ніхто не вмикав. Доданий `MapInit`-обробник синхронізує стан споживання зі станом перекладача. (Трейтові перекладачі вже робили це явно через `SetEnabled(false)`.)

Бонус: у `OnTranslatorToggle` тепер передається `args.User` у `HasDrawCharge` — коментар «This will show a popup if false» нарешті відповідає дійсності, гравець бачить попап про відсутність заряду.

## Медіа
Малий фікс, медіа не потребує.

## Вимоги
- [x] Я прочитав та дотримуюсь [Правил запитів на злиття та журналу змін](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я додав медіа, **АБО** цей запит на злиття не потребує медіа.

## Зміни, що порушують сумісність
Немає.

**Журнал змін**

:cl:
- fix: Перекладач більше не вмикається та не перекладає з повністю розрядженою батарейкою.
- fix: Вимкнений перекладач більше не розряджає батарейку пасивно.
- tweak: При спробі увімкнути перекладач без заряду тепер зʼявляється повідомлення.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
