### PR TITLE
Додаткове послаблення Скії та реген Soul-шкоди

### DIFF
--- a/Content.IntegrationTests/Tests/_Pirate/Damage/SoulDamageRegenerationTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Damage/SoulDamageRegenerationTest.cs
@@ -6,11 +6,15 @@ using Content.Shared._Shitmed.Targeting;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Mobs.Systems;
+using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests._Pirate.Damage;
 
 public sealed class SoulDamageRegenerationTest : InteractionTest
 {
+    private static readonly ProtoId<DamageTypePrototype> SoulDamageType = "Soul";
+    private static readonly ProtoId<DamageTypePrototype> BluntDamageType = "Blunt";
+
     protected override string PlayerPrototype => "MobHuman";
 
     [TestCase(false)]
@@ -19,66 +23,81 @@ public sealed class SoulDamageRegenerationTest : InteractionTest
     {
         await AddAtmosphere();
 
-        var body = SEntMan.System<BodySystem>();
-        var damageable = SEntMan.System<DamageableSystem>();
-        var mobState = SEntMan.System<MobStateSystem>();
-        var soulType = ProtoMan.Index<DamageTypePrototype>("Soul");
         FixedPoint2 initialSoulDamage = 9;
         FixedPoint2 additionalSoulDamage = 3;
+        FixedPoint2 healAmount = 0;
+        var halfRecoveryDelay = 0f;
 
-        var applied = damageable.TryChangeDamage(
-            SPlayer,
-            new DamageSpecifier(soulType, initialSoulDamage),
-            ignoreResistances: true,
-            canMiss: false);
-
-        Assert.That(applied?.DamageDict["Soul"], Is.EqualTo(initialSoulDamage));
-
-        var playerDamage = Comp<DamageableComponent>(Player);
-        var regeneration = SEntMan.GetComponent<SoulDamageRegenerationComponent>(SPlayer);
-        foreach (var part in body.GetBodyChildren(SPlayer))
+        await Server.WaitAssertion(() =>
         {
-            Assert.That(
-                SEntMan.HasComponent<SoulDamageRegenerationComponent>(part.Id),
-                Is.False,
-                $"Attached body part {part.Id} should not regenerate Soul damage separately");
-        }
+            var body = SEntMan.System<BodySystem>();
+            var damageable = SEntMan.System<DamageableSystem>();
+            var mobState = SEntMan.System<MobStateSystem>();
+            var soulType = ProtoMan.Index(SoulDamageType);
 
-        if (dead)
-        {
-            var bluntType = ProtoMan.Index<DamageTypePrototype>("Blunt");
+            var applied = damageable.TryChangeDamage(
+                SPlayer,
+                new DamageSpecifier(soulType, initialSoulDamage),
+                ignoreResistances: true,
+                canMiss: false);
+
+            Assert.That(applied?.DamageDict[SoulDamageType.Id], Is.EqualTo(initialSoulDamage));
+
+            var regeneration = SEntMan.GetComponent<SoulDamageRegenerationComponent>(SPlayer);
+            healAmount = regeneration.HealAmount;
+            halfRecoveryDelay = (float) regeneration.RecoveryDelay.TotalSeconds / 2f;
+
+            foreach (var part in body.GetBodyChildren(SPlayer))
+            {
+                Assert.That(
+                    SEntMan.HasComponent<SoulDamageRegenerationComponent>(part.Id),
+                    Is.False,
+                    $"Attached body part {part.Id} should not regenerate Soul damage separately");
+            }
+
+            if (!dead)
+                return;
+
             damageable.TryChangeDamage(
                 SPlayer,
-                new DamageSpecifier(bluntType, 210),
+                new DamageSpecifier(ProtoMan.Index(BluntDamageType), 210),
                 ignoreResistances: true,
                 targetPart: TargetBodyPart.Vital,
                 canMiss: false);
-
             Assert.That(mobState.IsDead(SPlayer), Is.True);
-        }
+        });
 
-        var halfRecoveryDelay = (float) regeneration.RecoveryDelay.TotalSeconds / 2f;
         await RunSeconds(halfRecoveryDelay);
 
-        var additionalApplied = damageable.TryChangeDamage(
-            SPlayer,
-            new DamageSpecifier(soulType, additionalSoulDamage),
-            ignoreResistances: true,
-            canMiss: false);
+        await Server.WaitAssertion(() =>
+        {
+            var damageable = SEntMan.System<DamageableSystem>();
+            var soulType = ProtoMan.Index(SoulDamageType);
+            var additionalApplied = damageable.TryChangeDamage(
+                SPlayer,
+                new DamageSpecifier(soulType, additionalSoulDamage),
+                ignoreResistances: true,
+                canMiss: false);
 
-        Assert.That(additionalApplied?.DamageDict["Soul"], Is.EqualTo(additionalSoulDamage));
+            Assert.That(additionalApplied?.DamageDict[SoulDamageType.Id], Is.EqualTo(additionalSoulDamage));
+        });
 
         var expectedSoulDamage = initialSoulDamage + additionalSoulDamage;
         await RunSeconds(halfRecoveryDelay);
-        Assert.That(playerDamage.Damage.DamageDict["Soul"], Is.EqualTo(expectedSoulDamage));
+        await Server.WaitAssertion(() => Assert.That(
+            Comp<DamageableComponent>(Player).Damage.DamageDict[SoulDamageType.Id],
+            Is.EqualTo(expectedSoulDamage)));
 
         await RunSeconds(halfRecoveryDelay + TickPeriod * 2);
-        Assert.That(
-            playerDamage.Damage.DamageDict["Soul"],
-            Is.EqualTo(expectedSoulDamage - regeneration.HealAmount));
+        await Server.WaitAssertion(() =>
+        {
+            Assert.That(
+                Comp<DamageableComponent>(Player).Damage.DamageDict[SoulDamageType.Id],
+                Is.EqualTo(expectedSoulDamage - healAmount));
 
-        if (dead)
-            Assert.That(mobState.IsDead(SPlayer), Is.True);
+            if (dead)
+                Assert.That(SEntMan.System<MobStateSystem>().IsDead(SPlayer), Is.True);
+        });
     }
 
     [Test]
@@ -86,20 +105,26 @@ public sealed class SoulDamageRegenerationTest : InteractionTest
     {
         await AddAtmosphere();
 
-        var damageable = SEntMan.System<DamageableSystem>();
-        var soulType = ProtoMan.Index<DamageTypePrototype>("Soul");
-        var playerDamage = Comp<DamageableComponent>(Player);
         FixedPoint2 initialSoulDamage = 3;
+        FixedPoint2 healAmount = 0;
+        var recoveryDelay = 0f;
 
-        var storedDamage = new DamageSpecifier(playerDamage.Damage);
-        storedDamage.DamageDict[soulType.ID] = initialSoulDamage;
-        damageable.SetDamage(SPlayer, playerDamage, storedDamage);
+        await Server.WaitAssertion(() =>
+        {
+            var damageable = SEntMan.System<DamageableSystem>();
+            var playerDamage = Comp<DamageableComponent>(Player);
+            var storedDamage = new DamageSpecifier(playerDamage.Damage);
+            storedDamage.DamageDict[SoulDamageType.Id] = initialSoulDamage;
+            damageable.SetDamage(SPlayer, playerDamage, storedDamage);
 
-        var regeneration = SEntMan.GetComponent<SoulDamageRegenerationComponent>(SPlayer);
-        await RunSeconds((float) regeneration.RecoveryDelay.TotalSeconds + TickPeriod * 2);
+            var regeneration = SEntMan.GetComponent<SoulDamageRegenerationComponent>(SPlayer);
+            healAmount = regeneration.HealAmount;
+            recoveryDelay = (float) regeneration.RecoveryDelay.TotalSeconds;
+        });
 
-        Assert.That(
-            playerDamage.Damage.DamageDict[soulType.ID],
-            Is.EqualTo(initialSoulDamage - regeneration.HealAmount));
+        await RunSeconds(recoveryDelay + TickPeriod * 2);
+        await Server.WaitAssertion(() => Assert.That(
+            Comp<DamageableComponent>(Player).Damage.DamageDict[SoulDamageType.Id],
+            Is.EqualTo(initialSoulDamage - healAmount)));
     }
 }

--- a/Content.IntegrationTests/Tests/_Pirate/Damage/SoulDamageRegenerationTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Damage/SoulDamageRegenerationTest.cs
@@ -1,0 +1,105 @@
+using Content.Goobstation.Maths.FixedPoint;
+using Content.IntegrationTests.Tests.Interaction;
+using Content.Server._Pirate.Damage;
+using Content.Server.Body.Systems;
+using Content.Shared._Shitmed.Targeting;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.Mobs.Systems;
+
+namespace Content.IntegrationTests.Tests._Pirate.Damage;
+
+public sealed class SoulDamageRegenerationTest : InteractionTest
+{
+    protected override string PlayerPrototype => "MobHuman";
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task RegeneratesAfterDelayForLivingAndDeadBodies(bool dead)
+    {
+        await AddAtmosphere();
+
+        var body = SEntMan.System<BodySystem>();
+        var damageable = SEntMan.System<DamageableSystem>();
+        var mobState = SEntMan.System<MobStateSystem>();
+        var soulType = ProtoMan.Index<DamageTypePrototype>("Soul");
+        FixedPoint2 initialSoulDamage = 9;
+        FixedPoint2 additionalSoulDamage = 3;
+
+        var applied = damageable.TryChangeDamage(
+            SPlayer,
+            new DamageSpecifier(soulType, initialSoulDamage),
+            ignoreResistances: true,
+            canMiss: false);
+
+        Assert.That(applied?.DamageDict["Soul"], Is.EqualTo(initialSoulDamage));
+
+        var playerDamage = Comp<DamageableComponent>(Player);
+        var regeneration = SEntMan.GetComponent<SoulDamageRegenerationComponent>(SPlayer);
+        foreach (var part in body.GetBodyChildren(SPlayer))
+        {
+            Assert.That(
+                SEntMan.HasComponent<SoulDamageRegenerationComponent>(part.Id),
+                Is.False,
+                $"Attached body part {part.Id} should not regenerate Soul damage separately");
+        }
+
+        if (dead)
+        {
+            var bluntType = ProtoMan.Index<DamageTypePrototype>("Blunt");
+            damageable.TryChangeDamage(
+                SPlayer,
+                new DamageSpecifier(bluntType, 210),
+                ignoreResistances: true,
+                targetPart: TargetBodyPart.Vital,
+                canMiss: false);
+
+            Assert.That(mobState.IsDead(SPlayer), Is.True);
+        }
+
+        var halfRecoveryDelay = (float) regeneration.RecoveryDelay.TotalSeconds / 2f;
+        await RunSeconds(halfRecoveryDelay);
+
+        var additionalApplied = damageable.TryChangeDamage(
+            SPlayer,
+            new DamageSpecifier(soulType, additionalSoulDamage),
+            ignoreResistances: true,
+            canMiss: false);
+
+        Assert.That(additionalApplied?.DamageDict["Soul"], Is.EqualTo(additionalSoulDamage));
+
+        var expectedSoulDamage = initialSoulDamage + additionalSoulDamage;
+        await RunSeconds(halfRecoveryDelay);
+        Assert.That(playerDamage.Damage.DamageDict["Soul"], Is.EqualTo(expectedSoulDamage));
+
+        await RunSeconds(halfRecoveryDelay + TickPeriod * 2);
+        Assert.That(
+            playerDamage.Damage.DamageDict["Soul"],
+            Is.EqualTo(expectedSoulDamage - regeneration.HealAmount));
+
+        if (dead)
+            Assert.That(mobState.IsDead(SPlayer), Is.True);
+    }
+
+    [Test]
+    public async Task RegeneratesSoulStoredOnComplexBodyParent()
+    {
+        await AddAtmosphere();
+
+        var damageable = SEntMan.System<DamageableSystem>();
+        var soulType = ProtoMan.Index<DamageTypePrototype>("Soul");
+        var playerDamage = Comp<DamageableComponent>(Player);
+        FixedPoint2 initialSoulDamage = 3;
+
+        var storedDamage = new DamageSpecifier(playerDamage.Damage);
+        storedDamage.DamageDict[soulType.ID] = initialSoulDamage;
+        damageable.SetDamage(SPlayer, playerDamage, storedDamage);
+
+        var regeneration = SEntMan.GetComponent<SoulDamageRegenerationComponent>(SPlayer);
+        await RunSeconds((float) regeneration.RecoveryDelay.TotalSeconds + TickPeriod * 2);
+
+        Assert.That(
+            playerDamage.Damage.DamageDict[soulType.ID],
+            Is.EqualTo(initialSoulDamage - regeneration.HealAmount));
+    }
+}

--- a/Content.IntegrationTests/Tests/_Pirate/Damage/SoulDamageRegenerationTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Damage/SoulDamageRegenerationTest.cs
@@ -106,25 +106,25 @@ public sealed class SoulDamageRegenerationTest : InteractionTest
         await AddAtmosphere();
 
         FixedPoint2 initialSoulDamage = 3;
-        FixedPoint2 healAmount = 0;
-        var recoveryDelay = 0f;
 
         await Server.WaitAssertion(() =>
         {
             var damageable = SEntMan.System<DamageableSystem>();
+            var regenerationSystem = SEntMan.System<SoulDamageRegenerationSystem>();
             var playerDamage = Comp<DamageableComponent>(Player);
             var storedDamage = new DamageSpecifier(playerDamage.Damage);
             storedDamage.DamageDict[SoulDamageType.Id] = initialSoulDamage;
             damageable.SetDamage(SPlayer, playerDamage, storedDamage);
 
             var regeneration = SEntMan.GetComponent<SoulDamageRegenerationComponent>(SPlayer);
-            healAmount = regeneration.HealAmount;
-            recoveryDelay = (float) regeneration.RecoveryDelay.TotalSeconds;
-        });
+            // Parent-only damage is transient on complex bodies, so exercise the fallback before body aggregation
+            // rewrites it.
+            regeneration.NextHeal = STiming.CurTime;
+            regenerationSystem.Update(TickPeriod);
 
-        await RunSeconds(recoveryDelay + TickPeriod * 2);
-        await Server.WaitAssertion(() => Assert.That(
-            Comp<DamageableComponent>(Player).Damage.DamageDict[SoulDamageType.Id],
-            Is.EqualTo(initialSoulDamage - healAmount)));
+            Assert.That(
+                Comp<DamageableComponent>(Player).Damage.DamageDict[SoulDamageType.Id],
+                Is.EqualTo(initialSoulDamage - regeneration.HealAmount));
+        });
     }
 }

--- a/Content.Server/_Pirate/Damage/SoulDamageRegenerationComponent.cs
+++ b/Content.Server/_Pirate/Damage/SoulDamageRegenerationComponent.cs
@@ -20,6 +20,6 @@ public sealed partial class SoulDamageRegenerationComponent : Component
     [DataField]
     public FixedPoint2 HealAmount = 1;
 
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField, Access(Other = AccessPermissions.ReadWrite)]
     public TimeSpan NextHeal;
 }

--- a/Content.Server/_Pirate/Damage/SoulDamageRegenerationComponent.cs
+++ b/Content.Server/_Pirate/Damage/SoulDamageRegenerationComponent.cs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Goobstation.Maths.FixedPoint;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Server._Pirate.Damage;
+
+/// <summary>
+/// Naturally restores Soul damage after the victim has gone a short time without taking more.
+/// </summary>
+[RegisterComponent, AutoGenerateComponentPause, Access(typeof(SoulDamageRegenerationSystem))]
+public sealed partial class SoulDamageRegenerationComponent : Component
+{
+    [DataField]
+    public TimeSpan RecoveryDelay = TimeSpan.FromSeconds(10);
+
+    [DataField]
+    public TimeSpan HealInterval = TimeSpan.FromSeconds(1);
+
+    [DataField]
+    public FixedPoint2 HealAmount = 1;
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
+    public TimeSpan NextHeal;
+}

--- a/Content.Server/_Pirate/Damage/SoulDamageRegenerationSystem.cs
+++ b/Content.Server/_Pirate/Damage/SoulDamageRegenerationSystem.cs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Goobstation.Maths.FixedPoint;
+using Content.Shared._Shitmed.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Part;
+using Content.Shared.Body.Systems;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.Server._Pirate.Damage;
+
+public sealed class SoulDamageRegenerationSystem : EntitySystem
+{
+    private static readonly ProtoId<DamageTypePrototype> SoulDamageType = "Soul";
+    private readonly HashSet<EntityUid> _storedSoulHealing = new();
+
+    [Dependency] private readonly SharedBodySystem _body = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly IPrototypeManager _prototypes = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DamageableComponent, ComponentStartup>(OnDamageableStartup);
+        SubscribeLocalEvent<DamageableComponent, ComponentShutdown>(OnDamageableShutdown);
+        SubscribeLocalEvent<DamageableComponent, DamageChangedEvent>(OnDamageChanged);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var currentTime = _timing.CurTime;
+        var query = EntityQueryEnumerator<SoulDamageRegenerationComponent, DamageableComponent>();
+        while (query.MoveNext(out var uid, out var regeneration, out var damageable))
+        {
+            if (IsAttachedBodyPart(uid))
+            {
+                RemCompDeferred<SoulDamageRegenerationComponent>(uid);
+                continue;
+            }
+
+            if (currentTime < regeneration.NextHeal)
+                continue;
+
+            regeneration.NextHeal = currentTime + regeneration.HealInterval;
+
+            if (!damageable.Damage.DamageDict.TryGetValue(SoulDamageType.Id, out var soulDamage) ||
+                soulDamage <= FixedPoint2.Zero)
+            {
+                RemCompDeferred<SoulDamageRegenerationComponent>(uid);
+                continue;
+            }
+
+            if (regeneration.HealAmount <= FixedPoint2.Zero)
+                continue;
+
+            var amount = FixedPoint2.Min(soulDamage, regeneration.HealAmount);
+            RegenerateSoulDamage(uid, damageable, amount);
+        }
+    }
+
+    private void RegenerateSoulDamage(EntityUid uid, DamageableComponent damageable, FixedPoint2 amount)
+    {
+        if (!TryComp<BodyComponent>(uid, out var body) || body.BodyType != BodyType.Complex)
+        {
+            HealSoulDamage(uid, damageable, amount);
+            return;
+        }
+
+        var remaining = amount;
+        foreach (var part in _body.GetBodyChildren(uid))
+        {
+            if (remaining <= FixedPoint2.Zero)
+                break;
+
+            if (!TryComp<DamageableComponent>(part.Id, out var partDamageable) ||
+                !partDamageable.Damage.DamageDict.TryGetValue(SoulDamageType.Id, out var partSoulDamage) ||
+                partSoulDamage <= FixedPoint2.Zero)
+            {
+                continue;
+            }
+
+            var partAmount = FixedPoint2.Min(partSoulDamage, remaining);
+            HealSoulDamage(part.Id, partDamageable, partAmount);
+            remaining -= partAmount;
+        }
+
+        if (remaining > FixedPoint2.Zero)
+            HealStoredSoulDamage(uid, damageable, remaining);
+    }
+
+    private void HealSoulDamage(EntityUid uid, DamageableComponent damageable, FixedPoint2 amount)
+    {
+        var healing = new DamageSpecifier(_prototypes.Index(SoulDamageType), -amount);
+        _damageable.TryChangeDamage(
+            uid,
+            healing,
+            ignoreResistances: true,
+            interruptsDoAfters: false,
+            damageable: damageable,
+            canMiss: false,
+            ignoreBlockers: true);
+    }
+
+    private void HealStoredSoulDamage(EntityUid uid, DamageableComponent damageable, FixedPoint2 amount)
+    {
+        if (!damageable.Damage.DamageDict.TryGetValue(SoulDamageType.Id, out var soulDamage) ||
+            soulDamage <= FixedPoint2.Zero)
+        {
+            return;
+        }
+
+        var updatedDamage = new DamageSpecifier(damageable.Damage);
+        updatedDamage.DamageDict[SoulDamageType.Id] = soulDamage - FixedPoint2.Min(soulDamage, amount);
+
+        _storedSoulHealing.Add(uid);
+        try
+        {
+            _damageable.SetDamage(uid, damageable, updatedDamage);
+        }
+        finally
+        {
+            _storedSoulHealing.Remove(uid);
+        }
+    }
+
+    private void OnDamageChanged(Entity<DamageableComponent> entity, ref DamageChangedEvent args)
+    {
+        if (IsAttachedBodyPart(entity))
+            return;
+
+        if (!args.Damageable.Damage.DamageDict.TryGetValue(SoulDamageType.Id, out var soulDamage) ||
+            soulDamage <= FixedPoint2.Zero)
+        {
+            RemCompDeferred<SoulDamageRegenerationComponent>(entity);
+            return;
+        }
+
+        var hasNewSoulDamage = !_storedSoulHealing.Contains(entity.Owner) &&
+            (args.DamageDelta == null ||
+                args.DamageDelta.DamageDict.TryGetValue(SoulDamageType.Id, out var soulDelta) &&
+                soulDelta > FixedPoint2.Zero);
+
+        var alreadyTracked = EnsureComp<SoulDamageRegenerationComponent>(entity, out var regeneration);
+        if (alreadyTracked && !hasNewSoulDamage)
+            return;
+
+        regeneration.NextHeal = _timing.CurTime + regeneration.RecoveryDelay;
+    }
+
+    private void OnDamageableStartup(Entity<DamageableComponent> entity, ref ComponentStartup args)
+    {
+        if (IsAttachedBodyPart(entity) ||
+            !entity.Comp.Damage.DamageDict.TryGetValue(SoulDamageType.Id, out var soulDamage) ||
+            soulDamage <= FixedPoint2.Zero)
+        {
+            return;
+        }
+
+        EnsureComp<SoulDamageRegenerationComponent>(entity, out var regeneration);
+        regeneration.NextHeal = _timing.CurTime + regeneration.RecoveryDelay;
+    }
+
+    private void OnDamageableShutdown(Entity<DamageableComponent> entity, ref ComponentShutdown args)
+    {
+        if (!TerminatingOrDeleted(entity))
+            RemCompDeferred<SoulDamageRegenerationComponent>(entity);
+    }
+
+    private bool IsAttachedBodyPart(EntityUid uid)
+        => TryComp<BodyPartComponent>(uid, out var bodyPart) && bodyPart.Body != null;
+}

--- a/Resources/Prototypes/_Pirate/Skia/actions.yml
+++ b/Resources/Prototypes/_Pirate/Skia/actions.yml
@@ -20,7 +20,7 @@
     blockedBySpectral: false
     school: Translocation
   - type: Action
-    useDelay: 60
+    useDelay: 90
     icon:
       sprite: _Goobstation/Wizard/actions.rsi
       state: jaunt

--- a/Resources/Prototypes/_Pirate/Skia/entities.yml
+++ b/Resources/Prototypes/_Pirate/Skia/entities.yml
@@ -81,15 +81,15 @@
     lightThreshold: 0.7
     darkDamage:
       types:
-        Blunt: -0.69
-        Piercing: -0.69
-        Slash: -0.69
-        Heat: -0.69
-        Poison: -0.69
-        Asphyxiation: -0.36
-        Bloodloss: -0.36
-        Cellular: -0.69
-        Soul: -0.14
+        Blunt: -0.35
+        Piercing: -0.35
+        Slash: -0.35
+        Heat: -0.35
+        Poison: -0.35
+        Asphyxiation: -0.17
+        Bloodloss: -0.17
+        Cellular: -0.35
+        Soul: -0.06
     lightDamage:
       types:
         Blunt: 1.5


### PR DESCRIPTION
Додатково послаблює Скію: зменшує регенерацію в темряві, збільшує перезарядку Ефірного ривка до 90 секунд і додає природне відновлення Soul-шкоди для живих та мертвих тіл.

:cl:
- tweak: Послаблено регенерацію Скії та збільшено перезарядку Ефірного ривка.
- fix: Душевна шкода Скії тепер поступово відновлюється навіть у трупів.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Нові можливості**
  - Додано автоматичну регенерацію духовної шкоди після періоду без нових ушкоджень.
  - Регенерація коректно працює для живих і мертвих тіл, зокрема складних тіл із частинами.

- **Зміни балансу**
  - Зменшено шкоду від перебування в темряві для Skia.
  - Збільшено час відновлення здатності Skia Jaunt із 60 до 90 секунд.

- **Тести**
  - Додано інтеграційні перевірки роботи регенерації духовної шкоди.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->