### PR TITLE
Fix energy shotgun steal objectives

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -1116,6 +1116,8 @@
   - type: Battery
     maxCharge: 1200 # Goobstation
     startingCharge: 1200 # Goobstation
+  - type: StealTarget # Pirate: Restore the energy shotgun steal objective target.
+    stealGroup: WeaponEnergyShotgun
 
 - type: entity
   name: energy magnum


### PR DESCRIPTION
Відновлює маркер цілі для енергетичного дробовика Наглядача.

:cl:
- fix: Енергетичний дробовик Наглядача знову зараховується для цілей крадіжки.