### PR TITLE
Fix changeling state after Last Resort

### DIFF
--- a/Content.Goobstation.Server/Changeling/ChangelingEggSystem.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingEggSystem.cs
@@ -33,6 +33,9 @@ public sealed class ChangelingEggSystem : EntitySystem
 
     public void Cycle(EntityUid uid, ChangelingEggComponent comp)
     {
+        if (!TryComp<ChangelingEggComponent>(uid, out var current) || current != comp)
+            return;
+
         if (!comp.Active)
         {
             comp.Active = true;

--- a/Content.Goobstation.Server/Changeling/ChangelingEggSystem.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingEggSystem.cs
@@ -54,6 +54,8 @@ public sealed class ChangelingEggSystem : EntitySystem
         EnsureComp<MindContainerComponent>(newUid);
         _mind.TransferTo(comp.LingMind, newUid);
 
+        comp.LingComponents.Clear();
+        RemComp<ChangelingEggComponent>(uid);
         _bodySystem.GibBody(uid);
     }
 }

--- a/Content.Goobstation.Server/Changeling/ChangelingEggSystem.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingEggSystem.cs
@@ -33,13 +33,13 @@ public sealed class ChangelingEggSystem : EntitySystem
 
     public void Cycle(EntityUid uid, ChangelingEggComponent comp)
     {
-        if (comp.active == false)
+        if (!comp.Active)
         {
-            comp.active = true;
+            comp.Active = true;
             return;
         }
 
-        if (TerminatingOrDeleted(comp.lingMind))
+        if (TerminatingOrDeleted(comp.LingMind))
         {
             _bodySystem.GibBody(uid);
             return;
@@ -47,12 +47,12 @@ public sealed class ChangelingEggSystem : EntitySystem
 
         var newUid = Spawn("MobMonkey", Transform(uid).Coordinates);
 
+        // Pirate: initialize the complete body before attaching a connected or reconnecting player.
+        foreach (var component in comp.LingComponents)
+            _changeling.RestoreLastResortComponent(newUid, component);
+
         EnsureComp<MindContainerComponent>(newUid);
-        _mind.TransferTo(comp.lingMind, newUid);
-
-        EnsureComp<ChangelingIdentityComponent>(newUid);
-
-        EntityManager.AddComponent(newUid, comp.lingStore);
+        _mind.TransferTo(comp.LingMind, newUid);
 
         _bodySystem.GibBody(uid);
     }

--- a/Content.Goobstation.Server/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingSystem.Abilities.cs
@@ -650,16 +650,17 @@ public sealed partial class ChangelingSystem
         var mind = _mind.GetMind(uid);
         if (mind == null)
             return;
-        if (!TryComp<StoreComponent>(uid, out var storeComp))
+        if (!HasComp<StoreComponent>(uid))
             return;
 
         comp.IsInLastResort = false;
         comp.IsInLesserForm = true;
 
         var eggComp = EnsureComp<ChangelingEggComponent>(target);
-        eggComp.lingComp = comp;
-        eggComp.lingMind = (EntityUid) mind;
-        eggComp.lingStore = _serialization.CreateCopy(storeComp, notNullableOverride: true);
+        eggComp.LingComponents = CopyLastResortComponents(uid, CurrentLastResortComponentTypes);
+        eggComp.LingComponents.AddRange(comp.LastResortComponents);
+        eggComp.LingMind = (EntityUid) mind;
+        comp.LastResortComponents.Clear();
 
         EnsureComp<AbsorbedComponent>(target);
         var dmg = new DamageSpecifier(_proto.Index(AbsorbedDamageGroup), 200);
@@ -812,6 +813,8 @@ public sealed partial class ChangelingSystem
         if (args.Handled)
             return;
 
+        var lastResortComponents = CopyLastResortComponents(uid, LastResortComponentTypes);
+        var store = CopyLastResortComponent<StoreComponent>(uid);
         comp.IsInLastResort = true;
 
         var newUid = TransformEntity(
@@ -827,6 +830,11 @@ public sealed partial class ChangelingSystem
             UpdateChemicals((uid, comp), Comp<InternalResourcesActionComponent>(args.Action).UseAmount);
             return;
         }
+
+        // Pirate: carry the suppressed state through the temporary headslug body.
+        Comp<ChangelingIdentityComponent>(newUid.Value).LastResortComponents = lastResortComponents;
+        if (store != null)
+            RestoreLastResortComponent(newUid.Value, store);
 
         _explosionSystem.QueueExplosion(
             (EntityUid) newUid,

--- a/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
@@ -67,6 +67,7 @@ using Content.Shared.Nutrition.Components;
 using Content.Shared.Polymorph;
 using Content.Shared.Projectiles;
 using Content.Shared.Rejuvenate;
+using Content.Shared.Store.Components;
 using Robust.Server.Audio;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
@@ -86,6 +87,26 @@ namespace Content.Goobstation.Server.Changeling;
 
 public sealed partial class ChangelingSystem : SharedChangelingSystem
 {
+    // Pirate: these components are deliberately not polymorphed onto a headslug, but must return after hatching.
+    private static readonly Type[] LastResortComponentTypes =
+    [
+        typeof(ChangelingRegenerateComponent),
+        typeof(ChangelingStasisComponent),
+        typeof(ChangelingBiomassComponent),
+        typeof(AugmentedEyesightComponent),
+        typeof(ChameleonSkinComponent),
+        typeof(DarknessAdaptionComponent),
+        typeof(VoidAdaptionComponent),
+    ];
+
+    private static readonly Type[] CurrentLastResortComponentTypes =
+    [
+        typeof(ChangelingComponent),
+        typeof(ChangelingIdentityComponent),
+        typeof(ChangelingChemicalComponent),
+        typeof(StoreComponent),
+    ];
+
     // this is one hell of a star wars intro text
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
@@ -653,6 +674,101 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
         return newUid;
     }
 
+    private List<Component> CopyLastResortComponents(EntityUid uid, IEnumerable<Type> componentTypes)
+    {
+        var components = new List<Component>();
+
+        foreach (var type in componentTypes)
+        {
+            if (!EntityManager.TryGetComponent(uid, type, out var component))
+                continue;
+
+            components.Add((Component) _serialization.CreateCopy(component, notNullableOverride: true));
+        }
+
+        return components;
+    }
+
+    private T? CopyLastResortComponent<T>(EntityUid uid) where T : Component
+    {
+        return TryComp<T>(uid, out var component)
+            ? _serialization.CreateCopy(component, notNullableOverride: true)
+            : null;
+    }
+
+    public void RestoreLastResortComponent(EntityUid uid, Component component)
+    {
+        var resourceData = component switch
+        {
+            ChangelingChemicalComponent chemicals => CopyResourceData(chemicals.ResourceData),
+            ChangelingBiomassComponent biomass => CopyResourceData(biomass.ResourceData),
+            _ => null,
+        };
+
+        Dictionary<string, ListingState>? listings = null;
+        if (component is StoreComponent store)
+        {
+            listings = store.Listings.ToDictionary(
+                listing => listing.ID,
+                listing => new ListingState(listing.PurchaseAmount, listing.RestockTime, listing.ProductActionEntity));
+        }
+
+        EntityManager.AddComponent(uid, component, true);
+
+        switch (component)
+        {
+            case ChangelingChemicalComponent chemicals when resourceData != null:
+                RestoreResourceData(resourceData, chemicals.ResourceData);
+                Dirty(uid, chemicals);
+                break;
+            case ChangelingBiomassComponent biomass when resourceData != null:
+                RestoreResourceData(resourceData, biomass.ResourceData);
+                Dirty(uid, biomass);
+                break;
+            case StoreComponent store when listings != null:
+                RestoreListings(store, listings);
+                Dirty(uid, store);
+                break;
+        }
+    }
+
+    private InternalResourcesData? CopyResourceData(InternalResourcesData? data)
+    {
+        return data == null
+            ? null
+            : _serialization.CreateCopy(data, notNullableOverride: true);
+    }
+
+    private static void RestoreResourceData(InternalResourcesData source, InternalResourcesData? target)
+    {
+        if (target == null)
+            return;
+
+        target.CurrentAmount = source.CurrentAmount;
+        target.MaxAmount = source.MaxAmount;
+        target.RegenerationRate = source.RegenerationRate;
+        target.Thresholds = source.Thresholds?.ToDictionary(entry => entry.Key, entry => entry.Value);
+        target.InternalResourcesType = source.InternalResourcesType;
+    }
+
+    private static void RestoreListings(StoreComponent store, Dictionary<string, ListingState> states)
+    {
+        foreach (var listing in store.Listings)
+        {
+            if (!states.TryGetValue(listing.ID, out var state))
+                continue;
+
+            listing.PurchaseAmount = state.PurchaseAmount;
+            listing.RestockTime = state.RestockTime;
+            listing.ProductActionEntity = state.ProductActionEntity;
+        }
+    }
+
+    private readonly record struct ListingState(
+        int PurchaseAmount,
+        TimeSpan RestockTime,
+        EntityUid? ProductActionEntity);
+
     public bool TryTransform(EntityUid target, ChangelingIdentityComponent comp, bool sting = false, bool persistentDna = false)
     {
         if (HasComp<AbsorbedComponent>(target))
@@ -722,8 +838,12 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
         foreach (var actionId in ent.Comp.BaseChangelingActions)
             _actions.AddAction(ent, actionId);
 
-        // make sure its set to the default
-        ent.Comp.TotalEvolutionPoints = _changelingRuleSystem.StartingCurrency;
+        // Pirate: copied identities already have their lifetime evolution total.
+        if (!ent.Comp.EvolutionPointsInitialized)
+        {
+            ent.Comp.TotalEvolutionPoints = _changelingRuleSystem.StartingCurrency;
+            ent.Comp.EvolutionPointsInitialized = true;
+        }
 
         // make their blood unreal
         _blood.ChangeBloodReagent(ent.Owner, "BloodChangeling");

--- a/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
@@ -725,9 +725,9 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
                 RestoreResourceData(resourceData, biomass.ResourceData);
                 Dirty(uid, biomass);
                 break;
-            case StoreComponent store when listings != null:
-                RestoreListings(store, listings);
-                Dirty(uid, store);
+            case StoreComponent restoredStore when listings != null:
+                RestoreListings(restoredStore, listings);
+                Dirty(uid, restoredStore);
                 break;
         }
     }

--- a/Content.Goobstation.Shared/Changeling/Components/ChangelingEggComponent.cs
+++ b/Content.Goobstation.Shared/Changeling/Components/ChangelingEggComponent.cs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using Content.Shared.Store.Components;
 using Robust.Shared.GameStates;
 
 namespace Content.Goobstation.Shared.Changeling.Components;
@@ -9,14 +8,14 @@ namespace Content.Goobstation.Shared.Changeling.Components;
 
 public sealed partial class ChangelingEggComponent : Component
 {
-    public ChangelingIdentityComponent lingComp;
-    public EntityUid lingMind;
-    public StoreComponent lingStore;
+    // Pirate: these are fresh serialized copies and are attached to the hatched body.
+    public List<Component> LingComponents = new();
+    public EntityUid LingMind;
 
     /// <summary>
     ///     Countdown before spawning monkey.
     /// </summary>
     public TimeSpan UpdateTimer = TimeSpan.Zero;
     public float UpdateCooldown = 120f;
-    public bool active = false;
+    public bool Active;
 }

--- a/Content.Goobstation.Shared/Changeling/Components/ChangelingIdentityComponent.cs
+++ b/Content.Goobstation.Shared/Changeling/Components/ChangelingIdentityComponent.cs
@@ -60,6 +60,9 @@ public sealed partial class ChangelingIdentityComponent : Component
     [DataField]
     public bool IsInLastResort = false;
 
+    // Pirate: server-side snapshots of evolutions suppressed while in headslug form.
+    public List<Component> LastResortComponents = new();
+
     public List<EntityUid>? ActiveArmor = null;
 
     public Dictionary<string, EntityUid?> Equipment = new();
@@ -69,6 +72,9 @@ public sealed partial class ChangelingIdentityComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public float TotalEvolutionPoints;
+
+    [DataField]
+    public bool EvolutionPointsInitialized;
 
     /// <summary>
     ///     Cooldown between chem regen events.

--- a/Content.IntegrationTests/Tests/_Pirate/Changeling/ChangelingLastResortTests.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Changeling/ChangelingLastResortTests.cs
@@ -99,8 +99,10 @@ public sealed class ChangelingLastResortTests
         await server.WaitPost(() =>
         {
             var egg = entMan.GetComponent<ChangelingEggComponent>(corpse);
-            egg.Active = true;
             eggSystem.Cycle(corpse, egg);
+            Assert.That(egg.Active, Is.True);
+            eggSystem.Cycle(corpse, egg);
+            Assert.That(entMan.HasComponent<ChangelingEggComponent>(corpse), Is.False);
         });
 
         await server.WaitRunTicks(5);
@@ -124,8 +126,8 @@ public sealed class ChangelingLastResortTests
                 Assert.That(entMan.HasComponent<ChangelingStasisComponent>(uid), Is.True);
                 Assert.That(entMan.HasComponent<AugmentedEyesightComponent>(uid), Is.True);
                 Assert.That(identity.TotalAbsorbedEntities, Is.EqualTo(4));
-                Assert.That(identity.TotalEvolutionPoints, Is.EqualTo(23));
-                Assert.That(chemicals.ResourceData!.CurrentAmount, Is.EqualTo(37f));
+                Assert.That(identity.TotalEvolutionPoints, Is.EqualTo(23f).Within(0.01f));
+                Assert.That(chemicals.ResourceData!.CurrentAmount, Is.EqualTo(37f).Within(0.01f));
                 Assert.That(store.Balance["EvolutionPoint"].Float(), Is.EqualTo(5f));
                 Assert.That(store.Listings.Single(listing => listing.ID == "EvolutionMenuUtilityEyesight").PurchaseAmount,
                     Is.EqualTo(2));

--- a/Content.IntegrationTests/Tests/_Pirate/Changeling/ChangelingLastResortTests.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Changeling/ChangelingLastResortTests.cs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Linq;
+using Content.Goobstation.Server.Changeling;
+using Content.Goobstation.Shared.Changeling.Actions;
+using Content.Goobstation.Shared.Changeling.Components;
+using Content.Goobstation.Shared.InternalResources.EntitySystems;
+using Content.Shared.Actions;
+using Content.Shared.Actions.Components;
+using Content.Shared.Mind;
+using Content.Shared.Mind.Components;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Store.Components;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests._Pirate.Changeling;
+
+[TestFixture]
+public sealed class ChangelingLastResortTests
+{
+    [Test]
+    public async Task HatchRestoresChangelingStateBeforeMindTransfer()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var testMap = await pair.CreateTestMap();
+        var entMan = server.ResolveDependency<IEntityManager>();
+
+        var actions = entMan.System<SharedActionsSystem>();
+        var actionContainer = entMan.System<ActionContainerSystem>();
+        var changeling = entMan.System<ChangelingSystem>();
+        var eggSystem = entMan.System<ChangelingEggSystem>();
+        var mindSystem = entMan.System<SharedMindSystem>();
+        var mobState = entMan.System<MobStateSystem>();
+        var resources = entMan.System<SharedInternalResourcesSystem>();
+
+        EntityUid ling = default;
+        EntityUid corpse = default;
+        EntityUid mindId = default;
+        EntityUid purchasedAction = default;
+
+        await server.WaitPost(() =>
+        {
+            ling = entMan.SpawnEntity("MobHuman", testMap.GridCoords);
+            corpse = entMan.SpawnEntity("MobHuman", testMap.GridCoords);
+
+            mindId = mindSystem.CreateMind(null).Owner;
+            mindSystem.TransferTo(mindId, ling);
+
+            entMan.EnsureComponent<ChangelingComponent>(ling);
+            var identity = entMan.GetComponent<ChangelingIdentityComponent>(ling);
+            identity.TotalAbsorbedEntities = 4;
+            identity.TotalEvolutionPoints = 23;
+
+            var chemicals = entMan.GetComponent<ChangelingChemicalComponent>(ling);
+            Assert.That(chemicals.ResourceData, Is.Not.Null);
+            resources.TryUpdateResourcesAmount(
+                ling,
+                chemicals.ResourceData!,
+                37f - chemicals.ResourceData!.CurrentAmount);
+
+            entMan.EnsureComponent<AugmentedEyesightComponent>(ling);
+
+            var store = entMan.EnsureComponent<StoreComponent>(ling);
+            store.Balance["EvolutionPoint"] = 7;
+            store.Listings.Single(listing => listing.ID == "EvolutionMenuUtilityEyesight").PurchaseAmount = 1;
+
+            purchasedAction = actionContainer.AddAction(mindId, "ActionToggleArmblade")!.Value;
+            Assert.That(entMan.GetComponent<ActionComponent>(purchasedAction).AttachedEntity, Is.EqualTo(ling));
+
+            var lastResort = new ActionLastResortEvent();
+            changeling.OnLastResort(ling, identity, ref lastResort);
+            Assert.That(lastResort.Handled, Is.True);
+
+            var headslug = entMan.GetComponent<MindComponent>(mindId).OwnedEntity;
+            Assert.That(headslug, Is.Not.Null);
+            Assert.That(entMan.GetComponent<MetaDataComponent>(headslug!.Value).EntityPrototype!.ID,
+                Is.EqualTo("MobHeadcrab"));
+
+            var headslugStore = entMan.GetComponent<StoreComponent>(headslug.Value);
+            Assert.That(headslugStore.Listings
+                .Single(listing => listing.ID == "EvolutionMenuUtilityEyesight").PurchaseAmount, Is.EqualTo(1));
+            headslugStore.Balance["EvolutionPoint"] = 5;
+            headslugStore.Listings
+                .Single(listing => listing.ID == "EvolutionMenuUtilityEyesight").PurchaseAmount = 2;
+
+            entMan.EnsureComponent<AbsorbableComponent>(corpse);
+            mobState.ChangeMobState(corpse, MobState.Dead);
+
+            var headslugIdentity = entMan.GetComponent<ChangelingIdentityComponent>(headslug.Value);
+            var layEgg = new StingLayEggsEvent { Target = corpse };
+            changeling.OnLayEgg(headslug.Value, headslugIdentity, ref layEgg);
+            Assert.That(layEgg.Handled, Is.True);
+        });
+
+        await server.WaitRunTicks(5);
+
+        await server.WaitPost(() =>
+        {
+            var egg = entMan.GetComponent<ChangelingEggComponent>(corpse);
+            egg.Active = true;
+            eggSystem.Cycle(corpse, egg);
+        });
+
+        await server.WaitRunTicks(5);
+
+        await server.WaitAssertion(() =>
+        {
+            var newBody = entMan.GetComponent<MindComponent>(mindId).OwnedEntity;
+            Assert.That(newBody, Is.Not.Null);
+            var uid = newBody!.Value;
+
+            var identity = entMan.GetComponent<ChangelingIdentityComponent>(uid);
+            var chemicals = entMan.GetComponent<ChangelingChemicalComponent>(uid);
+            var store = entMan.GetComponent<StoreComponent>(uid);
+            var action = entMan.GetComponent<ActionComponent>(purchasedAction);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.GetComponent<MetaDataComponent>(uid).EntityPrototype!.ID, Is.EqualTo("MobMonkey"));
+                Assert.That(entMan.HasComponent<ChangelingComponent>(uid), Is.True);
+                Assert.That(entMan.HasComponent<ChangelingRegenerateComponent>(uid), Is.True);
+                Assert.That(entMan.HasComponent<ChangelingStasisComponent>(uid), Is.True);
+                Assert.That(entMan.HasComponent<AugmentedEyesightComponent>(uid), Is.True);
+                Assert.That(identity.TotalAbsorbedEntities, Is.EqualTo(4));
+                Assert.That(identity.TotalEvolutionPoints, Is.EqualTo(23));
+                Assert.That(chemicals.ResourceData!.CurrentAmount, Is.EqualTo(37f));
+                Assert.That(store.Balance["EvolutionPoint"].Float(), Is.EqualTo(5f));
+                Assert.That(store.Listings.Single(listing => listing.ID == "EvolutionMenuUtilityEyesight").PurchaseAmount,
+                    Is.EqualTo(2));
+                Assert.That(action.AttachedEntity, Is.EqualTo(uid));
+                Assert.That(actions.GetActions(uid).Any(entity => entity.Owner == purchasedAction), Is.True);
+            });
+        });
+
+        await server.WaitPost(() =>
+        {
+            if (entMan.GetComponent<MindComponent>(mindId).OwnedEntity is { } body)
+                entMan.DeleteEntity(body);
+            if (entMan.EntityExists(ling))
+                entMan.DeleteEntity(ling);
+            entMan.DeleteEntity(mindId);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/_Pirate/Changeling/ChangelingLastResortTests.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Changeling/ChangelingLastResortTests.cs
@@ -92,17 +92,14 @@ public sealed class ChangelingLastResortTests
             var layEgg = new StingLayEggsEvent { Target = corpse };
             changeling.OnLayEgg(headslug.Value, headslugIdentity, ref layEgg);
             Assert.That(layEgg.Handled, Is.True);
-        });
 
-        await server.WaitRunTicks(5);
-
-        await server.WaitPost(() =>
-        {
             var egg = entMan.GetComponent<ChangelingEggComponent>(corpse);
+            Assert.That(egg.Active, Is.False);
             eggSystem.Cycle(corpse, egg);
             Assert.That(egg.Active, Is.True);
             eggSystem.Cycle(corpse, egg);
             Assert.That(entMan.HasComponent<ChangelingEggComponent>(corpse), Is.False);
+            eggSystem.Cycle(corpse, egg);
         });
 
         await server.WaitRunTicks(5);


### PR DESCRIPTION
Відновлює стан генокрада та його здібності після вилуплення з Last Resort.

:cl:
- fix: Після вилуплення з Last Resort генокрад більше не втрачає здібності та прогрес.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Виправлення**
  * Покращено перетворення changeling: під час Last Resort зберігаються ідентичність, ресурси, здібності, покращення, магазин і прив’язані дії.
  * Після вилуплення з яйця ці дані відновлюються в новому тілі до перенесення свідомості.
  * Виправлено активацію яєць та передачу свідомості changeling під час створення нового тіла.

* **Тести**
  * Додано перевірку повного відновлення стану changeling після вилуплення з яйця.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->