### PR TITLE
Виправити лікування нефункціональних кінцівок

### DIFF
--- a/Content.IntegrationTests/Tests/_Pirate/Medical/LimbFixationTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Medical/LimbFixationTest.cs
@@ -15,6 +15,9 @@ using Content.Shared._Shitmed.Medical.Surgery.Wounds.Components;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds.Systems;
 using Content.Shared._Shitmed.Targeting;
 using Content.Shared.Body.Part;
+using Content.Shared.DoAfter;
+using Content.Shared.Medical;
+using Content.Shared.Stacks;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 
@@ -450,6 +453,80 @@ public sealed class LimbFixationTest
             Assert.That(
                 wounds.GetDamageRedirectTarget(human, head.Id, "Piercing"),
                 Is.EqualTo(chest.Id));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task TopicalHealingOnDisabledPartDoesNotHealOtherParts()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = false,
+            InLobby = false,
+        });
+
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var body = entMan.System<BodySystem>();
+        var doAfters = entMan.System<SharedDoAfterSystem>();
+        var wounds = entMan.System<WoundSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            var human = entMan.Spawn("MobHuman");
+            entMan.EnsureComponent<LimbFixationComponent>(human);
+
+            var disabledHand = body.GetBodyChildrenOfType(
+                    human,
+                    BodyPartType.Hand,
+                    symmetry: BodyPartSymmetry.Left)
+                .Single()
+                .Id;
+            var damagedArm = body.GetBodyChildrenOfType(
+                    human,
+                    BodyPartType.Arm,
+                    symmetry: BodyPartSymmetry.Left)
+                .Single()
+                .Id;
+            var burnedArm = body.GetBodyChildrenOfType(
+                    human,
+                    BodyPartType.Arm,
+                    symmetry: BodyPartSymmetry.Right)
+                .Single()
+                .Id;
+            var burnedWoundable = entMan.GetComponent<WoundableComponent>(burnedArm);
+
+            entMan.EnsureComponent<LimbFixationDamageComponent>(damagedArm);
+            Assert.That(entMan.HasComponent<LimbFixationDisabledComponent>(disabledHand), Is.True);
+            Assert.That(
+                wounds.TryInduceWound(burnedArm, "Heat", FixedPoint2.New(10), out _, burnedWoundable),
+                Is.True);
+
+            var integrityBefore = burnedWoundable.WoundableIntegrity;
+            var ointment = entMan.Spawn("Ointment1");
+            entMan.GetComponent<TargetingComponent>(human).Target = TargetBodyPart.LeftHand;
+
+            var healing = new HealingDoAfterEvent();
+            var doAfterArgs = new DoAfterArgs(
+                entMan,
+                human,
+                TimeSpan.Zero,
+                healing,
+                human,
+                target: human,
+                used: ointment);
+            Assert.That(doAfters.TryStartDoAfter(doAfterArgs), Is.True);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    entMan.GetComponent<WoundableComponent>(burnedArm).WoundableIntegrity,
+                    Is.EqualTo(integrityBefore));
+                Assert.That(entMan.GetComponent<StackComponent>(ointment).Count, Is.EqualTo(1));
+                Assert.That(entMan.HasComponent<LimbFixationDamageComponent>(damagedArm), Is.True);
+            });
         });
 
         await pair.CleanReturnAsync();

--- a/Content.Shared/Medical/Healing/HealingSystem.cs
+++ b/Content.Shared/Medical/Healing/HealingSystem.cs
@@ -18,6 +18,8 @@ using Content.Shared.Popups;
 using Content.Shared.Stacks;
 using Robust.Shared.Audio.Systems;
 
+using Content.Shared._Pirate.Medical.LimbFixation; // Pirate
+
 // Shitmed Change
 using Content.Shared._Shitmed.Medical.Surgery.Consciousness.Components;
 using Content.Shared._Shitmed.Medical.Surgery.Traumas.Components;
@@ -371,15 +373,25 @@ public sealed class HealingSystem : EntitySystem
             // Create parts to go over queue: targetted part -> head -> torso -> groin -> everything else
             // Iterate over the parts in the predefined order until we run out of parts or run out of healing
             var woundablesQueue = new Queue<EntityUid>();
-            woundablesQueue.Enqueue(targetedWoundable);
-            for (var i = 0; i < _partHealingOrder.Length; i++)
+            // Pirate: restore function before treating the part or spreading its healing.
+            if (HasComp<LimbFixationDamageComponent>(targetedWoundable)
+                || HasComp<LimbFixationDisabledComponent>(targetedWoundable))
             {
-                var (partType, symmetry) = _bodySystem.ConvertTargetBodyPart(_partHealingOrder[i]);
-                var targetedBodyPart = _bodySystem.GetBodyChildrenOfType(ent, partType, comp, symmetry).ToList().FirstOrDefault();
-                if (targetedBodyPart.Id == targetedWoundable)
-                    continue;
-                woundablesQueue.Enqueue(targetedBodyPart.Id);
+                leftoverHealAndTrauma = true;
             }
+            else
+            {
+                woundablesQueue.Enqueue(targetedWoundable);
+                for (var i = 0; i < _partHealingOrder.Length; i++)
+                {
+                    var (partType, symmetry) = _bodySystem.ConvertTargetBodyPart(_partHealingOrder[i]);
+                    var targetedBodyPart = _bodySystem.GetBodyChildrenOfType(ent, partType, comp, symmetry).ToList().FirstOrDefault();
+                    if (targetedBodyPart.Id == targetedWoundable)
+                        continue;
+                    woundablesQueue.Enqueue(targetedBodyPart.Id);
+                }
+            }
+
             while (woundablesQueue.Count > 0 && healingLeft.GetTotal() < 0.0)
             {
                 canHeal = true;


### PR DESCRIPTION
Локальне лікування більше не переходить з нефункціональної цільової частини на решту тіла.

:cl:
- fix: Лікувальні засоби більше не витрачаються на інші частини тіла, коли обрана нефункціональна кінцівка трейту «Фіксація кінцівок».

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Виправлення помилок**
  * Лікування більше не поширюється на інші частини тіла, якщо цільова кінцівка вимкнена або зафіксована.
  * Пошкодження віддалених частин тіла тепер зберігаються коректно після застосування лікувальних засобів.
  * Для кінцівок із залишковими травмами належним чином визначається потреба в подальшому хірургічному втручанні.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->