### PR TITLE
Вимкнути спавн Різника

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -67,7 +67,7 @@
     - id: BingleSpawn #Goobstation - Bingle
     - id: SlaughterDemonMidround # Goobstation - Slaughter Demon
     - id: XenomorphsInfestation # WD EDIT
-    - id: SlasherSpawn # Goobstation - The Slasher
+    # - id: SlasherSpawn # Pirate disable
     - id: TerrorSpidersSpawn # Pirate - Starlight terror spiders
     - id: SpacePirates # Goobstation - you probably can read whom this rule spawns
     - id: SingulothKnightsMidround # Goobstation - New Midrounds

--- a/Resources/Prototypes/_Goobstation/GameRules/Admeme/token.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/Admeme/token.yml
@@ -308,63 +308,64 @@
     objectives:
     - SlaughterHugAndTickleObjective
 
-- type: entity
-  parent: SlasherSpawn
-  id: TokenSlasherSpawn
-  components:
-  - type: AntagSelection
-    selectionTime: PostPlayerSpawn
-    agentName: slasher-round-end-agent-name # Change later
-    definitions:
-    - spawnerPrototype: SpawnPointGhostSlasherToken
-      min: 1
-      max: 1
-      pickPlayer: false
-      startingGear: SlasherGear
-      roleLoadout:
-      - RoleSurvivalEVA
-      briefing:
-        text: slasher-role-greeting
-        color: Red
-        sound: /Audio/_Goobstation/Effects/Slasher/SlasherIntro.ogg
-      mindRoles:
-      - MindRoleSlasher
-      components:
-      - type: Slasher
-      - type: SlasherSummonMachete
-      - type: SlasherStaggerArea
-      - type: SlasherRelentlessGrab
-      - type: SlasherRegenerate
-      - type: SlasherBloodTrail
-      - type: SlasherIncorporeal
-      - type: SlasherSoulSteal
-      - type: SlasherSummonMeatSpike
-      - type: NightVision
-        color: "#FF0000"
-        toggleAction: ActionSlasherNightVision
-        activateSound: !type:SoundCollectionSpecifier
-          collection: EyeOpen
-        deactivateSound: !type:SoundCollectionSpecifier
-          collection: EyeClose
-      - type: Puller
-        grabThrownSpeed: 10
-        throwingDistance: 8
-        softGrabSpeedModifier: 1
-        hardGrabSpeedModifier: 1
-        chokeGrabSpeedModifier: 1
-      - type: Hunger
-        baseDecayRate: 0
-      - type: Thirst
-        baseDecayRate: 0
-      - type: MobThresholds
-        thresholds:
-          0: Alive
-          150: Dead
-      - type: RandomMetadata
-        nameSegments:
-        - NamesSlasherTitle
-        - NamesSlasher
-        nameFormat: name-format-slasher
+# Pirate: Slasher token gamerule is disabled.
+#- type: entity
+#  parent: SlasherSpawn
+#  id: TokenSlasherSpawn
+#  components:
+#  - type: AntagSelection
+#    selectionTime: PostPlayerSpawn
+#    agentName: slasher-round-end-agent-name # Change later
+#    definitions:
+#    - spawnerPrototype: SpawnPointGhostSlasherToken
+#      min: 1
+#      max: 1
+#      pickPlayer: false
+#      startingGear: SlasherGear
+#      roleLoadout:
+#      - RoleSurvivalEVA
+#      briefing:
+#        text: slasher-role-greeting
+#        color: Red
+#        sound: /Audio/_Goobstation/Effects/Slasher/SlasherIntro.ogg
+#      mindRoles:
+#      - MindRoleSlasher
+#      components:
+#      - type: Slasher
+#      - type: SlasherSummonMachete
+#      - type: SlasherStaggerArea
+#      - type: SlasherRelentlessGrab
+#      - type: SlasherRegenerate
+#      - type: SlasherBloodTrail
+#      - type: SlasherIncorporeal
+#      - type: SlasherSoulSteal
+#      - type: SlasherSummonMeatSpike
+#      - type: NightVision
+#        color: "#FF0000"
+#        toggleAction: ActionSlasherNightVision
+#        activateSound: !type:SoundCollectionSpecifier
+#          collection: EyeOpen
+#        deactivateSound: !type:SoundCollectionSpecifier
+#          collection: EyeClose
+#      - type: Puller
+#        grabThrownSpeed: 10
+#        throwingDistance: 8
+#        softGrabSpeedModifier: 1
+#        hardGrabSpeedModifier: 1
+#        chokeGrabSpeedModifier: 1
+#      - type: Hunger
+#        baseDecayRate: 0
+#      - type: Thirst
+#        baseDecayRate: 0
+#      - type: MobThresholds
+#        thresholds:
+#          0: Alive
+#          150: Dead
+#      - type: RandomMetadata
+#        nameSegments:
+#        - NamesSlasherTitle
+#        - NamesSlasher
+#        nameFormat: name-format-slasher
 
 - type: entity
   parent: ContractorSpawn

--- a/Resources/Prototypes/_Goobstation/GameRules/addtional_tables.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/addtional_tables.yml
@@ -34,7 +34,7 @@
     - id: BingleSpawn
    #- id: SlaughterDemonMidround
    #- id: XenomorphsInfestation #  removed for low pop too little sec
-    - id: SlasherSpawn
+    # - id: SlasherSpawn # Pirate disable
     - id: SpacePirates
     #- id: SingulothKnightsMidround
     #- id: DarkLordMidround

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -390,220 +390,221 @@
   - type: Tag
 
 # Slasher
-- type: entity
-  parent: BaseGameRule
-  id: SlasherSpawn
-  components:
-  - type: StationEvent
-    weight: 3
-    duration: null
-    earliestStart: 30
-    minimumPlayers: 30
-    chaos:
-      Hostile: 40
-      Combat: 40
-      Death: 40
-    eventType: HostilesSpawn
-  - type: GameRule
-    chaosScore: 600
-  - type: AntagLockerSpawn
-  - type: AntagLoadProfileRule
-    speciesOverride: Human
-    speciesOverrideBlacklist:
-    - Yowie
-    - IPC
-    - Diona
-    - Harpy
-    - Plasmaman
-    forceMaxSize: true
-  - type: AntagObjectives
-    objectives:
-    - SlasherSurviveObjective
-    - SlasherAbsorbSoulsObjective
-  - type: AntagSelection
-    selectionTime: PostPlayerSpawn
-    agentName: slasher-round-end-agent-name
-    definitions:
-    - spawnerPrototype: SpawnPointGhostSlasher
-      min: 1
-      max: 1
-      pickPlayer: false
-      briefing:
-        text: slasher-role-greeting
-        color: Red
-        sound: /Audio/_Goobstation/Effects/Slasher/SlasherIntro.ogg
-      mindRoles:
-      - MindRoleSlasher
-      components:
-      - type: SlasherKitSelect
-        kits:
-          slasher-kit-butcher:
-            gear: SlasherGear
-            description: slasher-kit-butcher-desc
-            sprite:
-              sprite: _Goobstation/Objects/Specific/Slasher/mask.rsi
-              state: icon
-          slasher-kit-spring:
-            gear: SlasherGearSpring
-            description: slasher-kit-spring-desc
-            sprite:
-              sprite: _Goobstation/Objects/Specific/Slasher/spring_mask.rsi
-              state: icon
-            machetePrototype: SlasherMacheteSpring
-            bloodTrailMusic:
-              path: /Audio/_Goobstation/Music/fnaf_bonnies_lullaby.ogg
-              params:
-                volume: -4
-                loop: true
-          slasher-kit-billy:
-            gear: SlasherGearBilly
-            description: slasher-kit-billy-desc
-            sprite:
-              sprite: Objects/Tools/crowbar.rsi
-              state: icon
-            machetePrototype: SlasherCrowbar
-            bloodTrailMusic:
-              path: /Audio/_Goobstation/Music/that_handsome_devil_midi.ogg
-              params:
-                volume: -7
-                loop: true
-          slasher-kit-cult:
-            gear: SlasherGearCult
-            description: slasher-kit-cult-desc
-            sprite:
-              sprite: Clothing/Head/Hoods/cult.rsi
-              state: icon
-            machetePrototype: SlasherEldritchBlade
-            bloodTrailMusic:
-              path: /Audio/_Goobstation/Music/cultist_chant.ogg
-              params:
-                loop: true
-          slasher-kit-maintenance:
-            gear: SlasherGearMaintenance
-            description: slasher-kit-maintenance-desc
-            sprite:
-              sprite: Clothing/Head/Hats/papersacksmile.rsi
-              state: icon
-            machetePrototype: SlasherButchCleaver
-            bloodTrailMusic:
-              path: /Audio/_Goobstation/Music/scared_to_bits.ogg
-              params:
-                loop: true
-          slasher-kit-cannibal:
-            gear: SlasherGearCannibal
-            description: slasher-kit-cannibal-desc
-            sprite:
-              sprite: _Goobstation/Wizard/Clothing/Mask/pig.rsi
-              state: icon
-            machetePrototype: SlasherButchCleaver
-            bloodTrailMusic:
-              path: /Audio/_Goobstation/Music/horror_violin_string.ogg
-              params:
-                volume: -7
-                loop: true
-          slasher-kit-clown:
-            gear: SlasherGearClown
-            description: slasher-kit-clown-desc
-            sprite:
-              sprite: Clothing/Mask/clown.rsi
-              state: icon
-            machetePrototype: SlasherOffsetCaneClown
-            bloodTrailMusic:
-              path: /Audio/_Goobstation/Music/naktigonis_catwhisker.ogg
-              params:
-                volume: -7
-                loop: true
-            jumpscareSound:
-              path: /Audio/Items/Toys/pushHornHonk.ogg
-            meatSpikePrototype: SlasherMeatSpikeClown
-            bloodTrailReagent: Honk
-            soulStealSound:
-              path: /Audio/Items/Toys/pushHornHonk.ogg
-            ascensionGear: SlasherGearClownAscended
-            ascendanceAnnouncementKey: slasher-soulsteal-ascendance-clown
-            ascendanceSound:
-              path: /Audio/Items/Toys/pushHornHonk.ogg
-              params:
-                volume: -2
-          slasher-kit-glutton:
-            gear: SlasherGearGlutton
-            description: slasher-kit-glutton-desc
-            sprite:
-              sprite: Clothing/OuterClothing/Hardsuits/lingspacesuit.rsi
-              state: icon
-            machetePrototype: SlasherButchCleaver
-            bloodTrailMusic:
-              path: /Audio/_Goobstation/Music/padtext_horror.ogg
-              params:
-                volume: -7
-                loop: true
-          slasher-kit-hockey:
-            gear: SlasherGearHockey
-            description: slasher-kit-hockey-desc
-            sprite:
-              sprite: _Goobstation/Objects/Specific/Slasher/hockymask/hockey_mask.rsi
-              state: icon
-            bloodTrailMusic:
-              path: /Audio/_Goobstation/Music/horror_synthwave.ogg
-              params:
-                volume: -7
-                loop: true
-            jumpscareSound:
-              path: /Audio/_Goobstation/Effects/Slasher/JasonJumpscare.ogg
-        postSelectionComponents:
-          - type: Slasher
-          - type: SlasherSummonMachete
-          - type: SlasherStaggerArea
-          - type: SlasherRelentlessGrab
-          - type: SlasherRegenerate
-          - type: SlasherBloodTrail
-          - type: SlasherIncorporeal
-          - type: SlasherSoulSteal
-          - type: SlasherSummonMeatSpike
-          - type: NightVision
-            color: "#FF0000"
-            toggleAction: ActionSlasherNightVision
-            activateSound: !type:SoundCollectionSpecifier
-              collection: EyeOpen
-            deactivateSound: !type:SoundCollectionSpecifier
-              collection: EyeClose
-          - type: GrabIntent
-            grabThrownSpeed: 10
-            throwingDistance: 8
-            softGrabSpeedModifier: 1
-            hardGrabSpeedModifier: 1
-            chokeGrabSpeedModifier: 1
-          - type: BreathingImmunity
-          - type: GunBlocked
-            popupText: slasher-cannot-use-guns # Seems to be broken inside AntagSelection
-          - type: WeakToHoly
-          - type: Hunger
-            baseDecayRate: 0
-          - type: Thirst
-            baseDecayRate: 0
-          - type: MobThresholds
-            thresholds:
-              0: Alive
-              150: Dead
-          - type: RandomMetadata
-            nameSegments:
-            - NamesSlasherTitle
-            - NamesSlasher
-            nameFormat: name-format-slasher
-      - type: UserInterface
-        interfaces:
-          enum.SlasherKitSelectUiKey.Key:
-            type: SlasherKitSelectBoundUserInterface
-      - type: GhostRole
-        name: ghost-role-information-slasher-name
-        description: ghost-role-information-slasher-description
-        rules: ghost-role-information-antagonist-rules
-        mindRoles:
-        - MindRoleGhostRoleSoloAntagonist
-      - type: GhostTakeoverAvailable
-  - type: Tag
-    tags:
-    - MidroundAntag
+# Pirate: Slasher gamerule is disabled.
+#- type: entity
+#  parent: BaseGameRule
+#  id: SlasherSpawn
+#  components:
+#  - type: StationEvent
+#    weight: 3
+#    duration: null
+#    earliestStart: 30
+#    minimumPlayers: 30
+#    chaos:
+#      Hostile: 40
+#      Combat: 40
+#      Death: 40
+#    eventType: HostilesSpawn
+#  - type: GameRule
+#    chaosScore: 600
+#  - type: AntagLockerSpawn
+#  - type: AntagLoadProfileRule
+#    speciesOverride: Human
+#    speciesOverrideBlacklist:
+#    - Yowie
+#    - IPC
+#    - Diona
+#    - Harpy
+#    - Plasmaman
+#    forceMaxSize: true
+#  - type: AntagObjectives
+#    objectives:
+#    - SlasherSurviveObjective
+#    - SlasherAbsorbSoulsObjective
+#  - type: AntagSelection
+#    selectionTime: PostPlayerSpawn
+#    agentName: slasher-round-end-agent-name
+#    definitions:
+#    - spawnerPrototype: SpawnPointGhostSlasher
+#      min: 1
+#      max: 1
+#      pickPlayer: false
+#      briefing:
+#        text: slasher-role-greeting
+#        color: Red
+#        sound: /Audio/_Goobstation/Effects/Slasher/SlasherIntro.ogg
+#      mindRoles:
+#      - MindRoleSlasher
+#      components:
+#      - type: SlasherKitSelect
+#        kits:
+#          slasher-kit-butcher:
+#            gear: SlasherGear
+#            description: slasher-kit-butcher-desc
+#            sprite:
+#              sprite: _Goobstation/Objects/Specific/Slasher/mask.rsi
+#              state: icon
+#          slasher-kit-spring:
+#            gear: SlasherGearSpring
+#            description: slasher-kit-spring-desc
+#            sprite:
+#              sprite: _Goobstation/Objects/Specific/Slasher/spring_mask.rsi
+#              state: icon
+#            machetePrototype: SlasherMacheteSpring
+#            bloodTrailMusic:
+#              path: /Audio/_Goobstation/Music/fnaf_bonnies_lullaby.ogg
+#              params:
+#                volume: -4
+#                loop: true
+#          slasher-kit-billy:
+#            gear: SlasherGearBilly
+#            description: slasher-kit-billy-desc
+#            sprite:
+#              sprite: Objects/Tools/crowbar.rsi
+#              state: icon
+#            machetePrototype: SlasherCrowbar
+#            bloodTrailMusic:
+#              path: /Audio/_Goobstation/Music/that_handsome_devil_midi.ogg
+#              params:
+#                volume: -7
+#                loop: true
+#          slasher-kit-cult:
+#            gear: SlasherGearCult
+#            description: slasher-kit-cult-desc
+#            sprite:
+#              sprite: Clothing/Head/Hoods/cult.rsi
+#              state: icon
+#            machetePrototype: SlasherEldritchBlade
+#            bloodTrailMusic:
+#              path: /Audio/_Goobstation/Music/cultist_chant.ogg
+#              params:
+#                loop: true
+#          slasher-kit-maintenance:
+#            gear: SlasherGearMaintenance
+#            description: slasher-kit-maintenance-desc
+#            sprite:
+#              sprite: Clothing/Head/Hats/papersacksmile.rsi
+#              state: icon
+#            machetePrototype: SlasherButchCleaver
+#            bloodTrailMusic:
+#              path: /Audio/_Goobstation/Music/scared_to_bits.ogg
+#              params:
+#                loop: true
+#          slasher-kit-cannibal:
+#            gear: SlasherGearCannibal
+#            description: slasher-kit-cannibal-desc
+#            sprite:
+#              sprite: _Goobstation/Wizard/Clothing/Mask/pig.rsi
+#              state: icon
+#            machetePrototype: SlasherButchCleaver
+#            bloodTrailMusic:
+#              path: /Audio/_Goobstation/Music/horror_violin_string.ogg
+#              params:
+#                volume: -7
+#                loop: true
+#          slasher-kit-clown:
+#            gear: SlasherGearClown
+#            description: slasher-kit-clown-desc
+#            sprite:
+#              sprite: Clothing/Mask/clown.rsi
+#              state: icon
+#            machetePrototype: SlasherOffsetCaneClown
+#            bloodTrailMusic:
+#              path: /Audio/_Goobstation/Music/naktigonis_catwhisker.ogg
+#              params:
+#                volume: -7
+#                loop: true
+#            jumpscareSound:
+#              path: /Audio/Items/Toys/pushHornHonk.ogg
+#            meatSpikePrototype: SlasherMeatSpikeClown
+#            bloodTrailReagent: Honk
+#            soulStealSound:
+#              path: /Audio/Items/Toys/pushHornHonk.ogg
+#            ascensionGear: SlasherGearClownAscended
+#            ascendanceAnnouncementKey: slasher-soulsteal-ascendance-clown
+#            ascendanceSound:
+#              path: /Audio/Items/Toys/pushHornHonk.ogg
+#              params:
+#                volume: -2
+#          slasher-kit-glutton:
+#            gear: SlasherGearGlutton
+#            description: slasher-kit-glutton-desc
+#            sprite:
+#              sprite: Clothing/OuterClothing/Hardsuits/lingspacesuit.rsi
+#              state: icon
+#            machetePrototype: SlasherButchCleaver
+#            bloodTrailMusic:
+#              path: /Audio/_Goobstation/Music/padtext_horror.ogg
+#              params:
+#                volume: -7
+#                loop: true
+#          slasher-kit-hockey:
+#            gear: SlasherGearHockey
+#            description: slasher-kit-hockey-desc
+#            sprite:
+#              sprite: _Goobstation/Objects/Specific/Slasher/hockymask/hockey_mask.rsi
+#              state: icon
+#            bloodTrailMusic:
+#              path: /Audio/_Goobstation/Music/horror_synthwave.ogg
+#              params:
+#                volume: -7
+#                loop: true
+#            jumpscareSound:
+#              path: /Audio/_Goobstation/Effects/Slasher/JasonJumpscare.ogg
+#        postSelectionComponents:
+#          - type: Slasher
+#          - type: SlasherSummonMachete
+#          - type: SlasherStaggerArea
+#          - type: SlasherRelentlessGrab
+#          - type: SlasherRegenerate
+#          - type: SlasherBloodTrail
+#          - type: SlasherIncorporeal
+#          - type: SlasherSoulSteal
+#          - type: SlasherSummonMeatSpike
+#          - type: NightVision
+#            color: "#FF0000"
+#            toggleAction: ActionSlasherNightVision
+#            activateSound: !type:SoundCollectionSpecifier
+#              collection: EyeOpen
+#            deactivateSound: !type:SoundCollectionSpecifier
+#              collection: EyeClose
+#          - type: GrabIntent
+#            grabThrownSpeed: 10
+#            throwingDistance: 8
+#            softGrabSpeedModifier: 1
+#            hardGrabSpeedModifier: 1
+#            chokeGrabSpeedModifier: 1
+#          - type: BreathingImmunity
+#          - type: GunBlocked
+#            popupText: slasher-cannot-use-guns # Seems to be broken inside AntagSelection
+#          - type: WeakToHoly
+#          - type: Hunger
+#            baseDecayRate: 0
+#          - type: Thirst
+#            baseDecayRate: 0
+#          - type: MobThresholds
+#            thresholds:
+#              0: Alive
+#              150: Dead
+#          - type: RandomMetadata
+#            nameSegments:
+#            - NamesSlasherTitle
+#            - NamesSlasher
+#            nameFormat: name-format-slasher
+#      - type: UserInterface
+#        interfaces:
+#          enum.SlasherKitSelectUiKey.Key:
+#            type: SlasherKitSelectBoundUserInterface
+#      - type: GhostRole
+#        name: ghost-role-information-slasher-name
+#        description: ghost-role-information-slasher-description
+#        rules: ghost-role-information-antagonist-rules
+#        mindRoles:
+#        - MindRoleGhostRoleSoloAntagonist
+#      - type: GhostTakeoverAvailable
+#  - type: Tag
+#    tags:
+#    - MidroundAntag
 
 # Santa
 

--- a/Resources/Prototypes/_Goobstation/threats.yml
+++ b/Resources/Prototypes/_Goobstation/threats.yml
@@ -50,10 +50,11 @@
   announcement: terror-wizard
   rule: WizardMidround
 
-- type: ninjaHackingThreat
-  id: Slasher
-  announcement: terror-slasher
-  rule: SlasherSpawn
+# Pirate: Slasher gamerule is disabled.
+#- type: ninjaHackingThreat
+#  id: Slasher
+#  announcement: terror-slasher
+#  rule: SlasherSpawn
 
 #- type: ninjaHackingThreat
 #  id: Wraith


### PR DESCRIPTION
Вимкнено автоматичний спавн Різника та його жетонне правило для `addgamerule`.

:cl:
- remove: Різника прибрано з автоматичної ротації та жетонних антагоністів.