### PR TITLE
Фікс застарілого SSD-стану активного гравця

### DIFF
--- a/Content.IntegrationTests/Tests/_Pirate/SSDIndicator/SSDIndicatorTests.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/SSDIndicator/SSDIndicatorTests.cs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Linq;
+using Content.Shared.SSDIndicator;
+using Content.Shared.StatusEffectNew;
+using Robust.Shared.Player;
+
+namespace Content.IntegrationTests.Tests._Pirate.SSDIndicator;
+
+[TestFixture]
+[TestOf(typeof(SSDIndicatorSystem))]
+public sealed class SSDIndicatorTests
+{
+    [Test]
+    public async Task ActivePlayerRecoversFromStaleSSDState()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = true,
+            DummyTicker = false,
+            Dirty = true,
+        });
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var statusEffects = server.System<StatusEffectsSystem>();
+        var player = server.PlayerMan.Sessions.Single().AttachedEntity!.Value;
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(entMan.HasComponent<ActorComponent>(player), Is.True);
+
+            var ssd = entMan.GetComponent<SSDIndicatorComponent>(player);
+            ssd.IsSSD = true;
+
+            Assert.That(statusEffects.TryUpdateStatusEffectDuration(
+                player,
+                SSDIndicatorSystem.StatusEffectSSDSleeping), Is.True);
+            Assert.That(statusEffects.HasStatusEffect(
+                player,
+                SSDIndicatorSystem.StatusEffectSSDSleeping), Is.True);
+        });
+
+        await pair.RunTicksSync(2);
+
+        await server.WaitAssertion(() =>
+        {
+            var ssd = entMan.GetComponent<SSDIndicatorComponent>(player);
+
+            Assert.That(entMan.HasComponent<ActorComponent>(player), Is.True);
+            Assert.That(ssd.IsSSD, Is.False);
+            Assert.That(ssd.FallAsleepTime, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(statusEffects.HasStatusEffect(
+                player,
+                SSDIndicatorSystem.StatusEffectSSDSleeping), Is.False);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -44,16 +44,19 @@ public sealed class SSDIndicatorSystem : EntitySystem
 
     private void OnPlayerAttached(EntityUid uid, SSDIndicatorComponent component, PlayerAttachedEvent args)
     {
+        ClearSSDState(uid, component);
+    }
+
+    private void ClearSSDState(EntityUid uid, SSDIndicatorComponent component)
+    {
+        var stateChanged = component.IsSSD || component.FallAsleepTime != TimeSpan.Zero;
+
         component.IsSSD = false;
+        component.FallAsleepTime = TimeSpan.Zero;
+        _statusEffects.TryRemoveStatusEffect(uid, StatusEffectSSDSleeping);
 
-        // Removes force sleep and resets the time to zero
-        if (_icSsdSleep)
-        {
-            component.FallAsleepTime = TimeSpan.Zero;
-            _statusEffects.TryRemoveStatusEffect(uid, StatusEffectSSDSleeping);
-        }
-
-        Dirty(uid, component);
+        if (stateChanged)
+            Dirty(uid, component);
     }
 
     private void OnPlayerDetached(EntityUid uid, SSDIndicatorComponent component, PlayerDetachedEvent args)
@@ -92,7 +95,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
     {
         base.Update(frameTime);
 
-        if (!_net.IsServer || !_icSsdSleep)
+        if (!_net.IsServer)
             return;
 
         var curTime = _timing.CurTime;
@@ -100,6 +103,16 @@ public sealed class SSDIndicatorSystem : EntitySystem
 
         while (query.MoveNext(out var uid, out var ssd))
         {
+            // Pirate: ActorComponent is authoritative when an attach event leaves stale SSD state behind.
+            if (HasComp<ActorComponent>(uid))
+            {
+                ClearSSDState(uid, ssd);
+                continue;
+            }
+
+            if (!_icSsdSleep)
+                continue;
+
             // _Pirate: Don't force NPCs to sleep via SSD
             if (HasComp<NOSSDSleepComponent>(uid))
                 continue;


### PR DESCRIPTION
Активний ActorComponent тепер самовідновлює застарілий SSD-стан і прибирає SSD-сон після перепідключення.

:cl:
- fix: Активні гравці більше не засинають через застарілий SSD-стан після перепідключення.