### PR TITLE
Виправлення відтворення власних касет

### DIFF
--- a/Content.Shared/_Pirate/Cassette/SharedCassetteSystem.cs
+++ b/Content.Shared/_Pirate/Cassette/SharedCassetteSystem.cs
@@ -17,6 +17,7 @@ using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Shared._Pirate.Cassette;
@@ -31,6 +32,7 @@ public abstract partial class SharedCassetteSystem : EntitySystem
     [Dependency] private INetManager _net = default!;
     [Dependency] private INetConfigurationManager _netConfig = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private IGameTiming _timing = default!;
 
     public override void Initialize()
     {
@@ -158,7 +160,9 @@ public abstract partial class SharedCassetteSystem : EntitySystem
             return;
         }
 
-        StopAllAudio(player);
+        // Pirate: custom tracks are client-only, so replay must not stop the predicted stream.
+        if (_net.IsServer || _timing.IsFirstTimePredicted)
+            StopAllAudio(player);
 
         tape ??= player.Comp.Tape;
         if (tape < 0 || tape >= tapeComp.Songs.Count)


### PR DESCRIPTION
Власні треки більше не зупиняються під час клієнтського prediction replay.\n\n:cl:\n- fix: Власні .ogg-треки у касетному плеєрі знову відтворюються.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Виправлення**
  * Виправлено відтворення касет під час клієнтського прогнозування.
  * Користувацькі аудіотреки більше не перериваються повторними викликами під час реплею або синхронізації.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->