### PR TITLE
Fix MODsuit armor coverage

### DIFF
--- a/Resources/Prototypes/_Pirate/Entities/Clothing/Modular/basemodular.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Clothing/Modular/basemodular.yml
@@ -221,7 +221,7 @@
     unlockOnClick: false
 
 - type: entity
-  parent: [ BaseItem, BaseClothingModularToggler, AllowSuitStorageClothing ]
+  parent: [ BaseItem, BaseClothingModularToggler, AllowSuitStorageClothing, ClothingArmorPlate ] # Pirate: armor plates.
   id: ClothingModularChestPlateBase
   abstract: true
   components:

--- a/Resources/Prototypes/_Pirate/Entities/Clothing/Modular/basemodular.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Clothing/Modular/basemodular.yml
@@ -168,6 +168,9 @@
       - state: visor-unshaded-vox
         shader: unshaded
   - type: Armor
+    # Pirate: Shitmed applies armor only to explicitly covered body parts.
+    coverage:
+    - Head
     modifiers:
       coefficients:
         Blunt: 0.90
@@ -249,6 +252,16 @@
       outerClothing-vox:
       - state: sealed-equipped-OUTERCLOTHING-vox
   - type: Armor
+    # Pirate: The chestplate protects the wearer outside the helmet coverage.
+    coverage:
+    - Chest
+    - Groin
+    - Arm
+    - Hand
+    - Leg
+    - Foot
+    - Tail
+    - Other
     modifiers:
       coefficients:
         Blunt: 0.90

--- a/Resources/Prototypes/_Pirate/Entities/Clothing/Modular/modular.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Clothing/Modular/modular.yml
@@ -3366,6 +3366,13 @@
   - type: PointLight
     color: "#83db2b"
   - type: Armor
+    # Pirate: matches the trauma protection of the nuclear operative hardsuit.
+    traumaDeductions:
+      Dismemberment: 0.5
+      OrganDamage: 0.5
+      BoneDamage: 0.5
+      VeinsDamage: 0
+      NerveDamage: 0
     modifiers:
       coefficients:
         Blunt: 0.9
@@ -3389,6 +3396,13 @@
       sprite: _Pirate/Clothing/Modular/Syndicate/chestplate.rsi
       state: icon-sealed
   - type: Armor
+    # Pirate: matches the trauma protection of the nuclear operative hardsuit.
+    traumaDeductions:
+      Dismemberment: 0.5
+      OrganDamage: 0.5
+      BoneDamage: 0.5
+      VeinsDamage: 0
+      NerveDamage: 0
     modifiers:
       coefficients:
         Blunt: 0.5


### PR DESCRIPTION
Відновлено покриття броні, захист від травм і комірки для бронепластин у МОД-скафах.

:cl:
- fix: МОД-скафи знову захищають від уражень і травм та підтримують бронепластини.