### PR TITLE
Додати гріншифт-варіанти секретних режимів

### DIFF
--- a/Resources/Prototypes/_Pirate/game_presets.yml
+++ b/Resources/Prototypes/_Pirate/game_presets.yml
@@ -25,6 +25,47 @@
     - SecretSalt
     - PsionicEventsScheduler # Pirate
 
+# Pirate: Admin-only decoy presets run Greenshift while showing another mode in the lobby.
+- type: gamePreset
+  id: SecretCosmicCultGreenshift
+  alias:
+    - secretcosmiccultgreenshift
+    - secretentropygreenshift
+    - entropygreenshift
+  name: secret-title
+  description: secret-description
+  showInVote: false
+  rules:
+    - SpaceTrafficControlFriendlyEventScheduler
+    - BasicRoundstartVariation
+    - PsionicEventsScheduler # Pirate
+
+- type: gamePreset
+  id: SecretTPGreenshift
+  alias:
+    - secrettpgreenshift
+    - tpsecretgreenshift
+  name: secrettp-title
+  description: secrettp-description
+  showInVote: false
+  rules:
+    - SpaceTrafficControlFriendlyEventScheduler
+    - BasicRoundstartVariation
+    - PsionicEventsScheduler # Pirate
+
+- type: gamePreset
+  id: SecretSaltGreenshift
+  alias:
+    - secretsaltgreenshift
+    - saltsecretgreenshift
+  name: secretsalt-title
+  description: secretsalt-description
+  showInVote: false
+  rules:
+    - SpaceTrafficControlFriendlyEventScheduler
+    - BasicRoundstartVariation
+    - PsionicEventsScheduler # Pirate
+
 - type: gamePreset
   id: PirateGreenshift
   alias:


### PR DESCRIPTION
Додає приховані адмінські пресети, які запускають Greenshift, але показують назви відповідних секретних режимів: ентропія/Секрет, Секрет ТП і Секрет Сіль.

:cl:
- add: Додано гріншифт-варіанти для секретних режимів.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Додано три приховані адміністративні пресети для спеціальних варіантів раунду.
  * Пресети запускають дружні космічні, базові та псіонічні події.
  * Вони не беруть участі в голосуванні за режим гри.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->