### PR TITLE
Обмежити ГШР і Дед Сквад людьми

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -89,6 +89,7 @@
 - type: randomHumanoidSettings
   id: DeathSquad
   parent: CentcommHumanoid # Goobstation
+  speciesWhitelist: Human # Pirate - Death Squad equipment is human-only.
   components:
     - type: AutoImplant
       implants: [ FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm] # Goobstation
@@ -128,6 +129,7 @@
 - type: randomHumanoidSettings
   id: ERTLeader
   parent: CentcommHumanoid # Goobstation
+  speciesWhitelist: Human # Pirate - ERT equipment is human-only.
   components:
     - type: GhostRole
       name: ghost-role-information-ert-leader-name


### PR DESCRIPTION
Обмежено ГШР та Дед Сквад людьми.

:cl:
- tweak: ГШР і Дед Сквад тепер можуть бути лише людьми.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Виправлення**
  * Обмежено спорядження ролей DeathSquad та ERTLeader людським видом.
  * Ролі тепер використовують лише сумісне людське спорядження.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->