### PR TITLE
Виправлено ефекти реагентів під час метаболізму

### DIFF
--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -239,6 +239,15 @@ public sealed class MetabolizerSystem : SharedMetabolizerSystem
 
                 var actualEntity = ent.Comp2?.Body ?? solutionEntityUid.Value;
 
+                // Pirate: bridge metabolism to legacy downstream reagent-effect handlers.
+                using var legacyReagent = LegacyEntityEffectContext.PushReagent(
+                    EntityManager,
+                    ent.Owner,
+                    solution,
+                    new ReagentQuantity(reagent, mostToRemove),
+                    proto,
+                    null);
+
                 // do all effects, if conditions apply
                 foreach (var effect in entry.Effects)
                 {

--- a/Content.Shared/_Pirate/EntityEffects/LegacyEntityEffectCompatibility.cs
+++ b/Content.Shared/_Pirate/EntityEffects/LegacyEntityEffectCompatibility.cs
@@ -59,49 +59,83 @@ public abstract partial class EventEntityEffect<T> : EntityEffectBase<T> where T
 
 public static class LegacyEntityEffectContext
 {
-    private static readonly ConcurrentDictionary<IEntityManager, LegacyEntityEffectReaction> CurrentReactions = new();
+    private static readonly ConcurrentDictionary<IEntityManager, LegacyEntityEffectReagent> CurrentReagents = new();
 
     public static IDisposable PushReaction(IEntityManager entityManager, ReactionEntityEvent reaction)
     {
-        LegacyEntityEffectReaction? previous = null;
-        if (CurrentReactions.TryGetValue(entityManager, out var current))
-            previous = current;
-
-        CurrentReactions[entityManager] = new LegacyEntityEffectReaction(
-            reaction.Method,
+        return PushReagent(
+            entityManager,
+            null,
+            null,
             reaction.ReagentQuantity,
-            reaction.Reagent);
-
-        return new ReactionScope(entityManager, previous);
+            reaction.Reagent,
+            reaction.Method);
     }
 
-    public static bool TryGetReaction(IEntityManager entityManager, out LegacyEntityEffectReaction reaction)
+    public static IDisposable PushReagent(
+        IEntityManager entityManager,
+        EntityUid? organEntity,
+        Solution? source,
+        ReagentQuantity reagentQuantity,
+        ReagentPrototype reagent,
+        ReactionMethod? method)
     {
-        return CurrentReactions.TryGetValue(entityManager, out reaction);
+        LegacyEntityEffectReagent? previous = null;
+        if (CurrentReagents.TryGetValue(entityManager, out var current))
+            previous = current;
+
+        CurrentReagents[entityManager] = new LegacyEntityEffectReagent(
+            method,
+            reagentQuantity,
+            reagent,
+            organEntity,
+            source);
+
+        return new ReagentScope(entityManager, previous);
+    }
+
+    public static bool TryGetReagent(IEntityManager entityManager, out LegacyEntityEffectReagent reagent)
+    {
+        return CurrentReagents.TryGetValue(entityManager, out reagent);
+    }
+
+    public static bool TryGetReaction(IEntityManager entityManager, out LegacyEntityEffectReagent reaction)
+    {
+        if (!TryGetReagent(entityManager, out reaction) || reaction.Method is null)
+        {
+            reaction = default;
+            return false;
+        }
+
+        return true;
     }
 
     public static EntityEffectBaseArgs CreateArgs(EntityUid target, IEntityManager entMan, float scale = 1f)
     {
-        if (!TryGetReaction(entMan, out var reaction))
+        if (!TryGetReagent(entMan, out var reagent))
             return new EntityEffectBaseArgs(target, entMan);
 
-        var source = new Solution();
-        source.AddReagent(reaction.ReagentQuantity);
+        var source = reagent.Source;
+        if (source is null)
+        {
+            source = new Solution();
+            source.AddReagent(reagent.ReagentQuantity);
+        }
 
         return new EntityEffectReagentArgs(
             target,
             entMan,
-            null,
+            reagent.OrganEntity,
             source,
-            reaction.ReagentQuantity.Quantity,
-            reaction.Reagent,
-            reaction.Method,
+            reagent.ReagentQuantity.Quantity,
+            reagent.Reagent,
+            reagent.Method,
             FixedPoint2.New(scale));
     }
 
-    private sealed class ReactionScope(
+    private sealed class ReagentScope(
         IEntityManager entityManager,
-        LegacyEntityEffectReaction? previous) : IDisposable
+        LegacyEntityEffectReagent? previous) : IDisposable
     {
         private bool _disposed;
 
@@ -113,17 +147,19 @@ public static class LegacyEntityEffectContext
             _disposed = true;
 
             if (previous is { } reaction)
-                CurrentReactions[entityManager] = reaction;
+                CurrentReagents[entityManager] = reaction;
             else
-                CurrentReactions.TryRemove(entityManager, out _);
+                CurrentReagents.TryRemove(entityManager, out _);
         }
     }
 }
 
-public readonly record struct LegacyEntityEffectReaction(
-    ReactionMethod Method,
+public readonly record struct LegacyEntityEffectReagent(
+    ReactionMethod? Method,
     ReagentQuantity ReagentQuantity,
-    ReagentPrototype Reagent);
+    ReagentPrototype Reagent,
+    EntityUid? OrganEntity,
+    Solution? Source);
 
 public static class EntityEffectExt
 {


### PR DESCRIPTION
Відновлено контекст реагенту для legacy-ефектів під час метаболізму.

:cl:
- fix: Нікотин, алкоголь і наркотики знову коректно впливають на настрій, залежності та псіоніку.