### PR TITLE
Дозволити Оні використовувати ракетницю ГІ

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -386,6 +386,9 @@
     fireRate: 0.5
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rpgfire.ogg
+  - type: RestrictGunshotsByUserTag # Pirate - allow Oni to use the emergency engineering launcher.
+    doesntContain: []
+    messages: []
   - type: BallisticAmmoProvider
     whitelist:
       tags:


### PR DESCRIPTION
Дозволяє Оні використовувати інженерну ракетницю для знищення сингулярності й тесли.

:cl:
- fix: Оні тепер можуть використовувати інженерну ракетницю ГІ.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові функції**
  * Додано обмеження на використання зброї Singularity Buster відповідно до тегів користувача.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->