### PR TITLE
fix: кулдаун для емоції сальто

### DIFF
--- a/Content.Server/Speech/EmotesMenuSystem.cs
+++ b/Content.Server/Speech/EmotesMenuSystem.cs
@@ -30,10 +30,10 @@ public sealed partial class EmotesMenuSystem : EntitySystem
         if (!_prototypeManager.Resolve(msg.ProtoId, out var proto) || proto.ChatTriggers.Count == 0)
             return;
 
-        if (!_pirateEmoteCooldown.CanEmote(player.Value)) // Pirate: emote cooldown
+        if (!_pirateEmoteCooldown.CanEmote(player.Value, msg.ProtoId)) // Pirate: emote cooldown
             return; // Pirate: emote cooldown
 
         if (_chat.TryEmoteWithChat(player.Value, msg.ProtoId)) // Pirate: emote cooldown
-            _pirateEmoteCooldown.CommitEmote(player.Value); // Pirate: emote cooldown
+            _pirateEmoteCooldown.CommitEmote(player.Value, msg.ProtoId); // Pirate: emote cooldown
     }
 }

--- a/Content.Server/_Pirate/Speech/PirateEmoteCooldownComponent.cs
+++ b/Content.Server/_Pirate/Speech/PirateEmoteCooldownComponent.cs
@@ -9,4 +9,7 @@ public sealed partial class PirateEmoteCooldownComponent : Component
 {
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
     public TimeSpan NextEmote;
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
+    public TimeSpan NextFlipEmote;
 }

--- a/Content.Server/_Pirate/Speech/PirateEmoteCooldownSystem.cs
+++ b/Content.Server/_Pirate/Speech/PirateEmoteCooldownSystem.cs
@@ -2,8 +2,10 @@
 
 using Content.Shared.CCVar;
 using Content.Shared._Pirate.Speech;
+using Content.Shared.Chat.Prototypes;
 using Robust.Shared.Player;
 using Robust.Shared.Configuration;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
 namespace Content.Server._Pirate.Speech;
@@ -13,29 +15,39 @@ public sealed class PirateEmoteCooldownSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
+    private static readonly ProtoId<EmotePrototype> FlipEmote = "Flip";
+
     private TimeSpan _emoteCooldown;
+    private TimeSpan _flipEmoteCooldown;
 
     public override void Initialize()
     {
         base.Initialize();
 
-        Subs.CVar(_config, CCVars.PirateEmoteCooldownSeconds, value => _emoteCooldown = TimeSpan.FromSeconds(value), true);
+        Subs.CVar(_config,
+            CCVars.PirateEmoteCooldownSeconds,
+            value => _emoteCooldown = TimeSpan.FromSeconds(value),
+            true);
+        Subs.CVar(_config,
+            CCVars.PirateFlipEmoteCooldownSeconds,
+            value => _flipEmoteCooldown = TimeSpan.FromSeconds(value),
+            true);
         SubscribeLocalEvent<PirateEmoteCooldownAttemptEvent>(OnEmoteCooldownAttempt);
         SubscribeLocalEvent<PirateEmoteCooldownCommitEvent>(OnEmoteCooldownCommit);
     }
 
     private void OnEmoteCooldownAttempt(ref PirateEmoteCooldownAttemptEvent args)
     {
-        if (!CanEmote(args.Source))
+        if (!CanEmote(args.Source, args.Emote))
             args.Cancel();
     }
 
     private void OnEmoteCooldownCommit(ref PirateEmoteCooldownCommitEvent args)
     {
-        CommitEmote(args.Source);
+        CommitEmote(args.Source, args.Emote);
     }
 
-    public bool CanEmote(EntityUid uid)
+    public bool CanEmote(EntityUid uid, ProtoId<EmotePrototype> emote)
     {
         if (!HasComp<ActorComponent>(uid))
             return true;
@@ -44,10 +56,11 @@ public sealed class PirateEmoteCooldownSystem : EntitySystem
             return true;
 
         var time = _timing.CurTime;
-        return time >= cooldown.NextEmote;
+        return time >= cooldown.NextEmote
+            && (emote != FlipEmote || time >= cooldown.NextFlipEmote);
     }
 
-    public void CommitEmote(EntityUid uid)
+    public void CommitEmote(EntityUid uid, ProtoId<EmotePrototype> emote)
     {
         if (!HasComp<ActorComponent>(uid))
             return;
@@ -55,5 +68,8 @@ public sealed class PirateEmoteCooldownSystem : EntitySystem
         var cooldown = EnsureComp<PirateEmoteCooldownComponent>(uid);
         var time = _timing.CurTime;
         cooldown.NextEmote = time + _emoteCooldown;
+
+        if (emote == FlipEmote)
+            cooldown.NextFlipEmote = time + _flipEmoteCooldown;
     }
 }

--- a/Content.Shared/Chat/SharedChatSystem.Emote.cs
+++ b/Content.Shared/Chat/SharedChatSystem.Emote.cs
@@ -216,7 +216,7 @@ public abstract partial class SharedChatSystem
             return true;
 
         // Pirate: emote cooldown
-        var cooldownAttempt = new PirateEmoteCooldownAttemptEvent(source);
+        var cooldownAttempt = new PirateEmoteCooldownAttemptEvent(source, emote.ID);
         RaiseLocalEvent(source, ref cooldownAttempt);
         if (cooldownAttempt.Cancelled)
             return false;
@@ -224,7 +224,7 @@ public abstract partial class SharedChatSystem
         if (!TryInvokeEmoteEvent(source, emote, voluntary: !forced))
             return false;
 
-        var cooldownCommit = new PirateEmoteCooldownCommitEvent(source);
+        var cooldownCommit = new PirateEmoteCooldownCommitEvent(source, emote.ID);
         RaiseLocalEvent(source, ref cooldownCommit);
         return true;
         // Pirate end

--- a/Content.Shared/_Pirate/CCVars/CCVars.Emote.cs
+++ b/Content.Shared/_Pirate/CCVars/CCVars.Emote.cs
@@ -6,4 +6,7 @@ public sealed partial class CCVars
 {
     public static readonly CVarDef<float> PirateEmoteCooldownSeconds =
         CVarDef.Create("pirate.emote_cooldown_seconds", 1.5f, CVar.SERVER | CVar.REPLICATED);
+
+    public static readonly CVarDef<float> PirateFlipEmoteCooldownSeconds =
+        CVarDef.Create("pirate.flip_emote_cooldown_seconds", 30f, CVar.SERVER | CVar.REPLICATED);
 }

--- a/Content.Shared/_Pirate/Speech/PirateEmoteCooldownEvents.cs
+++ b/Content.Shared/_Pirate/Speech/PirateEmoteCooldownEvents.cs
@@ -1,15 +1,24 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Shared.Chat.Prototypes;
+using Robust.Shared.Prototypes;
+
 namespace Content.Shared._Pirate.Speech;
 
 [ByRefEvent]
-public sealed class PirateEmoteCooldownAttemptEvent(EntityUid source) : CancellableEntityEventArgs
+public sealed class PirateEmoteCooldownAttemptEvent(
+    EntityUid source,
+    ProtoId<EmotePrototype> emote) : CancellableEntityEventArgs
 {
     public EntityUid Source = source;
+    public ProtoId<EmotePrototype> Emote = emote;
 }
 
 [ByRefEvent]
-public sealed class PirateEmoteCooldownCommitEvent(EntityUid source) : EntityEventArgs
+public sealed class PirateEmoteCooldownCommitEvent(
+    EntityUid source,
+    ProtoId<EmotePrototype> emote) : EntityEventArgs
 {
     public EntityUid Source = source;
+    public ProtoId<EmotePrototype> Emote = emote;
 }


### PR DESCRIPTION
Додано окремий 30-секундний кулдаун для емоції «Зробити сальто».

:cl:
- tweak: Емоція «Зробити сальто» тепер має 30-секундний кулдаун.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Додано окремий таймер повторного використання для емоції «Переворот».
  * Час очікування за замовчуванням становить 30 секунд і може налаштовуватися.

* **Виправлення**
  * Перевірка затримки тепер коректно враховує вибрану емоцію, запобігаючи неправильному блокуванню інших емоцій.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->