### PR TITLE
Fix зникнення свічки духів після створення

### DIFF
--- a/Resources/Prototypes/_Goobstation/Recipes/Construction/Graphs/misc/spirit_candle.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Construction/Graphs/misc/spirit_candle.yml
@@ -13,10 +13,6 @@
           sprite: Objects/Misc/candles.rsi
           state: candle-big
         doAfter: 2
-      completed:
-      - !type:SpawnPrototype
-        prototype: SpiritCandle
-      - !type:DeleteEntity {}
 
   - node: spiritCandle
-    entity: SpiritCandle
+    entity: SpiritCandle # Pirate: Use graph replacement to preserve hands and container state.


### PR DESCRIPTION
Виправлено зникнення свічки духів, якщо створювати її з черепа в руках або інвентарі.

:cl:
- fix: Свічка духів більше не зникає після створення з черепа в руках або інвентарі.