### PR TITLE
Фікс смерті курей та здібностей Zappy Egg

### DIFF
--- a/Content.Pirate.Shared/Ranching/RanchingEffectAction.cs
+++ b/Content.Pirate.Shared/Ranching/RanchingEffectAction.cs
@@ -33,8 +33,8 @@ public sealed class RanchingEffectActionSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<EffectActionComponent, ActionPerformedEvent>(OnActionPerformed);
-        SubscribeLocalEvent<EffectActionComponent, EffectInstantActionEvent>(OnInstantAction);
-        SubscribeLocalEvent<EffectActionComponent, EffectTargetActionEvent>(OnTargetAction);
+        SubscribeLocalEvent<EffectInstantActionEvent>(OnInstantAction);
+        SubscribeLocalEvent<EffectTargetActionEvent>(OnTargetAction);
     }
 
     private void OnActionPerformed(Entity<EffectActionComponent> ent, ref ActionPerformedEvent args)
@@ -43,15 +43,21 @@ public sealed class RanchingEffectActionSystem : EntitySystem
             _effects.ApplyEffects(args.Performer, ent.Comp.Effects);
     }
 
-    private void OnInstantAction(Entity<EffectActionComponent> ent, ref EffectInstantActionEvent args)
+    private void OnInstantAction(EffectInstantActionEvent args)
     {
-        _effects.ApplyEffects(args.Performer, ent.Comp.Effects);
+        if (args.Handled || !TryComp<EffectActionComponent>(args.Action, out var action))
+            return;
+
+        _effects.ApplyEffects(args.Performer, action.Effects);
         args.Handled = true;
     }
 
-    private void OnTargetAction(Entity<EffectActionComponent> ent, ref EffectTargetActionEvent args)
+    private void OnTargetAction(EffectTargetActionEvent args)
     {
-        _effects.ApplyEffects(args.Target, ent.Comp.Effects);
+        if (args.Handled || !TryComp<EffectActionComponent>(args.Action, out var action))
+            return;
+
+        _effects.ApplyEffects(args.Target, action.Effects);
         args.Handled = true;
     }
 }

--- a/Resources/Prototypes/_Pirate/Ranching/Entities/Mobs/chickens.yml
+++ b/Resources/Prototypes/_Pirate/Ranching/Entities/Mobs/chickens.yml
@@ -1784,6 +1784,15 @@
     - MobDragonRooster
   - type: Sprite
     sprite: _Pirate/Ranching/Mobs/Ranch/chicken-dragon.rsi
+  # Pirate: closed-source sprites have no dead states, so keep the available breed sprite.
+  - type: DamageStateVisuals
+    states:
+      Alive:
+        Base: chick
+      Critical:
+        Base: chick
+      Dead:
+        Base: chick
 
 - type: entity
   parent: [BaseChickenDragon, BaseMobHenRanch]
@@ -1792,6 +1801,14 @@
   components:
   - type: Sprite
     sprite: _Pirate/Ranching/Mobs/Ranch/chicken-dragon.rsi
+  - type: DamageStateVisuals
+    states:
+      Alive:
+        Base: hen
+      Critical:
+        Base: hen
+      Dead:
+        Base: hen
 
 - type: entity
   parent: [BaseChickenDragon, BaseMobRoosterRanch]
@@ -1800,6 +1817,14 @@
   components:
   - type: Sprite
     sprite: _Pirate/Ranching/Mobs/Ranch/chicken-dragon.rsi
+  - type: DamageStateVisuals
+    states:
+      Alive:
+        Base: rooster
+      Critical:
+        Base: rooster
+      Dead:
+        Base: rooster
   - type: RechargeBasicEntityAmmo
     rechargeCooldown: 1
   - type: BasicEntityAmmoProvider
@@ -1844,6 +1869,15 @@
     - MobCoralRooster
   - type: Sprite
     sprite: _Pirate/Ranching/Mobs/Ranch/chicken-coral.rsi
+  # Pirate: closed-source sprites have no dead states, so keep the available breed sprite.
+  - type: DamageStateVisuals
+    states:
+      Alive:
+        Base: chick
+      Critical:
+        Base: chick
+      Dead:
+        Base: chick
 
 - type: entity
   parent: [BaseChickenCoral, BaseMobHenRanch]
@@ -1852,6 +1886,14 @@
   components:
   - type: Sprite
     sprite: _Pirate/Ranching/Mobs/Ranch/chicken-coral.rsi
+  - type: DamageStateVisuals
+    states:
+      Alive:
+        Base: hen
+      Critical:
+        Base: hen
+      Dead:
+        Base: hen
 
 - type: entity
   parent: [BaseChickenCoral, BaseMobRoosterRanch]
@@ -1860,3 +1902,11 @@
   components:
   - type: Sprite
     sprite: _Pirate/Ranching/Mobs/Ranch/chicken-coral.rsi
+  - type: DamageStateVisuals
+    states:
+      Alive:
+        Base: rooster
+      Critical:
+        Base: rooster
+      Dead:
+        Base: rooster


### PR DESCRIPTION
Виправлено error-спрайти Dragon/Coral Chicken після смерті та активацію здібностей від Zappy Egg.

:cl:
- fix: Dragon і Coral Chicken більше не стають error-спрайтами після смерті.
- fix: Здібності від Zappy Egg знову можна використовувати.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Виправлення**
  - Виправлено застосування ефектів під час дій із тваринами: ефекти тепер коректно застосовуються до виконавця або цілі та не повторюються для вже оброблених подій.

- **Візуальні зміни**
  - Оновлено відображення драконячих і коралових курчат, курей та півнів.
  - Для живого, критичного та мертвого станів використовується відповідна модель без окремого спрайта смерті.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->