### PR TITLE
Fix slime extract reagent reactions

### DIFF
--- a/Content.Shared/EntityEffects/SharedEntityEffectsSystem.cs
+++ b/Content.Shared/EntityEffects/SharedEntityEffectsSystem.cs
@@ -31,6 +31,9 @@ public sealed partial class SharedEntityEffectsSystem : EntitySystem, IEntityEff
         using var legacyReaction = LegacyEntityEffectContext.PushReaction(EntityManager, args);
 
         var scale = args.ReagentQuantity.Quantity.Float();
+        // Pirate: one-unit reactions must not scale entity effects by injected volume.
+        if (entity.Comp.OneUnitReaction)
+            scale = 1f;
 
         if (args.Reagent.ReactiveEffects != null && entity.Comp.ReactiveGroups != null)
         {

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t0/grey.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t0/grey.yml
@@ -20,9 +20,10 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: Epinephrine
-        amount: 15
+        solution: extract
+        strengthModifier: 15
     - reagents: [ Plasma ]
       methods: [ Touch, Injection ]
       effects:

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t1/blue.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t1/blue.yml
@@ -34,9 +34,10 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: FrostOil
-        amount: 30
+        solution: extract
+        strengthModifier: 30
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:
@@ -46,9 +47,9 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: XenobioJellyBlue
-        amount: 1
+        solution: extract
   - type: Tag
     tags:
     - XenobiologyBlueExtract

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t1/orange.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t1/orange.yml
@@ -53,9 +53,10 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: CapsaicinOil
-        amount: 30
+        solution: extract
+        strengthModifier: 30
   - type: Tag
     tags:
     - XenobiologyOrangeExtract

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t1/purple.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t1/purple.yml
@@ -32,9 +32,9 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: XenobioJellyPurple
-        amount: 1
+        solution: extract
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:
@@ -44,9 +44,10 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: Omnizine
-        amount: 15
+        solution: extract
+        strengthModifier: 15
   - type: Tag
     tags:
     - XenobiologyPurpleExtract

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t2/cerulean.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t2/cerulean.yml
@@ -43,9 +43,9 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: XenobioJellyCerulean
-        amount: 1
+        solution: extract
   - type: Tag
     tags:
     - XenobiologyCeruleanExtract

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t2/dark_blue.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t2/dark_blue.yml
@@ -20,9 +20,9 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: XenobioJellyDarkBlue
-        amount: 1
+        solution: extract
     - reagents: [ Plasma ]
       methods: [ Touch, Injection ]
       effects:
@@ -44,9 +44,10 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: Leporazine
-        amount: 30
+        solution: extract
+        strengthModifier: 30
   - type: Tag
     tags:
     - XenobiologyDarkBlueExtract

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/green.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/green.yml
@@ -20,9 +20,10 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: XenobioFelinidToxin # EVIL
-        amount: 10
+        solution: extract
+        strengthModifier: 10
     - reagents: [ Plasma ]
       methods: [ Touch, Injection ]
       effects:
@@ -32,9 +33,10 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: XenobioJellyGreen
-        amount: 10
+        solution: extract
+        strengthModifier: 10
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:
@@ -44,9 +46,10 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: XenobioHumanToxin
-        amount: 10
+        solution: extract
+        strengthModifier: 10
   - type: Tag
     tags:
     - XenobiologyGreenExtract

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/pink.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/pink.yml
@@ -31,9 +31,10 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: XenobioJellyPink
-        amount: 10
+        solution: extract
+        strengthModifier: 10
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:
@@ -43,9 +44,10 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: XenobioGenderFluid
-        amount: 10
+        solution: extract
+        strengthModifier: 10
   - type: Tag
     tags:
     - XenobiologyPinkExtract

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/red.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/red.yml
@@ -33,9 +33,9 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: XenobioJellyRed
-        amount: 1
+        solution: extract
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/sepia.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/sepia.yml
@@ -21,9 +21,10 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: Tilenol
-        amount: 100
+        solution: extract
+        strengthModifier: 100
     - reagents: [ Plasma ]
       methods: [ Touch, Injection ]
       effects:

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t4/black.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t4/black.yml
@@ -29,9 +29,10 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: AdvancedMutationToxin
-        amount: 10
+        solution: extract
+        strengthModifier: 10
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t4/light_pink.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t4/light_pink.yml
@@ -37,9 +37,10 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: Cognizine
-        amount: 10
+        solution: extract
+        strengthModifier: 10
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t4/oil.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t4/oil.yml
@@ -21,9 +21,10 @@
         messages: [ "xeno-extract-reaction-reagent" ]
       - !type:PlaySoundEffect
         sound: /Audio/Effects/Chemistry/bubbles.ogg
-      - !type:AdjustReagent
+      - !type:AddReagentToSolution
         reagent: SpaceLube
-        amount: 100
+        solution: extract
+        strengthModifier: 100
     - reagents: [ Plasma ]
       methods: [ Touch, Injection ]
       effects:


### PR DESCRIPTION
Виправляє реакції екстрактів слаймів після міграції entity effects: хімічні результати знову зберігаються всередині екстракту, а разові ефекти не множаться на об'єм введеного реагенту.

:cl:
- fix: Виправлено створення реагентів екстрактами слаймів.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Зміни ігрового процесу**
  * Реакції екстрактів слаймів тепер коректно додають створені реагенти до їхнього розчину, зберігаючи передбачені модифікатори сили.
  * Оновлено ефекти екстрактів сірого, синього, помаранчевого, фіолетового, церулеанового, темно-синього, зеленого, рожевого, червоного, сепієвого, чорного, світло-рожевого та олійного слаймів.
  * Для реакцій із дозованими реагентами масштабується саме сила ефекту, а не об’єм введеного реагенту.
  * Одноразові реакції більше не залежать від об’єму ін’єкції під час розрахунку сили ефекту.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->