### PR TITLE
Меч культу крові можна витягти з персонажа

### DIFF
--- a/Content.Pirate.Shared/BloodCult/SharedBloodCultItemSystem.cs
+++ b/Content.Pirate.Shared/BloodCult/SharedBloodCultItemSystem.cs
@@ -41,7 +41,8 @@ public sealed class SharedBloodCultItemSystem : EntitySystem
 
     private void OnActivate(Entity<BloodCultItemComponent> item, ref ActivateInWorldEvent args)
     {
-        if (_whitelist.IsWhitelistPass(item.Comp.Whitelist, args.User))
+        if (_whitelist.IsWhitelistPass(item.Comp.Whitelist, args.User) ||
+            TryComp<EmbeddableProjectileComponent>(item, out var embeddable) && embeddable.EmbeddedIntoUid != null)
             return;
 
         args.Handled = true;


### PR DESCRIPTION
Виправлено блокування взаємодії під час витягування меча культу крові.

:cl:
- fix: Меч культу крові тепер можна витягти з персонажа.