### PR TITLE
Виправлення зачісок зомбі та часу підготовки нульового пацієнта

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -157,6 +157,8 @@ public sealed partial class ZombieSystem
             return;
         }
 
+        // Pirate: Preserve hair and other humanoid markings through the zombie polymorph.
+        _humanoidAppearance.CloneAppearance(target, zombie);
         _meta.SetEntityName(zombie, _nameMod.GetBaseName(target));
 
         // reassign target to polymorphed zombie !!

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -442,7 +442,9 @@
         color: Plum
         sound: "/Audio/Ambience/Antag/zombie_start.ogg"
       components:
-      - type: PendingZombie
+      - type: PendingZombie # Pirate: Restore preparation time for patient zero.
+        minInitialInfectedGrace: 750
+        maxInitialInfectedGrace: 900
       - type: ZombifyOnDeath
       - type: IncurableZombie
       - type: InitialInfected


### PR DESCRIPTION
Зберігає зачіску та інші маркування після перетворення на зомбі. Повертає нульовому пацієнту 12,5-15 хвилин підготовки на початку раунду.

:cl:
- fix: Зомбі більше не втрачають зачіску після перетворення.
- fix: Нульовий пацієнт тепер має достатньо часу на підготовку.