### PR TITLE
Додано мезонне бачення до MOD-костюма

### DIFF
--- a/Content.Pirate.Client/ModularSuit/MesonVisionOverlay.cs
+++ b/Content.Pirate.Client/ModularSuit/MesonVisionOverlay.cs
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 Pirate
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Numerics;
+using Content.Pirate.Shared.ModularSuit;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.Player;
+using Robust.Shared.Enums;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+
+namespace Content.Pirate.Client.ModularSuit;
+
+/// <summary>
+/// Draws terrain and occluding structures after lighting and FOV without revealing other entities.
+/// </summary>
+public sealed class MesonVisionOverlay : Overlay
+{
+    private static readonly Color TerrainFill = Color.FromHex("#103b2c").WithAlpha(0.10f);
+    private static readonly Color TerrainOutline = Color.FromHex("#68d99a").WithAlpha(0.24f);
+    private static readonly Color StructureColor = Color.FromHex("#75ffad").WithAlpha(0.68f);
+
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IEyeManager _eyeManager = default!;
+    [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+
+    private readonly EntityLookupSystem _lookup;
+    private readonly SharedMapSystem _map;
+    private readonly SpriteSystem _sprite;
+    private readonly SharedTransformSystem _transform;
+
+    private readonly EntityQuery<SpriteComponent> _spriteQuery;
+    private readonly EntityQuery<TransformComponent> _transformQuery;
+    private readonly List<Entity<MapGridComponent>> _grids = new();
+    private readonly HashSet<Entity<OccluderComponent>> _structures = new();
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+
+    public MesonVisionOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+
+        _lookup = _entityManager.System<EntityLookupSystem>();
+        _map = _entityManager.System<SharedMapSystem>();
+        _sprite = _entityManager.System<SpriteSystem>();
+        _transform = _entityManager.System<SharedTransformSystem>();
+
+        _spriteQuery = _entityManager.GetEntityQuery<SpriteComponent>();
+        _transformQuery = _entityManager.GetEntityQuery<TransformComponent>();
+    }
+
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        return args.Viewport.Eye == _eyeManager.CurrentEye
+            && _player.LocalEntity is { Valid: true } player
+            && _entityManager.HasComponent<MesonVisionComponent>(player);
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        var eye = args.Viewport.Eye;
+        if (eye == null)
+            return;
+
+        DrawTerrain(args);
+        DrawStructures(args, eye.Rotation);
+
+        args.WorldHandle.SetTransform(Matrix3x2.Identity);
+        args.WorldHandle.UseShader(null);
+    }
+
+    private void DrawTerrain(in OverlayDrawArgs args)
+    {
+        var handle = args.WorldHandle;
+        _grids.Clear();
+        _mapManager.FindGridsIntersecting(args.MapId, args.WorldBounds, ref _grids, approx: true);
+
+        foreach (var grid in _grids)
+        {
+            handle.SetTransform(_transform.GetWorldMatrix(grid.Owner));
+            var tiles = _map.GetTilesEnumerator(grid.Owner, grid.Comp, args.WorldBounds);
+
+            while (tiles.MoveNext(out var tile))
+            {
+                if (tile.Tile.IsEmpty)
+                    continue;
+
+                var bounds = _lookup.GetLocalBounds(tile, grid.Comp.TileSize);
+                handle.DrawRect(bounds, TerrainFill);
+                handle.DrawRect(bounds, TerrainOutline, filled: false);
+            }
+        }
+
+        handle.SetTransform(Matrix3x2.Identity);
+    }
+
+    private void DrawStructures(in OverlayDrawArgs args, Angle eyeRotation)
+    {
+        _structures.Clear();
+        _lookup.GetEntitiesIntersecting(args.MapId, args.WorldBounds, _structures);
+
+        foreach (var structure in _structures)
+        {
+            var uid = structure.Owner;
+            if (!_spriteQuery.TryComp(uid, out var sprite)
+                || !sprite.Visible
+                || !_transformQuery.TryComp(uid, out var xform)
+                || xform.MapID != args.MapId)
+            {
+                continue;
+            }
+
+            var originalColor = sprite.Color;
+            try
+            {
+                _sprite.SetColor((uid, sprite), StructureColor);
+                _sprite.RenderSprite(
+                    (uid, sprite),
+                    args.WorldHandle,
+                    eyeRotation,
+                    _transform.GetWorldRotation(xform),
+                    _transform.GetWorldPosition(xform));
+            }
+            finally
+            {
+                _sprite.SetColor((uid, sprite), originalColor);
+            }
+        }
+    }
+}

--- a/Content.Pirate.Client/ModularSuit/MesonVisionOverlay.cs
+++ b/Content.Pirate.Client/ModularSuit/MesonVisionOverlay.cs
@@ -35,6 +35,7 @@ public sealed class MesonVisionOverlay : Overlay
     private readonly EntityQuery<SpriteComponent> _spriteQuery;
     private readonly EntityQuery<TransformComponent> _transformQuery;
     private List<Entity<MapGridComponent>> _grids = new();
+    private readonly List<Box2> _tileBounds = new();
     private readonly HashSet<Entity<OccluderComponent>> _structures = new();
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
@@ -81,6 +82,7 @@ public sealed class MesonVisionOverlay : Overlay
         foreach (var grid in _grids)
         {
             handle.SetTransform(_transform.GetWorldMatrix(grid.Owner));
+            _tileBounds.Clear();
             var tiles = _map.GetTilesEnumerator(grid.Owner, grid.Comp, args.WorldBounds);
 
             while (tiles.MoveNext(out var tile))
@@ -88,10 +90,14 @@ public sealed class MesonVisionOverlay : Overlay
                 if (tile.Tile.IsEmpty)
                     continue;
 
-                var bounds = _lookup.GetLocalBounds(tile, grid.Comp.TileSize);
-                handle.DrawRect(bounds, TerrainFill);
-                handle.DrawRect(bounds, TerrainOutline, filled: false);
+                _tileBounds.Add(_lookup.GetLocalBounds(tile, grid.Comp.TileSize));
             }
+
+            foreach (var bounds in _tileBounds)
+                handle.DrawRect(bounds, TerrainFill);
+
+            foreach (var bounds in _tileBounds)
+                handle.DrawRect(bounds, TerrainOutline, filled: false);
         }
 
         handle.SetTransform(Matrix3x2.Identity);

--- a/Content.Pirate.Client/ModularSuit/MesonVisionOverlay.cs
+++ b/Content.Pirate.Client/ModularSuit/MesonVisionOverlay.cs
@@ -34,7 +34,7 @@ public sealed class MesonVisionOverlay : Overlay
 
     private readonly EntityQuery<SpriteComponent> _spriteQuery;
     private readonly EntityQuery<TransformComponent> _transformQuery;
-    private readonly List<Entity<MapGridComponent>> _grids = new();
+    private List<Entity<MapGridComponent>> _grids = new();
     private readonly HashSet<Entity<OccluderComponent>> _structures = new();
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;

--- a/Content.Pirate.Client/ModularSuit/MesonVisionSystem.cs
+++ b/Content.Pirate.Client/ModularSuit/MesonVisionSystem.cs
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Pirate
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Pirate.Shared.ModularSuit;
+using Robust.Client.Graphics;
+using Robust.Shared.Player;
+
+namespace Content.Pirate.Client.ModularSuit;
+
+public sealed class MesonVisionSystem : EntitySystem
+{
+    [Dependency] private readonly IOverlayManager _overlayManager = default!;
+    [Dependency] private readonly ISharedPlayerManager _player = default!;
+
+    private MesonVisionOverlay _overlay = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MesonVisionComponent, ComponentInit>(OnComponentInit);
+        SubscribeLocalEvent<MesonVisionComponent, ComponentShutdown>(OnComponentShutdown);
+        SubscribeLocalEvent<MesonVisionComponent, LocalPlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeLocalEvent<MesonVisionComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
+
+        _overlay = new MesonVisionOverlay();
+    }
+
+    private void OnComponentInit(Entity<MesonVisionComponent> ent, ref ComponentInit args)
+    {
+        if (ent.Owner == _player.LocalEntity)
+            AddOverlay();
+    }
+
+    private void OnComponentShutdown(Entity<MesonVisionComponent> ent, ref ComponentShutdown args)
+    {
+        if (ent.Owner == _player.LocalEntity)
+            RemoveOverlay();
+    }
+
+    private void OnPlayerAttached(Entity<MesonVisionComponent> ent, ref LocalPlayerAttachedEvent args)
+    {
+        AddOverlay();
+    }
+
+    private void OnPlayerDetached(Entity<MesonVisionComponent> ent, ref LocalPlayerDetachedEvent args)
+    {
+        RemoveOverlay();
+    }
+
+    private void AddOverlay()
+    {
+        if (!_overlayManager.HasOverlay<MesonVisionOverlay>())
+            _overlayManager.AddOverlay(_overlay);
+    }
+
+    private void RemoveOverlay()
+    {
+        _overlayManager.RemoveOverlay(_overlay);
+    }
+}

--- a/Content.Pirate.Shared/ModularSuit/Components/MesonVisionComponent.cs
+++ b/Content.Pirate.Shared/ModularSuit/Components/MesonVisionComponent.cs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Robust.Shared.GameStates;
+
 namespace Content.Pirate.Shared.ModularSuit;
 
 /// <summary>

--- a/Content.Pirate.Shared/ModularSuit/Components/MesonVisionComponent.cs
+++ b/Content.Pirate.Shared/ModularSuit/Components/MesonVisionComponent.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 Pirate
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Pirate.Shared.ModularSuit;
+
+/// <summary>
+/// Enables the structural overlay used by meson MOD-suit visors.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class MesonVisionComponent : Component;

--- a/Resources/Prototypes/_Pirate/Entities/Objects/Specific/Robotics/suitmodules.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Objects/Specific/Robotics/suitmodules.yml
@@ -342,6 +342,9 @@
   - type: ModularSuitModuleEffect
     activeComponents:
     - type: EyeProtection
+  - type: ModularSuitModuleWearerEffect
+    activeComponents:
+    - type: MesonVision
   - type: ModularSuitModule
     tags: [ VisorSuitModule, WeldingModuleConflict ]
     verbIcon:


### PR DESCRIPTION
Мезонний візор тепер показує рельєф і конструкції крізь темряву та стіни, не розкриваючи мобів чи предмети.

:cl:
- add: Мезонний візор MOD-костюма тепер відображає рельєф і конструкції крізь стіни.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові функції**
  * Додано режим Meson Vision для візора модульного костюма.
  * Відображається рельєф і видимі структури у світовому просторі.
  * Ефект автоматично вмикається та вимикається для локального носія візора.
  * Додано мережевий компонент для керування Meson Vision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->