### PR TITLE
Виправити лікування та кровотечу скелетів

### DIFF
--- a/Content.Server/_Shitmed/PartStatus/PartStatusSystem.cs
+++ b/Content.Server/_Shitmed/PartStatus/PartStatusSystem.cs
@@ -199,7 +199,8 @@ public sealed class PartStatusSystem : EntitySystem
             titlestring += "-styleless";
         }
 
-        message.AddText(Loc.GetString(titlestring, ("entity", Identity.Name(entity, EntityManager))));
+        // Pirate: status locale strings contain markup and entity names are already escaped by Identity.Name.
+        message.AddMarkupOrThrow(Loc.GetString(titlestring, ("entity", Identity.Name(entity, EntityManager))));
         message.PushNewline();
         AddLine(message);
         CreateBodyPartMessage(partStatusSet, entity == examiner, ref message, !styling);
@@ -238,10 +239,12 @@ public sealed class PartStatusSystem : EntitySystem
                 locString += "-styleless";
             }
 
-            message.AddText("    " + Loc.GetString(locString,
-                ("possessive", possessive),
-                ("part", partStatus.PartName),
-                ("status", statusDescription)));
+            message.AddText("    ");
+            // Pirate: parse locale markup while keeping interpolated text literal.
+            message.AddMarkupOrThrow(Loc.GetString(locString,
+                ("possessive", FormattedMessage.EscapeText(possessive)),
+                ("part", FormattedMessage.EscapeText(partStatus.PartName)),
+                ("status", FormattedMessage.EscapeText(statusDescription))));
 
             message.PushNewline();
         }

--- a/Resources/Prototypes/Body/Parts/skeleton.yml
+++ b/Resources/Prototypes/Body/Parts/skeleton.yml
@@ -24,7 +24,12 @@
         color: "#555555AA"
       Burn:
         sprite: _Shitmed/Mobs/Effects/burn_damage.rsi
+    bleedingOverlay: null # Pirate: skeletons have no blood.
+  - type: Woundable
+    damageContainer: Skeleton # Pirate: match the skeleton body's damage container.
+    canBleed: false # Pirate: skeletons have no blood.
   - type: Damageable # Shitmed
+    damageContainer: Skeleton # Pirate: match the skeleton body's damage container.
     damageModifierSet: Skeleton
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -20,7 +20,7 @@
     requiredLegs: 2
     gibSound: /Audio/Effects/bone_rattle.ogg
   - type: Damageable
-    damageContainer: InorganicMetaphysical # DeltaV
+    damageContainer: Skeleton # Pirate: allow skeleton-specific medical treatment.
     damageModifierSet: Skeleton # If we get non-Holy metaphysical damage types in the future, the Skeleton set might need to be adjusted to provide immunity to them (depends on what exactly the new types are)
   #  - type: DamageVisuals
   #    damageOverlayGroups:
@@ -95,6 +95,7 @@
       methods: [ Touch ]
       effects: # TODO: when magic is around - make a milk transformation to a skeleton monster
       - !type:HealthChange
+        splitDamage: SplitEnsureAll # Pirate: skeleton body parts are inorganic.
         damage:
           groups: # these groups are the only 3 possible ways to damage a skeleton. numerical values obviously up to discussion
             Burn: -4 # healing obviously up to discussion # Shitmed value

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -33,6 +33,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - Skeleton # Pirate: allow treating skeleton burns.
     damage:
       types:
         Heat: -10
@@ -81,6 +82,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - Skeleton # Pirate: allow treating skeleton burns.
     damage:
       types:
         Heat: -15
@@ -129,6 +131,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - Skeleton # Pirate: allow treating skeleton injuries.
     damage:
       groups:
         Brute: -30 # was 5 (-15 Brute) for each, Buffed due to limb damage changes (Goobstation)
@@ -175,6 +178,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - Skeleton # Pirate: allow treating skeleton injuries.
     damage:
       groups:
         Brute: -45 # was 10 for each, Buffed due to Limb Damage Changes (Goobstation)
@@ -312,6 +316,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - Skeleton # Pirate: allow treating skeleton injuries.
     damage:
       types:
         Slash: -10 # Was 5

--- a/Resources/Prototypes/_Pirate/Damage/containers.yml
+++ b/Resources/Prototypes/_Pirate/Damage/containers.yml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Pirate: Keep skeleton treatment separate from other metaphysical inorganic mobs.
+- type: damageContainer
+  id: Skeleton
+  supportedGroups:
+  - Brute
+  - Burn
+  - Metaphysical
+  supportedTypes:
+  - Holy
+  - Shock


### PR DESCRIPTION
Виправлено медичну взаємодію скелетів і відображення стану частин тіла.

:cl:
- fix: Скелети лікуються молоком і стандартними засобами та не кровоточать
- fix: Виправлено markup у статусі частин тіла