### PR TITLE
Balance Skia regeneration and teleport cooldown

### DIFF
--- a/Resources/Prototypes/_Pirate/Skia/actions.yml
+++ b/Resources/Prototypes/_Pirate/Skia/actions.yml
@@ -20,7 +20,7 @@
     blockedBySpectral: false
     school: Translocation
   - type: Action
-    useDelay: 30
+    useDelay: 60
     icon:
       sprite: _Goobstation/Wizard/actions.rsi
       state: jaunt

--- a/Resources/Prototypes/_Pirate/Skia/entities.yml
+++ b/Resources/Prototypes/_Pirate/Skia/entities.yml
@@ -81,15 +81,15 @@
     lightThreshold: 0.7
     darkDamage:
       types:
-        Blunt: -5
-        Piercing: -5
-        Slash: -5
-        Heat: -5
-        Poison: -5
-        Asphyxiation: -2.5
-        Bloodloss: -2.5
-        Cellular: -5
-        Soul: -1
+        Blunt: -0.69
+        Piercing: -0.69
+        Slash: -0.69
+        Heat: -0.69
+        Poison: -0.69
+        Asphyxiation: -0.36
+        Bloodloss: -0.36
+        Cellular: -0.69
+        Soul: -0.14
     lightDamage:
       types:
         Blunt: 1.5


### PR DESCRIPTION
Зменшує регенерацію Скії в темряві до 5 шкоди за секунду та встановлює перезарядку Ефірного ривка на 60 секунд.

:cl:
- tweak: Збалансовано регенерацію Скії в темряві та перезарядку Ефірного ривка.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Зміни балансу**
  * Збільшено час повторного використання здібності «Стрибок Скіа» з 30 до 60 секунд.
  * Зменшено негативний ефект темної шкоди для Скіа за всіма типами шкоди, зокрема фізичної, теплової, отруйної, клітинної, асфіксії, крововтрати та душевної.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->