### PR TITLE
Fix stale light effect with night vision

### DIFF
--- a/Content.Client/_Pirate/PostProcess/CEPostProcessOverlay.cs
+++ b/Content.Client/_Pirate/PostProcess/CEPostProcessOverlay.cs
@@ -51,7 +51,7 @@ public sealed class CEPostProcessOverlay : Overlay
         if (eyeComp.Eye is not { } eye)
             return false;
 
-        if (!_lightManager.Enabled || !eye.DrawLight || !eye.DrawFov)
+        if (!_lightManager.Enabled || !_lightManager.DrawLighting || !eye.DrawLight || !eye.DrawFov)
             return false;
 
         if (_player.LocalSession?.AttachedEntity == null)


### PR DESCRIPTION
Виправлено залипання світлового постефекту після ввімкнення нічного бачення біля яскравих джерел.

:cl:
- fix: Світловий ефект більше не закріплюється за персонажем під час нічного бачення.