### PR TITLE
Покращити гніздо та стан-проєктори Реплікаторів

### DIFF
--- a/Content.Pirate.Shared/Replicator/ReplicatorNestComponent.cs
+++ b/Content.Pirate.Shared/Replicator/ReplicatorNestComponent.cs
@@ -133,7 +133,7 @@ public sealed partial class ReplicatorNestComponent : Component
     public EntProtoId SpawnNewNestAction = "ActionReplicatorSpawnNest";
 
     [DataField]
-    public SoundSpecifier FallingSound = new SoundPathSpecifier("/Audio/_Pirate/Effects/falling.ogg");
+    public SoundSpecifier FallingSound = new SoundPathSpecifier("/Audio/Effects/falling.ogg");
     [DataField]
     public SoundSpecifier LevelUpSound = new SoundPathSpecifier("/Audio/_Pirate/Ambience/hole_2.ogg");
     [DataField]

--- a/Resources/Prototypes/_Pirate/Replicators/replicator-loadout.yml
+++ b/Resources/Prototypes/_Pirate/Replicators/replicator-loadout.yml
@@ -205,7 +205,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanStaminaDamage
-    staminaDamage: 18
+    staminaDamage: 20
   - type: HitscanBasicVisuals
     muzzleFlash:
       sprite: _Pirate/Mobs/Replicator/replicator_gun.rsi
@@ -223,7 +223,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanStaminaDamage
-    staminaDamage: 32
+    staminaDamage: 34
   - type: HitscanBasicVisuals
     muzzleFlash:
       sprite: _Pirate/Mobs/Replicator/replicator_gun.rsi

--- a/Resources/Prototypes/_Pirate/Replicators/replicator-nest.yml
+++ b/Resources/Prototypes/_Pirate/Replicators/replicator-nest.yml
@@ -15,7 +15,7 @@
   components:
   - type: ReplicatorNest
     fallingSound:
-      path: /Audio/_Pirate/Effects/falling.ogg
+      path: /Audio/Effects/falling.ogg
       params:
         variation: 0.1
     blacklist:
@@ -95,6 +95,8 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: RequireProjectileTarget
+  - type: ExplosionResistance
+    damageCoefficient: 0.1
   - type: SolutionContainerManager
     solutions:
       drainBuffer:

--- a/Resources/Prototypes/_Pirate/Replicators/replicators.yml
+++ b/Resources/Prototypes/_Pirate/Replicators/replicators.yml
@@ -230,6 +230,9 @@
     upgradeActions:
     - ActionReplicatorUpgrade2
     - ActionReplicatorUpgrade2Alt
+  - type: HTN
+    rootTask:
+      task: SimpleHumanoidHostileCompound
   - type: CombatMode
   - type: StaminaDamageOnHit
     damage: 20
@@ -337,6 +340,9 @@
   categories: [HideSpawnMenu] # I don't want admins spawning a replicator that's unlinked to a nest
   suffix: Level 2 Alt
   components:
+  - type: HTN
+    rootTask:
+      task: SimpleHumanoidHostileCompound
   - type: CombatMode
   - type: Replicator
     upgradeStage: 1
@@ -389,6 +395,9 @@
   description: "Повільна й надзвичайно міцна форма Реплікатора."
   suffix: Level 3
   components:
+  - type: HTN
+    rootTask:
+      task: SimpleHumanoidHostileCompound
   - type: CombatMode
   - type: Replicator
     upgradeStage: 2


### PR DESCRIPTION
Додає звук падіння Bingle для гнізда, посилює стан-проєктори та дає гнізду 90% опору вибухам.

:cl:
- tweak: Гніздо Реплікаторів отримало звук поглинання та захист від вибухів, а стан-проєктори стали трохи сильнішими.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Нові можливості**
  - Гнізда реплікаторів тепер мають підвищену стійкість до вибухової шкоди.

- **Баланс**
  - Збільшено шкоду витривалості для `HitscanReplicator` з 18 до 20.
  - Збільшено шкоду витривалості для `HitscanReplicator2` з 32 до 34.

- **Виправлення**
  - Звук падіння для реплікаторів і їхніх гнізд замінено на стандартний звуковий ефект.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->