### PR TITLE
Виправити перевірку профілю для ghost roles

### DIFF
--- a/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
@@ -2,9 +2,11 @@
 
 using System.Linq;
 using Content.Client.Eui;
+using Content.Client.Lobby; // Pirate
 using Content.Client.Players.PlayTimeTracking;
 using Content.Shared.Eui;
 using Content.Shared.Ghost.Roles;
+using Content.Shared.Preferences; // Pirate
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 
@@ -91,13 +93,15 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
             var sysManager = entityManager.EntitySysManager;
             var spriteSystem = sysManager.GetEntitySystem<SpriteSystem>();
             var requirementsManager = IoCManager.Resolve<JobRequirementsManager>();
+            var profile = (HumanoidCharacterProfile?) IoCManager.Resolve<IClientPreferencesManager>()
+                .Preferences?.SelectedCharacter; // Pirate: mirror the server-side ghost role requirement check.
 
             // Grouping roles
             var groupedRoles = ghostState.GhostRoles.GroupBy(role => (
                     role.Name,
                     role.Description,
                     //  Check the prototypes for role requirements and bans
-                    requirementsManager.IsAllowed(role.RolePrototypes.Item1, role.RolePrototypes.Item2, null, out var reason),
+                    requirementsManager.IsAllowed(role.RolePrototypes.Item1, role.RolePrototypes.Item2, profile, out var reason),
                     reason));
 
             // Add a new entry for each role group


### PR DESCRIPTION
Виправлено перевірку вибраного профілю для ghost roles.

:cl:
- fix: Виправлено доступ до ghost roles з вимогами до профілю персонажа.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Виправлення**
  * Виправлено відображення доступності ролей для привидів у меню ролей.
  * Перевірки вимог і заборон тепер враховують вибраний профіль персонажа.
  * Причини недоступності ролей відображаються коректніше, відповідно до серверної логіки.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->