### PR TITLE
Виправити зависання при поверненні привида в тіло у контейнері

### DIFF
--- a/Content.Goobstation.Server/Shadowling/Systems/Abilities/CollectiveMind/ShadowlingBlackRecuperationSystem.cs
+++ b/Content.Goobstation.Server/Shadowling/Systems/Abilities/CollectiveMind/ShadowlingBlackRecuperationSystem.cs
@@ -43,6 +43,7 @@ public sealed class ShadowlingBlackRecuperationSystem : EntitySystem
     [Dependency] private readonly ISharedPlayerManager _playerMan = default!;
     [Dependency] private readonly IPrototypeManager _protoMan = default!;
     [Dependency] private readonly EuiManager _euiManager = default!;
+    [Dependency] private readonly GhostSystem _ghostSystem = default!; // Pirate
 
     public override void Initialize()
     {
@@ -104,7 +105,7 @@ public sealed class ShadowlingBlackRecuperationSystem : EntitySystem
             {
                 // notify them they're being revived.
                 if (mind.CurrentEntity != target)
-                    _euiManager.OpenEui(new ReturnToBodyEui(mind, _mind, _playerMan), session);
+                    _euiManager.OpenEui(new ReturnToBodyEui(mind, _ghostSystem, _playerMan), session);
             }
             else
             {

--- a/Content.IntegrationTests/Tests/_Pirate/Ghost/GhostReturnContainedBodyTests.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Ghost/GhostReturnContainedBodyTests.cs
@@ -2,6 +2,7 @@
 
 using System.Linq;
 using Content.IntegrationTests.Pair;
+using Content.Server.EUI;
 using Content.Server.Ghost;
 using Content.Server.Mind;
 using Content.Server.Storage.EntitySystems;
@@ -28,6 +29,7 @@ public sealed class GhostReturnContainedBodyTests
         });
         var map = await pair.CreateTestMap();
         var entMan = pair.Server.EntMan;
+        var euiManager = pair.Server.ResolveDependency<EuiManager>();
         var ghostSystem = pair.Server.System<GhostSystem>();
         var mindSystem = pair.Server.System<MindSystem>();
         var mobState = pair.Server.System<MobStateSystem>();
@@ -62,7 +64,15 @@ public sealed class GhostReturnContainedBodyTests
         {
             Assert.That(session.AttachedEntity, Is.EqualTo(ghost));
             Assert.That(mindSystem.TryGetMind(session.UserId, out _, out var mind), Is.True);
-            Assert.That(mind!.VisitingEntity, Is.EqualTo(ghost));
+            var mindComponent = mind!;
+            Assert.That(mindComponent.VisitingEntity, Is.EqualTo(ghost));
+
+            var returnEui = new ReturnToBodyEui(mindComponent, ghostSystem, pair.Server.PlayerMan);
+            euiManager.OpenEui(returnEui, session);
+            returnEui.HandleMessage(new ReturnToBodyMessage(true));
+
+            Assert.That(session.AttachedEntity, Is.EqualTo(ghost));
+            Assert.That(mindComponent.VisitingEntity, Is.EqualTo(ghost));
         });
 
         await pair.Server.WaitAssertion(() =>

--- a/Content.IntegrationTests/Tests/_Pirate/Ghost/GhostReturnContainedBodyTests.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Ghost/GhostReturnContainedBodyTests.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Linq;
+using Content.IntegrationTests.Pair;
+using Content.Server.Ghost;
+using Content.Server.Mind;
+using Content.Server.Storage.EntitySystems;
+using Content.Shared.Ghost;
+using Content.Shared.Mind.Components;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Storage.Components;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests._Pirate.Ghost;
+
+[TestFixture]
+public sealed class GhostReturnContainedBodyTests
+{
+    [Test]
+    public async Task ReturnToBodyWaitsUntilBodyLeavesEntityStorage()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            DummyTicker = false,
+            Connected = true,
+            Dirty = true,
+        });
+        var map = await pair.CreateTestMap();
+        var entMan = pair.Server.EntMan;
+        var ghostSystem = pair.Server.System<GhostSystem>();
+        var mindSystem = pair.Server.System<MindSystem>();
+        var mobState = pair.Server.System<MobStateSystem>();
+        var storageSystem = pair.Server.System<EntityStorageSystem>();
+        var session = pair.Server.PlayerMan.Sessions.Single();
+
+        EntityUid body = default;
+        EntityUid bodyBag = default;
+        EntityUid ghost = default;
+
+        await pair.Server.WaitAssertion(() =>
+        {
+            body = entMan.SpawnEntity("MobHuman", map.GridCoords);
+            var mind = mindSystem.CreateMind(session.UserId, session.Name);
+            mindSystem.TransferTo(mind, body, mind: mind.Comp);
+            mobState.ChangeMobState(body, MobState.Dead);
+
+            Assert.That(ghostSystem.OnGhostAttempt(mind, true, mind: mind.Comp), Is.True);
+            ghost = session.AttachedEntity!.Value;
+            Assert.That(entMan.HasComponent<GhostComponent>(ghost), Is.True);
+
+            bodyBag = entMan.SpawnEntity("BodyBag", map.GridCoords);
+            Assert.That(storageSystem.Insert(body, bodyBag), Is.True);
+            Assert.That(entMan.HasComponent<InsideEntityStorageComponent>(body), Is.True);
+        });
+        await pair.RunTicksSync(10);
+
+        await pair.Client.WaitPost(() => pair.Client.System<Content.Client.Ghost.GhostSystem>().ReturnToBody());
+        await pair.RunTicksSync(10);
+
+        await pair.Server.WaitAssertion(() =>
+        {
+            Assert.That(session.AttachedEntity, Is.EqualTo(ghost));
+            Assert.That(mindSystem.TryGetMind(session.UserId, out _, out var mind), Is.True);
+            Assert.That(mind!.VisitingEntity, Is.EqualTo(ghost));
+        });
+
+        await pair.Server.WaitAssertion(() =>
+        {
+            Assert.That(storageSystem.Remove(body, bodyBag), Is.True);
+            Assert.That(entMan.HasComponent<InsideEntityStorageComponent>(body), Is.False);
+        });
+        await pair.RunTicksSync(5);
+
+        await pair.Client.WaitPost(() => pair.Client.System<Content.Client.Ghost.GhostSystem>().ReturnToBody());
+        await pair.RunTicksSync(10);
+
+        await pair.Server.WaitAssertion(() =>
+        {
+            Assert.That(session.AttachedEntity, Is.EqualTo(body));
+            Assert.That(entMan.HasComponent<GhostComponent>(session.AttachedEntity!.Value), Is.False);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -311,6 +311,19 @@ namespace Content.Server.Ghost
                 return;
             }
 
+            // Pirate: Attaching to a body hidden in entity storage leaves the client without a usable eye.
+            if (_mind.TryGetMind(actor.PlayerSession, out _, out var mind)
+                && mind.OwnedEntity is { } body
+                && HasComp<InsideEntityStorageComponent>(body))
+            {
+                _popup.PopupEntity(
+                    Loc.GetString("ghost-return-to-body-in-container"),
+                    attached,
+                    actor.PlayerSession,
+                    PopupType.MediumCaution);
+                return;
+            }
+
             _mind.UnVisit(actor.PlayerSession);
         }
 

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -311,20 +311,32 @@ namespace Content.Server.Ghost
                 return;
             }
 
-            // Pirate: Attaching to a body hidden in entity storage leaves the client without a usable eye.
-            if (_mind.TryGetMind(actor.PlayerSession, out _, out var mind)
-                && mind.OwnedEntity is { } body
+            TryReturnToBody(actor.PlayerSession);
+        }
+
+        // Pirate: Keep every player-facing return path from attaching to a body hidden in entity storage.
+        public bool TryReturnToBody(ICommonSession session)
+        {
+            if (!_mind.TryGetMind(session, out _, out var mind)
+                || mind.VisitingEntity == null
+                || session.AttachedEntity is not { Valid: true } attached)
+            {
+                return false;
+            }
+
+            if (mind.OwnedEntity is { } body
                 && HasComp<InsideEntityStorageComponent>(body))
             {
                 _popup.PopupEntity(
                     Loc.GetString("ghost-return-to-body-in-container"),
                     attached,
-                    actor.PlayerSession,
+                    session,
                     PopupType.MediumCaution);
-                return;
+                return false;
             }
 
-            _mind.UnVisit(actor.PlayerSession);
+            _mind.UnVisit(session);
+            return true;
         }
 
         #region Warp

--- a/Content.Server/Ghost/ReturnToBodyEui.cs
+++ b/Content.Server/Ghost/ReturnToBodyEui.cs
@@ -11,13 +11,13 @@ namespace Content.Server.Ghost;
 
 public sealed class ReturnToBodyEui : BaseEui
 {
-    private readonly SharedMindSystem _mindSystem;
+    private readonly GhostSystem _ghostSystem; // Pirate
     private readonly ISharedPlayerManager _player;
     private readonly NetUserId? _userId;
 
-    public ReturnToBodyEui(MindComponent mind, SharedMindSystem mindSystem, ISharedPlayerManager player)
+    public ReturnToBodyEui(MindComponent mind, GhostSystem ghostSystem, ISharedPlayerManager player)
     {
-        _mindSystem = mindSystem;
+        _ghostSystem = ghostSystem;
         _player = player;
         _userId = mind.UserId;
     }
@@ -34,7 +34,7 @@ public sealed class ReturnToBodyEui : BaseEui
         }
 
         if (_userId is { } userId && _player.TryGetSessionById(userId, out var session))
-            _mindSystem.UnVisit(session);
+            _ghostSystem.TryReturnToBody(session); // Pirate
 
         Close();
     }

--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -47,6 +47,7 @@ public sealed class DefibrillatorSystem : EntitySystem
     [Dependency] private readonly DoAfterSystem _doAfter = default!;
     [Dependency] private readonly ElectrocutionSystem _electrocution = default!;
     [Dependency] private readonly EuiManager _euiManager = default!;
+    [Dependency] private readonly GhostSystem _ghostSystem = default!; // Pirate
     [Dependency] private readonly ISharedPlayerManager _player = default!;
     [Dependency] private readonly ItemToggleSystem _toggle = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
@@ -261,7 +262,7 @@ public sealed class DefibrillatorSystem : EntitySystem
                 // notify them they're being revived.
                 if (mind.CurrentEntity != target)
                 {
-                    _euiManager.OpenEui(new ReturnToBodyEui(mind, _mind, _player), session);
+                    _euiManager.OpenEui(new ReturnToBodyEui(mind, _ghostSystem, _player), session);
                 }
             }
             else

--- a/Content.Server/Silicons/StationAi/StationAiFixerConsoleSystem.cs
+++ b/Content.Server/Silicons/StationAi/StationAiFixerConsoleSystem.cs
@@ -11,6 +11,7 @@ namespace Content.Server.Silicons.StationAi;
 public sealed partial class StationAiFixerConsoleSystem : SharedStationAiFixerConsoleSystem
 {
     [Dependency] private readonly EuiManager _eui = default!;
+    [Dependency] private readonly GhostSystem _ghostSystem = default!; // Pirate
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -29,7 +30,7 @@ public sealed partial class StationAiFixerConsoleSystem : SharedStationAiFixerCo
                         mind.IsVisitingEntity &&
                         _player.TryGetSessionById(mind.UserId, out var session))
                     {
-                        _eui.OpenEui(new ReturnToBodyEui(mind, _mind, _player), session);
+                        _eui.OpenEui(new ReturnToBodyEui(mind, _ghostSystem, _player), session);
                         _popup.PopupEntity(Loc.GetString("station-ai-fixer-console-repair-finished"), ent);
                     }
                     else

--- a/Content.Server/_EinsteinEngines/Silicon/DeadStartupButton/DeadStartupButtonSystem.cs
+++ b/Content.Server/_EinsteinEngines/Silicon/DeadStartupButton/DeadStartupButtonSystem.cs
@@ -40,6 +40,7 @@ public sealed class DeadStartupButtonSystem : SharedDeadStartupButtonSystem
 
      // Goobstation - Revive notification
     [Dependency] private readonly EuiManager _euiManager = default!;
+    [Dependency] private readonly GhostSystem _ghostSystem = default!; // Pirate
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly ISharedPlayerManager _player = default!;
 
@@ -110,7 +111,7 @@ public sealed class DeadStartupButtonSystem : SharedDeadStartupButtonSystem
         {
             // notify them they're being revived
             if (mind.CurrentEntity != uid)
-                _euiManager.OpenEui(new ReturnToBodyEui(mind, _mind, _player), playerSession);
+                _euiManager.OpenEui(new ReturnToBodyEui(mind, _ghostSystem, _player), playerSession);
         }
     }
 

--- a/Resources/Locale/uk-UA/ghost/ghost-gui.ftl
+++ b/Resources/Locale/uk-UA/ghost/ghost-gui.ftl
@@ -16,6 +16,7 @@ ghost-roles-window-no-roles-available-label = Наразі немає досту
 ghost-roles-window-rules-footer = Кнопка буде активна після {$time} секунд (затримка зроблена для того, щоб ви встигли прочитали правила).
 ghost-return-to-body-title = Повернутися у тіло
 ghost-return-to-body-text = Вас реанімують! Повернутися у тіло?
+ghost-return-to-body-in-container = Спочатку ваше тіло мають дістати з контейнера.
 ghost-gui-return-to-round-button = Респавн
 ghost-target-window-warp-to-most-followed = До найвідстежуванішого
 ghost-roles-window-join-raffle-button = Приєднатися до розіграшу ролі


### PR DESCRIPTION
Повернення у тіло тепер очікує, доки його дістануть із сумки чи іншого сховища.

:cl:
- fix: Привиди більше не зависають, повертаючись у тіло всередині контейнера.