### PR TITLE
Видалено Snowball station та Гейт ТП з маппулу

### DIFF
--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -130,7 +130,7 @@ namespace Content.IntegrationTests.Tests
             "Exo",          // okay fine fuck it.
             "Fland",
             "FlandHighPop",
-            "GateTP",         // Pirate
+            // "GateTP",         // Pirate - re-add after the rework
             "GlacierTP",      // Pirate
             "Kettle",
             "KettleTP",       // Pirate
@@ -198,7 +198,7 @@ namespace Content.IntegrationTests.Tests
               "GlacierTP", // Pirate
               "OmegaTP", // Pirate
               "KettleTP", // Pirate
-              "GateTP", // Pirate
+            //"GateTP", // Pirate - re-add after the rework
               "PerditionTP", // Pirate
               "PiramideTP", // Pirate
               "Packed",

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -7,7 +7,7 @@
   - Bagel
   - BoxTP # Pirate
   #- Box # Pirate
-  - GateTP # Pirate
+  #- GateTP # Pirate - will be re-added after the rework
   - Cluster
   #- Core
   - Fland
@@ -26,7 +26,7 @@
   - FlandHighPop
   - OasisHighPop
   - Barratry # Goobstation - Re-add barratry
-  - KettleTP # Pirate - Попа.
+  - KettleTP # Pirate
   #- Kettle # Pirate
   - Leonid # Goobstation - for goob by goob
   - Delta # Goobstation - ported from Corvax
@@ -37,4 +37,4 @@
   - PiramideTP # Pirate
   #- Plasma # Goob - No. Leave it to the mappers.
   #- Exo # Goobstation - Just no
-  - Snowball
+  #- Snowball # Pirate - not even Goob station map, nuh uh


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Iced-Coded <volkogon212@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!--- ЛІЦЕНЗІЯ: AGPL -->
## Про ПР
Видалено Гейт ТП та Snowball station з маппулу. Гейт ТП буде повернено туди після реворку.

## Вимоги
- [X] Я прочитав та дотримуюсь [Правил пулл реквестів та всього такого](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Не додавав я медіа до ПР цього

**Чейнджлог**
:cl:
- remove: Видалено Гейт ТП та Snowball Station з голосування вибору мапи.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Зміни ігрового контенту**
  * Оновлено стандартний пул мап для режиму Pirate.
  * Мапу GateTP тимчасово вилучено з пулу до завершення переробки.
  * Мапу Snowball також вимкнено в межах поточного оновлення.
  * Мапу KettleTP залишено доступною, а її опис уточнено.
  * Це забезпечує актуальніший склад доступних мап під час вибору та запуску матчів.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->