### PR TITLE
tweak: move bonus payments

### DIFF
--- a/Content.Goobstation.Server/ServerCurrency/ServerCurrencySystem.cs
+++ b/Content.Goobstation.Server/ServerCurrency/ServerCurrencySystem.cs
@@ -2,6 +2,7 @@
 
 using Content.Goobstation.Common.CCVar;
 using Content.Goobstation.Common.ServerCurrency;
+using Content.Server._Pirate.ServerCurrency; // Pirate: roundstart bonus
 using Content.Server._RMC14.LinkAccount;
 using Content.Server.GameTicking;
 using Content.Server.Popups;
@@ -31,6 +32,7 @@ namespace Content.Goobstation.Server.ServerCurrency
         [Dependency] private readonly LinkAccountManager _linkAccount = default!;
         [Dependency] private readonly GameTicker _gameTicker = default!;
         [Dependency] private readonly SandboxSystem _sandbox = default!; // Pirate
+        [Dependency] private readonly PirateGoobcoinRewardSystem _pirateGoobcoins = default!; // Pirate: roundstart bonus
 
         private int _goobcoinsPerPlayer = 10;
         private int _goobcoinsNonAntagMultiplier = 1;
@@ -113,6 +115,8 @@ namespace Content.Goobstation.Server.ServerCurrency
                             var roundMinutesActual = _gameTicker.RoundDuration().TotalMinutes;
                             money = (int) (money * Math.Min(1, roundMinutesActual / _goobcoinsShortRoundPenaltyTargetMinutes));
                         }
+
+                        money += _pirateGoobcoins.GetRoundStartBonus(mind.OriginalOwnerUserId.Value); // Pirate: roundstart bonus
 
                         _currencyMan.AddCurrency(mind.OriginalOwnerUserId.Value, money);
                     }

--- a/Content.Server/_Pirate/ServerCurrency/PirateCryoEntryTimeComponent.cs
+++ b/Content.Server/_Pirate/ServerCurrency/PirateCryoEntryTimeComponent.cs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-namespace Content.Pirate.Server.ServerCurrency;
+namespace Content.Server._Pirate.ServerCurrency;
 
 /// <summary>Tracks a cryopod stay for the early-cryo penalty.</summary>
 [RegisterComponent]
@@ -10,5 +10,5 @@ public sealed partial class PirateCryoEntryTimeComponent : Component
     public TimeSpan RoundTimeOnEntry;
 
     [ViewVariables]
-    public bool Charged;
+    public bool Processed;
 }

--- a/Content.Server/_Pirate/ServerCurrency/PirateGoobcoinRewardSystem.cs
+++ b/Content.Server/_Pirate/ServerCurrency/PirateGoobcoinRewardSystem.cs
@@ -10,10 +10,11 @@ using Content.Shared.GameTicking;
 using Content.Shared.Mind.Components;
 using Robust.Server.Player;
 using Robust.Shared.Configuration;
+using Robust.Shared.Network;
 
-namespace Content.Pirate.Server.ServerCurrency;
+namespace Content.Server._Pirate.ServerCurrency;
 
-/// <summary>Handles round-start bonuses and early-cryo penalties.</summary>
+/// <summary>Handles sign-on bonuses and early-cryo penalties.</summary>
 public sealed class PirateGoobcoinRewardSystem : EntitySystem
 {
     [Dependency] private readonly ICommonCurrencyManager _currency = default!;
@@ -22,6 +23,8 @@ public sealed class PirateGoobcoinRewardSystem : EntitySystem
     [Dependency] private readonly IPlayerManager _players = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly SandboxSystem _sandbox = default!;
+
+    private readonly HashSet<NetUserId> _signedOn = new();
 
     private int _roundStartBonus;
     private int _earlyCryoPenalty;
@@ -32,6 +35,7 @@ public sealed class PirateGoobcoinRewardSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawnComplete);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestartCleanup);
         // CryostorageSystem owns the direct insertion and mind-removal events.
         // This component starts on pod entry and is available when the mind is removed.
         SubscribeLocalEvent<CryostorageContainedComponent, ComponentStartup>(OnCryoContainedStartup);
@@ -42,15 +46,22 @@ public sealed class PirateGoobcoinRewardSystem : EntitySystem
         Subs.CVar(_cfg, PirateGoobcoinCVars.EarlyCryoWindowMinutes, value => _earlyCryoWindowMinutes = value, true);
     }
 
+    public int GetRoundStartBonus(NetUserId userId) => _signedOn.Contains(userId) ? _roundStartBonus : 0;
+
     private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent ev)
     {
         if (ev.LateJoin || _roundStartBonus <= 0 || _sandbox.IsSandboxEnabled)
             return;
 
-        _currency.AddCurrency(ev.Player.UserId, _roundStartBonus);
+        _signedOn.Add(ev.Player.UserId);
         _chat.DispatchServerMessage(ev.Player,
-            Loc.GetString("pirate-goobcoin-round-start-bonus",
+            Loc.GetString("pirate-goobcoin-signed-on",
                 ("amount", _currency.Stringify(_roundStartBonus))));
+    }
+
+    private void OnRoundRestartCleanup(RoundRestartCleanupEvent ev)
+    {
+        _signedOn.Clear();
     }
 
     private void OnCryoContainedStartup(Entity<CryostorageContainedComponent> ent, ref ComponentStartup args)
@@ -60,12 +71,12 @@ public sealed class PirateGoobcoinRewardSystem : EntitySystem
 
         var entry = EnsureComp<PirateCryoEntryTimeComponent>(ent.Owner);
         entry.RoundTimeOnEntry = _gameTicker.RoundDuration();
-        entry.Charged = false;
+        entry.Processed = false;
     }
 
     private void OnCryoMindRemoved(Entity<PirateCryoEntryTimeComponent> ent, ref MindRemovedMessage args)
     {
-        if (_earlyCryoPenalty <= 0 || _sandbox.IsSandboxEnabled)
+        if (_sandbox.IsSandboxEnabled)
             return;
 
         if (args.Mind.Comp.UserId is not { } userId)
@@ -76,23 +87,43 @@ public sealed class PirateGoobcoinRewardSystem : EntitySystem
             return;
 
         var entry = ent.Comp;
-        if (entry.Charged || entry.RoundTimeOnEntry.TotalMinutes > _earlyCryoWindowMinutes)
+        if (entry.Processed)
             return;
 
-        entry.Charged = true;
+        entry.Processed = true;
 
-        var amount = Math.Min(_earlyCryoPenalty, _currency.GetBalance(userId));
+        // Payouts use the original owner; messages use the active session.
+        var account = args.Mind.Comp.OriginalOwnerUserId ?? userId;
+        _players.TryGetSessionById(userId, out var session);
+
+        if (_signedOn.Remove(account) && session != null)
+        {
+            _chat.DispatchServerMessage(session,
+                Loc.GetString("pirate-goobcoin-signed-on-forfeited",
+                    ("amount", _currency.Stringify(_roundStartBonus))));
+        }
+
+        if (_earlyCryoPenalty <= 0 || _earlyCryoWindowMinutes <= 0f)
+            return;
+
+        // Tapering avoids a hard timing threshold.
+        var elapsedMinutes = entry.RoundTimeOnEntry.TotalMinutes;
+        if (elapsedMinutes >= _earlyCryoWindowMinutes)
+            return;
+
+        var scaled = (int) Math.Round(_earlyCryoPenalty * (1d - elapsedMinutes / _earlyCryoWindowMinutes));
+
+        var amount = Math.Min(scaled, _currency.GetBalance(account));
         if (amount <= 0)
             return;
 
-        _currency.RemoveCurrency(userId, amount);
+        _currency.RemoveCurrency(account, amount);
 
-        if (!_players.TryGetSessionById(userId, out var session))
+        if (session == null)
             return;
 
         _chat.DispatchServerMessage(session,
             Loc.GetString("pirate-goobcoin-early-cryo-penalty",
-                ("amount", _currency.Stringify(amount)),
-                ("minutes", _earlyCryoWindowMinutes)));
+                ("amount", _currency.Stringify(amount))));
     }
 }

--- a/Content.Shared/_Pirate/CCVars/CCVars.Goobcoins.cs
+++ b/Content.Shared/_Pirate/CCVars/CCVars.Goobcoins.cs
@@ -8,15 +8,15 @@ namespace Content.Shared._Pirate.CCVars;
 [CVarDefs]
 public sealed class PirateGoobcoinCVars
 {
-    /// <summary>Set to 0 to disable the round-start bonus.</summary>
+    /// <summary>Sign-on bonus paid at round end. Set to 0 to disable.</summary>
     public static readonly CVarDef<int> RoundStartBonus =
         CVarDef.Create("pirate.goobcoin.round_start_bonus", 50, CVar.SERVERONLY);
 
-    /// <summary>Set to 0 to disable the early-cryo penalty.</summary>
+    /// <summary>Maximum early-cryo penalty. Set to 0 to disable.</summary>
     public static readonly CVarDef<int> EarlyCryoPenalty =
         CVarDef.Create("pirate.goobcoin.early_cryo_penalty", 100, CVar.SERVERONLY);
 
-    /// <summary>Minutes after round start when entering cryo still counts as early.</summary>
+    /// <summary>Minutes after pod entry over which the penalty tapers to zero.</summary>
     public static readonly CVarDef<float> EarlyCryoWindowMinutes =
         CVarDef.Create("pirate.goobcoin.early_cryo_window_minutes", 10f, CVar.SERVERONLY);
 }

--- a/Resources/Locale/en-US/_Pirate/servercurrency/server_currency.ftl
+++ b/Resources/Locale/en-US/_Pirate/servercurrency/server_currency.ftl
@@ -7,7 +7,8 @@ gs-balanceui-shop-buy-minor-token-antag-desc = Allows you to become a minor anta
 gs-balanceui-remark-major-token-antag = Bought a major antag token.
 gs-balanceui-remark-minor-token-antag = Bought a minor antag token.
 
-## Mid-round payouts
+## Sign-on bonus and early departure
 
-pirate-goobcoin-round-start-bonus = You have been awarded {$amount} for showing up at the start of the shift.
-pirate-goobcoin-early-cryo-penalty = You have been docked {$amount} for abandoning your post within the first {$minutes} minutes of the shift.
+pirate-goobcoin-signed-on = You are signed on for the full shift. {$amount} will be paid out at the end of it.
+pirate-goobcoin-signed-on-forfeited = You abandoned your shift early and forfeited your {$amount} sign-on bonus.
+pirate-goobcoin-early-cryo-penalty = You have been docked {$amount} for abandoning your post so soon after the shift began.

--- a/Resources/Locale/uk-UA/_Pirate/servercurrency/server_currency.ftl
+++ b/Resources/Locale/uk-UA/_Pirate/servercurrency/server_currency.ftl
@@ -7,7 +7,8 @@ gs-balanceui-shop-buy-minor-token-antag-desc = Дозволяє стати мі�
 gs-balanceui-remark-major-token-antag = Куплено жетон мажорного антагоніста.
 gs-balanceui-remark-minor-token-antag = Куплено жетон мінорного антагоніста.
 
-## Виплати протягом зміни
+## Бонус за вихід на зміну та передчасне залишення
 
-pirate-goobcoin-round-start-bonus = Вам нараховано {$amount} за прибуття на початку зміни.
-pirate-goobcoin-early-cryo-penalty = З вас стягнуто {$amount} за залишення посту протягом перших {$minutes} хвилин зміни.
+pirate-goobcoin-signed-on = Вас записано на повну зміну. {$amount} буде виплачено після її завершення.
+pirate-goobcoin-signed-on-forfeited = Ви передчасно залишили зміну та втратили бонус за вихід на неї — {$amount}.
+pirate-goobcoin-early-cryo-penalty = З вас стягнуто {$amount} за залишення посту невдовзі після початку зміни.


### PR DESCRIPTION
## Чому / Баланс
Дякую Question'у, який  розказав про свої плани потужно фармити губки

**Журнал змін**
:cl:
- tweak: бонусні 50 губок за готовність виплачуються не на старті раунду, а в кінці, разом із всіма іншими


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Бонус за повну зміну тепер додається до підсумкової нагороди наприкінці раунду.
  * Достроковий вихід або рання кріоконсервація можуть скасувати бонус чи зменшити винагороду залежно від часу перебування в раунді.
  * Повідомлення про отримання, втрату та штрафи за бонус оновлено.

* **Локалізація**
  * Оновлено англійські й українські тексти повідомлень про нагороди, вихід зі зміни та кріоконсервацію.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->