### PR TITLE
Увімкнути нижню білизну для всіх рас

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/undergarments.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/undergarments.yml
@@ -5,7 +5,7 @@
   id: UndergarmentBottomBoxers
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson]
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species; reptilians and Feroxi use fitted sprites below.
   coloring:
     default:
       type: null
@@ -18,7 +18,7 @@
   id: UndergarmentBottomBriefs
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson]
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species; reptilians and Feroxi use fitted sprites below.
   coloring:
     default:
       type: null
@@ -31,7 +31,7 @@
   id: UndergarmentBottomSatin
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson]
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species; reptilians and Feroxi use fitted sprites below.
   coloring:
     default:
       type: null
@@ -44,7 +44,7 @@
   id: UndergarmentTopBra
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson]
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Feroxi, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species.
   coloring:
     default:
       type: null
@@ -57,7 +57,7 @@
   id: UndergarmentTopSportsbra
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson]
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Feroxi, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species.
   coloring:
     default:
       type: null
@@ -70,7 +70,7 @@
   id: UndergarmentTopBinder
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson]
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Feroxi, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species.
   coloring:
     default:
       type: null
@@ -83,7 +83,7 @@
   id: UndergarmentTopTanktop
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson]
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Feroxi, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species.
   coloring:
     default:
       type: null
@@ -187,7 +187,7 @@
   id: UndergarmentBottomBoxersReptilian
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Reptilian]
+  speciesRestriction: [Feroxi, Reptilian] # Pirate: Feroxi already use these fitted sprites.
   coloring:
     default:
       type: null
@@ -200,7 +200,7 @@
   id: UndergarmentBottomBriefsReptilian
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Reptilian]
+  speciesRestriction: [Feroxi, Reptilian] # Pirate: Feroxi already use these fitted sprites.
   coloring:
     default:
       type: null
@@ -213,7 +213,7 @@
   id: UndergarmentBottomSatinReptilian
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Reptilian]
+  speciesRestriction: [Feroxi, Reptilian] # Pirate: Feroxi already use these fitted sprites.
   coloring:
     default:
       type: null

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/undershirt.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/undershirt.yml
@@ -4,7 +4,7 @@
   id: UndershirtDefault
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Diona, Moth, Harpy, Yowie] # goob edit - yowies
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Feroxi, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species.
   coloring:
     default:
       type:
@@ -18,7 +18,7 @@
   id: UndershirtRolled
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Diona, Moth, Harpy, Yowie] # goob edit - yowies
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Feroxi, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species.
   coloring:
     default:
       type:
@@ -32,7 +32,7 @@
   id: UndershirtSleeveless
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Diona, Moth, Harpy, Yowie] # goob edit - yowies
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Feroxi, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species.
   coloring:
     default:
       type:
@@ -46,7 +46,7 @@
   id: UndershirtRolledSleeveless
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Diona, Moth, Harpy, Yowie] # goob edit - yowies
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Feroxi, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species.
   coloring:
     default:
       type:
@@ -60,7 +60,7 @@
   id: UndershirtGrossSleeveless
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Diona, Moth, Harpy, Yowie] # goob edit - yowies
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Feroxi, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species.
   coloring:
     default:
       type:
@@ -74,7 +74,7 @@
   id: UndershirtNanotrasen
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Diona, Moth, Harpy, Yowie] # goob edit - yowies
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Feroxi, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species.
   coloring:
     default:
       type:
@@ -88,7 +88,7 @@
   id: UndershirtBinder
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Diona, Moth, Harpy, Yowie] # goob edit - yowies
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Feroxi, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species.
   coloring:
     default:
       type:
@@ -102,7 +102,7 @@
   id: UndershirtBraClassic
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Diona, Moth, Harpy, Yowie] # goob edit - yowies
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Feroxi, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species.
   coloring:
     default:
       type:
@@ -116,7 +116,7 @@
   id: UndershirtBraSports
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Diona, Moth, Harpy, Yowie] # goob edit - yowies
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Feroxi, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species.
   coloring:
     default:
       type:
@@ -130,7 +130,7 @@
   id: UndershirtBraStrapless
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Diona, Moth, Harpy, Yowie] # goob edit - yowies
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Feroxi, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species.
   coloring:
     default:
       type:

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/underwear.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/underwear.yml
@@ -4,7 +4,7 @@
   id: UnderwearDefault
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Diona, Moth, Harpy, Yowie] # goob edit - yowies
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species; Feroxi use fitted sprites.
   coloring:
     default:
       type:
@@ -18,7 +18,7 @@
   id: UnderwearBriefs
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Diona, Moth, Harpy, Yowie] # goob edit - yowies
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species; Feroxi use fitted sprites.
   coloring:
     default:
       type:
@@ -32,7 +32,7 @@
   id: UnderwearLowriders
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Diona, Moth, Harpy, Yowie] # goob edit - yowies
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species; Feroxi use fitted sprites.
   coloring:
     default:
       type:
@@ -46,7 +46,7 @@
   id: UnderwearSatin
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Diona, Moth, Harpy, Yowie] # goob edit - yowies
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species; Feroxi use fitted sprites.
   coloring:
     default:
       type:
@@ -60,7 +60,7 @@
   id: UnderwearTanga
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, SlimePerson, Diona, Moth, Harpy, Yowie] # goob edit - yowies
+  speciesRestriction: [Arachnid, Chitinid, Diona, Dwarf, Felinid, Goblin, Harpy, Human, Hydrakin, IPC, Moth, Oni, Plasmaman, Reptilian, Resomi, Rodentia, Shadowkin, SlimePerson, Tajaran, Vulpkanin, Yowie] # Pirate: all compatible round-start species; Feroxi use fitted sprites.
   coloring:
     default:
       type:

--- a/Resources/Prototypes/Nyanotrasen/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Species/Oni.yml
@@ -45,6 +45,13 @@
     Chest:
       points: 8
       required: false
+    # Pirate: enable underwear customization.
+    UndergarmentTop:
+      points: 1
+      required: false
+    UndergarmentBottom:
+      points: 1
+      required: false
     RightLeg:
       points: 2
       required: false

--- a/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
@@ -30,6 +30,13 @@
     Chest:
       points: 1
       required: false
+    # Pirate: enable underwear customization.
+    UndergarmentTop:
+      points: 1
+      required: false
+    UndergarmentBottom:
+      points: 1
+      required: false
     RightLeg:
       points: 2
       required: false

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
@@ -88,6 +88,9 @@
       - map: [ "enum.HumanoidVisualLayers.LArm" ]
       - map: [ "enum.HumanoidVisualLayers.RLeg" ]
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
+      # Pirate: underwear customization.
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
       - map: [ "jumpsuit" ]
       - map: [ "enum.HumanoidVisualLayers.LHand" ]
       - map: [ "enum.HumanoidVisualLayers.RHand" ]

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
@@ -235,6 +235,9 @@
       - map: [ "enum.HumanoidVisualLayers.LArm" ]
       - map: [ "enum.HumanoidVisualLayers.RLeg" ]
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
+      # Pirate: underwear customization in character setup.
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
       - map: [ "underpants" ]
       - map: [ "undershirt" ]
       - map: [ "socks" ]

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
@@ -59,6 +59,9 @@
       - map: [ "enum.HumanoidVisualLayers.LArm" ]
       - map: [ "enum.HumanoidVisualLayers.RLeg" ]
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
+      # Pirate: underwear customization.
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
       - map: [ "jumpsuit" ]
       - map: [ "enum.HumanoidVisualLayers.LHand" ]
       - map: [ "enum.HumanoidVisualLayers.RHand" ]

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
@@ -54,6 +54,9 @@
         sprite: _DV/Mobs/Customization/Vulpkanin/masking_helpers.rsi
         state: female_full
         visible: false
+      # Pirate: underwear customization.
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
       - map: [ "jumpsuit" ]
       - map: [ "enum.HumanoidVisualLayers.LHand" ]
       - map: [ "enum.HumanoidVisualLayers.RHand" ]

--- a/Resources/Prototypes/_DV/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Species/chitinid.yml
@@ -70,6 +70,13 @@
     Chest:
       points: 1
       required: false
+    # Pirate: enable underwear customization.
+    UndergarmentTop:
+      points: 1
+      required: false
+    UndergarmentBottom:
+      points: 1
+      required: false
     RightLeg:
       points: 3
       required: false

--- a/Resources/Prototypes/_DV/Species/feroxi.yml
+++ b/Resources/Prototypes/_DV/Species/feroxi.yml
@@ -58,6 +58,13 @@
     Chest:
       points: 3
       required: false
+    # Pirate: enable underwear customization.
+    UndergarmentTop:
+      points: 1
+      required: false
+    UndergarmentBottom:
+      points: 1
+      required: false
     Arms:
       points: 4
       required: false

--- a/Resources/Prototypes/_DV/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_DV/Species/vulpkanin.yml
@@ -86,6 +86,13 @@
     HeadSide:
       points: 2
       required: false
+    # Pirate: enable underwear customization.
+    UndergarmentTop:
+      points: 1
+      required: false
+    UndergarmentBottom:
+      points: 1
+      required: false
     Overlay:
       points: 2
       required: false

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -121,6 +121,9 @@
           sprite: Mobs/Customization/masking_helpers.rsi
           state: female_full
           visible: false
+        # Pirate: underwear customization.
+        - map: ["enum.HumanoidVisualLayers.UndergarmentBottom"]
+        - map: ["enum.HumanoidVisualLayers.UndergarmentTop"]
         - map: ["enum.HumanoidVisualLayers.LFoot"]
         - map: ["enum.HumanoidVisualLayers.RFoot"]
         - map: ["socks"]

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Species/plasmaman.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Species/plasmaman.yml
@@ -28,6 +28,9 @@
       sprite: Mobs/Customization/masking_helpers.rsi
       state: unisex_full
       visible: false
+    # Pirate: underwear customization.
+    - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
+    - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
     - map: ["enum.HumanoidVisualLayers.LFoot"]
     - map: ["enum.HumanoidVisualLayers.RFoot"]
     - map: ["jumpsuit"] # jumpsuit after foot to show envirosuit shoes

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Species/shadowkin.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Species/shadowkin.yml
@@ -157,6 +157,9 @@
         sprite: Mobs/Customization/masking_helpers.rsi
         state: full
         visible: false
+      # Pirate: underwear customization.
+      - map: ["enum.HumanoidVisualLayers.UndergarmentBottom"]
+      - map: ["enum.HumanoidVisualLayers.UndergarmentTop"]
       - map: ["enum.HumanoidVisualLayers.LFoot"]
       - map: ["enum.HumanoidVisualLayers.RFoot"]
       - map: ["socks"]
@@ -275,6 +278,9 @@
           sprite: Mobs/Customization/masking_helpers.rsi
           state: full
           visible: false
+        # Pirate: underwear customization.
+        - map: ["enum.HumanoidVisualLayers.UndergarmentBottom"]
+        - map: ["enum.HumanoidVisualLayers.UndergarmentTop"]
         - map: ["enum.HumanoidVisualLayers.LFoot"]
         - map: ["enum.HumanoidVisualLayers.RFoot"]
         - map: ["socks"]

--- a/Resources/Prototypes/_EinsteinEngines/Species/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Species/ipc.yml
@@ -35,6 +35,9 @@
     HeadSide: MobHumanoidAnyMarking
     Tail: MobHumanoidAnyMarking
     Hair: MobHumanoidMarkingMatchSkin
+    # Pirate: enable underwear customization.
+    UndergarmentTop: MobHumanoidAnyMarking
+    UndergarmentBottom: MobHumanoidAnyMarking
     Chest: MobIPCChest
     Groin: MobIPCGroin
     LArm: MobIPCLArm
@@ -64,6 +67,13 @@
       points: 1
       required: true
       defaultMarkings: [ MobIPCChestDefault ]
+    # Pirate: enable underwear customization.
+    UndergarmentTop:
+      points: 1
+      required: false
+    UndergarmentBottom:
+      points: 1
+      required: false
     HeadSide:
       points: 1
       required: false

--- a/Resources/Prototypes/_EinsteinEngines/Species/plasmaman.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Species/plasmaman.yml
@@ -22,6 +22,9 @@
   sprites:
     Head: MobPlasmamanHead
     Face: MobHumanoidAnyMarking
+    # Pirate: enable underwear customization.
+    UndergarmentTop: MobHumanoidAnyMarking
+    UndergarmentBottom: MobHumanoidAnyMarking
     Chest: MobPlasmamanChest
     Groin: MobPlasmamanGroin
     Eyes: MobPlasmamanEyes
@@ -54,6 +57,13 @@
       points: 1
       required: false
     Chest:
+      points: 1
+      required: false
+    # Pirate: enable underwear customization.
+    UndergarmentTop:
+      points: 1
+      required: false
+    UndergarmentBottom:
       points: 1
       required: false
     Legs:

--- a/Resources/Prototypes/_EinsteinEngines/Species/shadowkin.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Species/shadowkin.yml
@@ -66,6 +66,13 @@
     Chest:
       points: 8
       required: false
+    # Pirate: enable underwear customization.
+    UndergarmentTop:
+      points: 1
+      required: false
+    UndergarmentBottom:
+      points: 1
+      required: false
     Legs:
       points: 8
       required: false

--- a/Resources/Prototypes/_Floofstation/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Floofstation/Entities/Mobs/Species/resomi.yml
@@ -248,6 +248,9 @@
     - map: [ "enum.HumanoidVisualLayers.RLeg" ]
     - map: [ "enum.HumanoidVisualLayers.LFoot" ]
     - map: [ "enum.HumanoidVisualLayers.RFoot" ]
+    # Pirate: underwear customization.
+    - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
+    - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
     - map: [ "enum.HumanoidVisualLayers.LHand" ]  # Hands below jumpsuit since its bigger-than-usual sprite and this allows jumpsuits to have better-looking sleeves
     - map: [ "enum.HumanoidVisualLayers.RHand" ]
     - map: [ "enum.HumanoidVisualLayers.Tail" ]   # Tail changed to be below outerclothing and above limbs
@@ -373,6 +376,9 @@
     - map: [ "enum.HumanoidVisualLayers.RLeg" ]
     - map: [ "enum.HumanoidVisualLayers.LFoot" ]
     - map: [ "enum.HumanoidVisualLayers.RFoot" ]
+    # Pirate: underwear customization.
+    - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
+    - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
     - map: [ "enum.HumanoidVisualLayers.LHand" ]  # Hands below jumpsuit since its bigger-than-usual sprite and this allows jumpsuits to have better-looking sleeves
     - map: [ "enum.HumanoidVisualLayers.RHand" ]
     - map: [ "enum.HumanoidVisualLayers.Tail" ]   # Tail changed to be below outerclothing and above limbs

--- a/Resources/Prototypes/_Obelisk/Species/hydrakin.yml
+++ b/Resources/Prototypes/_Obelisk/Species/hydrakin.yml
@@ -64,6 +64,13 @@
     Chest:
       points: 4
       required: false
+    # Pirate: enable underwear customization.
+    UndergarmentTop:
+      points: 1
+      required: false
+    UndergarmentBottom:
+      points: 1
+      required: false
     Legs:
       points: 8 # imp 2<8
       required: false


### PR DESCRIPTION
Нижня білизна доступна всім ігровим расам; для кастомних тіл додані відсутні точки та шари.

:cl:
- fix: Нижня білизна стала доступною для всіх ігрових рас.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Розширено кастомізацію нижньої білизни для багатьох видів персонажів, зокрема Oni, Felinid, Chitinid, Feroxi, IPC, Plasmaman, Shadowkin, Resomi, Hydrakin та інших.
  * Додано підтримку відображення верхньої й нижньої білизни для нових видів і синтетичних персонажів.
  * Розширено сумісність доступних варіантів білизни, включно зі спеціально підігнаними варіантами для Feroxi.
  * У налаштуваннях персонажа білизна доступна як необов’язкова кастомізація.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->