### PR TITLE
Fix SecLink issuance and fun baton balance

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -143,6 +143,7 @@
     back:
     - Flash
     - ClothingMaskBreathMedicalSecurity
+    - BaseSeclinkRadio # Pirate: SecLink for security staff
 
 # Aghost
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -61,6 +61,7 @@
   storage:
     back:
     - Flash
+    - BaseSeclinkRadio # Pirate: SecLink for security staff
     - ForensicPad
     - ForensicScanner
     - ClothingMaskGasSecurity # Goobstation

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -90,6 +90,7 @@
   storage:
     back:
     - Flash
+    - BaseSeclinkRadio # Pirate: SecLink for security staff
 #    - MagazinePistol # PIRATE, moved to loadouts
 
 - type: chameleonOutfit

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -76,6 +76,7 @@
   storage:
     back:
     - Flash
+    - BaseSeclinkRadio # Pirate: SecLink for security staff
 #    - MagazinePistol # PIRATE, moved to loadouts
 
 - type: chameleonOutfit

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Wildcards/security_clown.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Wildcards/security_clown.yml
@@ -55,6 +55,7 @@
     back:
     - Flash
     - ClownRecorder
+    - BaseSeclinkRadio # Pirate: SecLink for security staff
 
 - type: chameleonOutfit
   id: SecurityClownChameleonOutfit

--- a/Resources/Prototypes/_Pirate/Roles/Jobs/Security/instructor.yml
+++ b/Resources/Prototypes/_Pirate/Roles/Jobs/Security/instructor.yml
@@ -56,6 +56,7 @@
     back:
     - MagazineUniversalMagnum
     - SecurityInstructorWhistle
+    - BaseSeclinkRadio
 
 - type: chameleonOutfit
   id: SecurityInstructorChameleonOutfit

--- a/Resources/Prototypes/_Pirate/Security/SecLink/batons.yml
+++ b/Resources/Prototypes/_Pirate/Security/SecLink/batons.yml
@@ -23,7 +23,6 @@
     - state: stunbaton_off
       map: [ "enum.ToggleableVisuals.Layer" ]
   - type: StaminaDamageOnHit
-    damage: 35
     sound: /Audio/_Pirate/Items/Security/SecLink/funbaton.ogg
   - type: Clothing
     sprite: _Pirate/Objects/Weapons/Melee/funbaton.rsi


### PR DESCRIPTION
SecLink тепер видається ГСБ, наглядачам, детективам, інструкторам, клоунам СБ та бригмедикам; кадети лишаються без нього. Веселий кийок успадковує характеристики стандартного й відрізняється лише звуком та виглядом.

:cl:
- tweak: Розширено стартову видачу SecLink серед співробітників СБ, крім кадетів.
- fix: Веселий кийок SecLink тепер має характеристики звичайного електрокийка.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Радіо додано до стартового спорядження бригмедика, детектива, начальника служби безпеки, наглядача, клоуна служби безпеки та інструктора.

* **Виправлення**
  * Для Funbaton прибрано додаткове пошкодження витривалості під час удару.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->