### PR TITLE
Виправити скидання особливостей персонажа

### DIFF
--- a/Content.Client/_Pirate/Traits/UI/TraitCategory.xaml.cs
+++ b/Content.Client/_Pirate/Traits/UI/TraitCategory.xaml.cs
@@ -115,11 +115,14 @@ public sealed partial class TraitCategory : BoxContainer
         }
     }
 
-    public void SetTraitSelected(ProtoId<TraitPrototype> traitId, bool selected)
+    public void SetTraitSelected(
+        ProtoId<TraitPrototype> traitId,
+        bool selected,
+        bool respectConditions = true)
     {
         if (_traitEntries.TryGetValue(traitId, out var entry))
         {
-            entry.SetSelected(selected);
+            entry.SetSelected(selected, respectConditions);
         }
     }
 

--- a/Content.Client/_Pirate/Traits/UI/TraitEntry.xaml.cs
+++ b/Content.Client/_Pirate/Traits/UI/TraitEntry.xaml.cs
@@ -215,10 +215,10 @@ public sealed partial class TraitEntry : PanelContainer
         OnToggled?.Invoke(args.Pressed);
     }
 
-    public void SetSelected(bool selected)
+    public void SetSelected(bool selected, bool respectConditions = true)
     {
         _isUpdating = true;
-        TraitCheckbox.Pressed = selected && MeetsConditions;
+        TraitCheckbox.Pressed = selected && (!respectConditions || MeetsConditions);
         UpdateSelectedStyle();
         _isUpdating = false;
     }
@@ -231,4 +231,3 @@ public sealed partial class TraitEntry : PanelContainer
             RemoveStyleClass("TraitsEntrySelected");
     }
 }
-

--- a/Content.Client/_Pirate/Traits/UI/TraitsTab.xaml.cs
+++ b/Content.Client/_Pirate/Traits/UI/TraitsTab.xaml.cs
@@ -382,7 +382,8 @@ public sealed partial class TraitsTab : BoxContainer
 
             if (trait.Category != null && _categoryUis.TryGetValue(trait.Category.Value, out var categoryUi))
             {
-                categoryUi.SetTraitSelected(traitId, true);
+                // Conditions still describe the previously displayed profile until UpdateConditions runs.
+                categoryUi.SetTraitSelected(traitId, true, respectConditions: false);
             }
         }
 

--- a/Content.IntegrationTests/Tests/_Pirate/Traits/TraitSelectionPersistenceTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Traits/TraitSelectionPersistenceTest.cs
@@ -40,5 +40,7 @@ public sealed class TraitSelectionPersistenceTest
                 Is.Null,
                 $"Loading {traitId} must not clear it using conditions from {previousSpecies}");
         });
+
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/_Pirate/Traits/TraitSelectionPersistenceTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Traits/TraitSelectionPersistenceTest.cs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Client._Pirate.Traits.UI;
+using Content.Shared.Preferences;
+using Content.Shared.Traits;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests._Pirate.Traits;
+
+[TestFixture]
+public sealed class TraitSelectionPersistenceTest
+{
+    [TestCase("Tajaran", "TraitNightVision")]
+    [TestCase("IPC", "Vampirism")]
+    public async Task LoadingProfileDoesNotUsePreviousSpeciesConditions(
+        string previousSpecies,
+        string traitId)
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+        var client = pair.Client;
+
+        await client.WaitAssertion(() =>
+        {
+            var traitsTab = new TraitsTab();
+            try
+            {
+                var previousProfile = HumanoidCharacterProfile.DefaultWithSpecies(previousSpecies);
+                var selectedTrait = new ProtoId<TraitPrototype>(traitId);
+                var nextProfile = HumanoidCharacterProfile.DefaultWithSpecies("Human")
+                    .WithTraitPreferences([selectedTrait]);
+
+                traitsTab.UpdateConditions(previousProfile);
+
+                HashSet<ProtoId<TraitPrototype>> changedTraits = null;
+                traitsTab.OnTraitsChanged += traits => changedTraits = new HashSet<ProtoId<TraitPrototype>>(traits);
+
+                traitsTab.SetSelectedTraits(nextProfile.TraitPreferences);
+                traitsTab.UpdateConditions(nextProfile);
+
+                Assert.That(changedTraits,
+                    Is.Null,
+                    $"Loading {traitId} must not clear it using conditions from {previousSpecies}");
+            }
+            finally
+            {
+                traitsTab.Dispose();
+            }
+        });
+    }
+}

--- a/Content.IntegrationTests/Tests/_Pirate/Traits/TraitSelectionPersistenceTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Traits/TraitSelectionPersistenceTest.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using System.Collections.Generic;
 using Content.Client._Pirate.Traits.UI;
 using Content.Shared.Preferences;
 using Content.Shared.Traits;
@@ -22,29 +23,22 @@ public sealed class TraitSelectionPersistenceTest
         await client.WaitAssertion(() =>
         {
             var traitsTab = new TraitsTab();
-            try
-            {
-                var previousProfile = HumanoidCharacterProfile.DefaultWithSpecies(previousSpecies);
-                var selectedTrait = new ProtoId<TraitPrototype>(traitId);
-                var nextProfile = HumanoidCharacterProfile.DefaultWithSpecies("Human")
-                    .WithTraitPreferences([selectedTrait]);
+            var previousProfile = HumanoidCharacterProfile.DefaultWithSpecies(previousSpecies);
+            var selectedTrait = new ProtoId<TraitPrototype>(traitId);
+            var nextProfile = HumanoidCharacterProfile.DefaultWithSpecies("Human")
+                .WithTraitPreferences([selectedTrait]);
 
-                traitsTab.UpdateConditions(previousProfile);
+            traitsTab.UpdateConditions(previousProfile);
 
-                HashSet<ProtoId<TraitPrototype>> changedTraits = null;
-                traitsTab.OnTraitsChanged += traits => changedTraits = new HashSet<ProtoId<TraitPrototype>>(traits);
+            HashSet<ProtoId<TraitPrototype>> changedTraits = null;
+            traitsTab.OnTraitsChanged += traits => changedTraits = new HashSet<ProtoId<TraitPrototype>>(traits);
 
-                traitsTab.SetSelectedTraits(nextProfile.TraitPreferences);
-                traitsTab.UpdateConditions(nextProfile);
+            traitsTab.SetSelectedTraits(nextProfile.TraitPreferences);
+            traitsTab.UpdateConditions(nextProfile);
 
-                Assert.That(changedTraits,
-                    Is.Null,
-                    $"Loading {traitId} must not clear it using conditions from {previousSpecies}");
-            }
-            finally
-            {
-                traitsTab.Dispose();
-            }
+            Assert.That(changedTraits,
+                Is.Null,
+                $"Loading {traitId} must not clear it using conditions from {previousSpecies}");
         });
     }
 }


### PR DESCRIPTION
Виправляє скидання збережених особливостей під час перемикання між персонажами з різними умовами виду.

:cl:
- fix: Особливості персонажа більше не скидаються через умови попереднього персонажа.