### PR TITLE
Fix GoldSlimeExtract mob spawning

### DIFF
--- a/Content.Shared/EntityEffects/Effects/EntitySpawning/SpawnEntityEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/EntitySpawning/SpawnEntityEntityEffectSystem.cs
@@ -43,7 +43,7 @@ public sealed partial class SpawnEntityEntityEffectSystem : EntityEffectSystem<T
 public sealed partial class SpawnEntity : BaseSpawnEntityEntityEffect<SpawnEntity>
 {
     /// <summary>
-    /// Pirate: initialize the spawned entity at the target's map/grid position.
+    /// Pirate: initialize the spawned entity at the target's map/grid position before MapInit.
     /// </summary>
     [DataField]
     public bool SpawnAtPosition;

--- a/Content.Shared/EntityEffects/Effects/EntitySpawning/SpawnEntityEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/EntitySpawning/SpawnEntityEntityEffectSystem.cs
@@ -20,18 +20,31 @@ public sealed partial class SpawnEntityEntityEffectSystem : EntityEffectSystem<T
         {
             for (var i = 0; i < quantity; i++)
             {
-                PredictedSpawnNextToOrDrop(proto, entity, entity.Comp);
+                if (args.Effect.SpawnAtPosition)
+                    PredictedSpawnAtPosition(proto, entity.Comp.Coordinates);
+                else
+                    PredictedSpawnNextToOrDrop(proto, entity, entity.Comp);
             }
         }
         else if (_net.IsServer)
         {
             for (var i = 0; i < quantity; i++)
             {
-                SpawnNextToOrDrop(proto, entity, entity.Comp);
+                if (args.Effect.SpawnAtPosition)
+                    SpawnAtPosition(proto, entity.Comp.Coordinates);
+                else
+                    SpawnNextToOrDrop(proto, entity, entity.Comp);
             }
         }
     }
 }
 
 /// <inheritdoc cref="BaseSpawnEntityEntityEffect{T}"/>
-public sealed partial class SpawnEntity : BaseSpawnEntityEntityEffect<SpawnEntity>;
+public sealed partial class SpawnEntity : BaseSpawnEntityEntityEffect<SpawnEntity>
+{
+    /// <summary>
+    /// Pirate: initialize the spawned entity at the target's map/grid position.
+    /// </summary>
+    [DataField]
+    public bool SpawnAtPosition;
+}

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/gold.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/gold.yml
@@ -27,7 +27,10 @@
       - !type:SpawnEntity
         entity: RPassiveMobSpawner
         number: 5
+        predicted: false
         shouldScale: false
+        # Pirate: initialize random spawners at the extract's map position.
+        spawnAtPosition: true
     - reagents: [ Plasma ]
       methods: [ Touch, Injection ]
       effects:
@@ -43,7 +46,9 @@
       - !type:SpawnEntity
         entity: RHostileMobSpawner
         number: 5
+        predicted: false
         shouldScale: false
+        spawnAtPosition: true
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:
@@ -59,7 +64,9 @@
       - !type:SpawnEntity
         entity: RNeutralMobSpawner
         number: 5
+        predicted: false
         shouldScale: false
+        spawnAtPosition: true
   - type: Tag
     tags:
     - XenobiologyGoldExtract


### PR DESCRIPTION
Виправлено спавн мобів із GoldSlimeExtract: випадковий спавнер тепер ініціалізується на позиції екстракту, а випадкові спавни виконуються сервером.

:cl:
- fix: Виправлено появу мобів із золотого слаймового екстракту.