### PR TITLE
Уточнити мобільність і зір Реплікаторів

### DIFF
--- a/Resources/Prototypes/_Pirate/Replicators/replicators.yml
+++ b/Resources/Prototypes/_Pirate/Replicators/replicators.yml
@@ -149,6 +149,10 @@
   - type: ThermalVision
     lightRadius: 7
     color: "#d70aa0"
+  - type: NightVision
+    color: "#d70aa0"
+    activateSound: null
+    deactivateSound: null
   - type: Prying
     pryPowered: true
     force: true
@@ -244,6 +248,17 @@
     weightlessFrictionNoInput: 200
     weightlessAcceleration: 1.8
   - type: NoSlip
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.2
+        density: 100
+        mask:
+        - SmallMobMask
+        layer:
+        - SmallMobLayer
   - type: Sprite
     granularLayersRendering: true
     drawdepth: SmallMobs


### PR DESCRIPTION
Повертає Реплікаторам першого рівня малу колізію для проходу під дверима й додає всім формам нічне бачення.

:cl:
- fix: Реплікатори першого рівня знову можуть проходити під дверима.
- add: Реплікатори отримали нічне бачення.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Базовий реплікатор отримав нічне бачення з рожевим відтінком.
  * Для нічного бачення реплікатора вимкнено звуки активації та деактивації.
  * Реплікатор першого рівня отримав фізичні параметри для взаємодії з малими істотами.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->