### PR TITLE
Fix alert icons overflowing screen

### DIFF
--- a/Content.Client/UserInterface/Systems/Alerts/Widgets/AlertsUI.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Alerts/Widgets/AlertsUI.xaml.cs
@@ -22,6 +22,8 @@ public sealed partial class AlertsUI : UIWidget
     public AlertsUI()
     {
         RobustXamlLoader.Load(this);
+        // Pirate: Keep wrapped alert columns inside the right edge of the screen.
+        LayoutContainer.SetGrowHorizontal(this, LayoutContainer.GrowDirection.Begin);
     }
 
     public void SyncControls(AlertsSystem alertsSystem,


### PR DESCRIPTION
Виправлено перенесення колонок статусних індикаторів: тепер вони ростуть уліво й не виходять за межі екрана.

:cl:
- fix: Піктограми статусів більше не обрізаються краєм екрана.