### PR TITLE
Дозволити соло-конвертацію закованих цілей

### DIFF
--- a/Content.Pirate.Server/BloodCult/EntitySystems/OfferOnTriggerSystem.cs
+++ b/Content.Pirate.Server/BloodCult/EntitySystems/OfferOnTriggerSystem.cs
@@ -17,6 +17,8 @@ using Robust.Shared.Containers;
 using Robust.Shared.Timing;
 using Content.Shared.Trigger;
 using Content.Shared.DoAfter;
+using Content.Shared.Cuffs;
+using Content.Shared.Cuffs.Components;
 using Content.Server.Explosion.EntitySystems;
 using Content.Server.Popups;
 using Content.Shared.Popups;
@@ -77,6 +79,7 @@ namespace Content.Server.BloodCult.EntitySystems
 		[Dependency] private readonly SharedAudioSystem _audio = default!;
 		[Dependency] private readonly GameTicker _gameTicker = default!;
 		[Dependency] private readonly SharedContainerSystem _container = default!;
+		[Dependency] private readonly SharedCuffableSystem _cuffable = default!;
 		[Dependency] private readonly BloodstreamSystem _bloodstream = default!;
 		[Dependency] private readonly SharedStunSystem _stun = default!;
 		[Dependency] private readonly BloodCultRuleSystem _bloodCultRule = default!;
@@ -120,6 +123,8 @@ namespace Content.Server.BloodCult.EntitySystems
 				_FailRitual(uid, "cult-invocation-interrupted");
 				continue;
 			}
+
+			var requiredParticipants = GetMindshieldBreakCultistsRequired(ritual.Victim);
 			
 			// Validate all participants are still alive, in range, and not deleted
 			var runePos = _transform.ToMapCoordinates(ritual.RuneLocation).Position;
@@ -143,8 +148,7 @@ namespace Content.Server.BloodCult.EntitySystems
 				validParticipants++;
 			}
 			
-			// Need at least 3 valid participants to continue the ritual
-			if (validParticipants < 3)
+			if (validParticipants < requiredParticipants)
 			{
 				_FailRitual(uid, "cult-invocation-fail");
 				continue;
@@ -156,13 +160,12 @@ namespace Content.Server.BloodCult.EntitySystems
 				ritual.ChantCount++;
 				ritual.NextChantTime = curTime + TimeSpan.FromSeconds(2);
 
-				// Make only the minimum required participants chant (first 3 valid cultists)
+				// Make only the minimum required participants chant.
 				int chantersCount = 0;
-				const int requiredChanters = 3;
 				
 				foreach (var participant in ritual.Participants)
 				{
-					if (chantersCount >= requiredChanters)
+					if (chantersCount >= requiredParticipants)
 						break;
 					
 					if (!Exists(participant) || _mobState.IsDead(participant))
@@ -228,10 +231,21 @@ namespace Content.Server.BloodCult.EntitySystems
 				}
 			}
 		}
-		
+
 		// Remove the ritual component
 		// This ensures the completion handler will return early if it somehow still fires
 		RemCompDeferred<MindshieldBreakRitualComponent>(ritualist);
+	}
+
+	private int GetMindshieldBreakCultistsRequired(EntityUid victim)
+	{
+		if (TryComp<CuffableComponent>(victim, out var cuffable) &&
+			_cuffable.IsCuffed((victim, cuffable)))
+		{
+			return 1;
+		}
+
+		return MindshieldBreakCultistsRequired;
 	}
 
 		private void HandleOfferTrigger(EntityUid uid, OfferOnTriggerComponent component, TriggerEvent args)
@@ -745,16 +759,6 @@ namespace Content.Server.BloodCult.EntitySystems
 			return;
 		}
 
-		// Require 2 cultists total (user + 1 other)
-		if (cultistsInRange.Length < MindshieldBreakCultistsRequired)
-		{
-			_popupSystem.PopupEntity(
-				Loc.GetString("cult-invocation-fail"),
-				user, user, PopupType.MediumCaution
-			);
-			return;
-		}
-
 		// Validate victim is still valid and has a mindshield before starting the ritual
 		// This ensures we're targeting the correct entity and prevents issues with multiple entities
 		if (!Exists(victim))
@@ -765,10 +769,19 @@ namespace Content.Server.BloodCult.EntitySystems
 			);
 			return;
 		}
-		
+
 		if (!TryComp<MindShieldComponent>(victim, out var _))
 		{
 			// Victim no longer has mindshield or was the wrong entity
+			_popupSystem.PopupEntity(
+				Loc.GetString("cult-invocation-fail"),
+				user, user, PopupType.MediumCaution
+			);
+			return;
+		}
+
+		if (cultistsInRange.Length < GetMindshieldBreakCultistsRequired(victim))
+		{
 			_popupSystem.PopupEntity(
 				Loc.GetString("cult-invocation-fail"),
 				user, user, PopupType.MediumCaution
@@ -910,8 +923,7 @@ namespace Content.Server.BloodCult.EntitySystems
 		validParticipants.Add(participant);
 	}
 
-	// Still need 2 cultists at the end
-	if (validParticipants.Count < MindshieldBreakCultistsRequired)
+	if (validParticipants.Count < GetMindshieldBreakCultistsRequired(victim))
 	{
 		// Show failure message to all participants who are still around
 		foreach (var participant in participants)

--- a/Content.Pirate.Server/GameTicking/Rules/BloodCultRuleSystem.cs
+++ b/Content.Pirate.Server/GameTicking/Rules/BloodCultRuleSystem.cs
@@ -56,6 +56,8 @@ using Content.Shared.Database;
 using Content.Server.Administration.Logs;
 using Content.Shared.Bed.Cryostorage;
 using Content.Shared.Bed.Sleep;
+using Content.Shared.Cuffs;
+using Content.Shared.Cuffs.Components;
 
 using Content.Server.BloodCult.EntitySystems;
 using Content.Shared.BloodCult.Prototypes;
@@ -183,6 +185,7 @@ public sealed class BloodCultRuleSystem : GameRuleSystem<BloodCultRuleComponent>
 	[Dependency] private readonly IPrototypeManager _proto = default!;
 	[Dependency] private readonly SharedActionsSystem _action = default!;
 	[Dependency] private readonly SharedPointLightSystem _pointLight = default!;
+	[Dependency] private readonly SharedCuffableSystem _cuffable = default!;
 
 	public readonly string CultComponentId = "BloodCultist";
 
@@ -910,6 +913,13 @@ public sealed class BloodCultRuleSystem : GameRuleSystem<BloodCultRuleComponent>
 
 	private bool _ConvertOffering(ConvertingData convert, BloodCultRuleComponent component, EntityUid cultistUid)
 	{
+		var requiredCultists = component.CultistsToConvert;
+		if (TryComp<CuffableComponent>(convert.Subject, out var cuffable) &&
+			_cuffable.IsCuffed((convert.Subject, cuffable)))
+		{
+			requiredCultists = 1;
+		}
+
 		if (HasComp<CultResistantComponent>(convert.Subject) || HasComp<CosmicCultComponent>(convert.Subject) || HasComp<ChangelingComponent>(convert.Subject))
 		{
 			_popupSystem.PopupEntity(
@@ -918,13 +928,13 @@ public sealed class BloodCultRuleSystem : GameRuleSystem<BloodCultRuleComponent>
 			);
 			return false;
 		}
-		else if (convert.Invokers.Length >= component.CultistsToConvert)
+		else if (convert.Invokers.Length >= requiredCultists)
 		{
 			// Only make the minimum required number of cultists speak
 			int speakerCount = 0;
 			foreach (EntityUid invoker in convert.Invokers)
 			{
-				if (speakerCount >= component.CultistsToConvert)
+				if (speakerCount >= requiredCultists)
 					break;
 
 				Speak(invoker, Loc.GetString("cult-invocation-offering"));

--- a/Content.Server/_DV/CosmicCult/CosmicGlyphSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicGlyphSystem.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Server.Popups;
+using Content.Server._Pirate.GameTicking.Rules; // Pirate
 using Content.Shared._DV.CosmicCult.Components.Examine;
 using Content.Shared._DV.CosmicCult.Components;
 using Content.Shared._DV.CosmicCult;
@@ -77,10 +78,7 @@ public sealed class CosmicGlyphSystem : SharedCosmicGlyphSystem
             return;
 
         var cultists = GatherCultists(uid, uid.Comp.ActivationRange);
-        var requiredCultists = uid.Comp.RequiredCultists;
-
-        if (TryComp(args.User, out LoneCosmicCultLeadComponent? leadComp))
-            requiredCultists = Math.Max(requiredCultists - leadComp.CultAbilityDeduction, 1);
+        var requiredCultists = GetRequiredCultists(uid, args.User); // Pirate
 
         if (cultists.Count < requiredCultists)
         {
@@ -124,10 +122,17 @@ public sealed class CosmicGlyphSystem : SharedCosmicGlyphSystem
 
         if (ent.Comp.User is not { } user) return;
         var cultists = GatherCultists(ent, ent.Comp.ActivationRange);
+        var requiredCultists = GetRequiredCultists(ent, user); // Pirate
+        var tgtpos = Transform(ent).Coordinates;
+        if (cultists.Count < requiredCultists)
+        {
+            _audio.PlayPvs(ent.Comp.FailSFX, tgtpos);
+            return;
+        }
+
         var tryInvokeEv = new TryActivateGlyphEvent(user, cultists);
         RaiseLocalEvent(ent, ref tryInvokeEv);
-        var tgtpos = Transform(ent).Coordinates;
-        if (tryInvokeEv.Cancelled || cultists.Count < ent.Comp.RequiredCultists)
+        if (tryInvokeEv.Cancelled)
         {
             _audio.PlayPvs(ent.Comp.FailSFX, tgtpos);
             return;
@@ -140,6 +145,18 @@ public sealed class CosmicGlyphSystem : SharedCosmicGlyphSystem
         _audio.PlayPvs(ent.Comp.TriggerSFX, tgtpos, AudioParams.Default.WithVolume(+1f));
         Spawn(ent.Comp.GlyphVFX, tgtpos);
         ent.Comp.User = null;
+    }
+
+    // Pirate: let downstream rules adjust requirements and recheck them when activation completes.
+    private int GetRequiredCultists(Entity<CosmicGlyphComponent> glyph, EntityUid user)
+    {
+        var requiredCultists = glyph.Comp.RequiredCultists;
+        if (TryComp(user, out LoneCosmicCultLeadComponent? leadComp))
+            requiredCultists = Math.Max(requiredCultists - leadComp.CultAbilityDeduction, 1);
+
+        var ev = new GetCosmicGlyphCultistRequirementEvent(requiredCultists);
+        RaiseLocalEvent(glyph, ref ev);
+        return Math.Max(ev.RequiredCultists, 1);
     }
     #endregion
 

--- a/Content.Server/_Pirate/GameTicking/Rules/CuffedCultConversionSystem.cs
+++ b/Content.Server/_Pirate/GameTicking/Rules/CuffedCultConversionSystem.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server._DV.CosmicCult;
+using Content.Shared._DV.CosmicCult;
+using Content.Shared._DV.CosmicCult.Components;
+using Content.Shared.Cuffs;
+using Content.Shared.Cuffs.Components;
+
+namespace Content.Server._Pirate.GameTicking.Rules;
+
+/// <summary>
+/// Allows a single cosmic cultist to invoke a conversion glyph when its target is fully cuffed.
+/// </summary>
+public sealed class CuffedCultConversionSystem : EntitySystem
+{
+    [Dependency] private readonly SharedCuffableSystem _cuffable = default!;
+    [Dependency] private readonly SharedCosmicCultSystem _cosmicCult = default!;
+    [Dependency] private readonly CosmicGlyphSystem _glyph = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CosmicGlyphConversionComponent, GetCosmicGlyphCultistRequirementEvent>(OnGetRequirement);
+    }
+
+    private void OnGetRequirement(
+        Entity<CosmicGlyphConversionComponent> ent,
+        ref GetCosmicGlyphCultistRequirementEvent args)
+    {
+        var targets = _glyph.GetTargetsNearGlyph(
+            ent,
+            ent.Comp.ConversionRange,
+            target => _cosmicCult.EntityIsCultist(target));
+
+        if (targets.Count != 1)
+            return;
+
+        foreach (var target in targets)
+        {
+            if (TryComp<CuffableComponent>(target.Owner, out var cuffable) &&
+                _cuffable.IsCuffed((target.Owner, cuffable)))
+            {
+                args.RequiredCultists = 1;
+            }
+        }
+    }
+}
+
+[ByRefEvent]
+public record struct GetCosmicGlyphCultistRequirementEvent(int RequiredCultists);


### PR DESCRIPTION
Повністю заковану ціль можна конвертувати одним культистом крові або космосу.

:cl:
- tweak: Повністю заковані цілі тепер можна конвертувати одним культистом крові або космосу.