### PR TITLE
Показувати авторів голосів адміністраторам

### DIFF
--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -417,6 +417,7 @@ namespace Content.Server.Voting.Managers
 
             v.Finished = true;
             v.Dirty = true;
+            SendAdminVoteResults(v); // Pirate - show admins who voted for each option.
             var args = new VoteFinishedEventArgs(winners.Length == 1 ? winners[0] : null, winners, voteTally);
             v.OnFinished?.Invoke(_voteHandles[v.Id], args);
             DirtyCanCallVoteAll();

--- a/Content.Server/_Pirate/Voting/Managers/VoteManager.Pirate.cs
+++ b/Content.Server/_Pirate/Voting/Managers/VoteManager.Pirate.cs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Linq;
+
+namespace Content.Server.Voting.Managers;
+
+public sealed partial class VoteManager
+{
+    private void SendAdminVoteResults(VoteReg vote)
+    {
+        var optionResults = vote.Entries.Select((entry, optionId) =>
+        {
+            var voters = vote.CastVotes
+                .Where(castVote => castVote.Value == optionId)
+                .Select(castVote => castVote.Key.Name)
+                .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            var voterNames = voters.Length == 0
+                ? Loc.GetString("vote-manager-admin-results-no-voters")
+                : string.Join(", ", voters);
+
+            return Loc.GetString("vote-manager-admin-results-option",
+                ("option", entry.Text),
+                ("voters", voterNames));
+        });
+
+        var title = Loc.GetString("vote-manager-admin-results-title", ("title", vote.Title));
+        _chatManager.SendAdminAlert($"{title}\n{string.Join("\n", optionResults)}");
+    }
+}

--- a/Resources/Locale/uk-UA/_Pirate/voting/vote-manager.ftl
+++ b/Resources/Locale/uk-UA/_Pirate/voting/vote-manager.ftl
@@ -1,0 +1,3 @@
+vote-manager-admin-results-title = Голосування «{$title}» завершено. Розподіл голосів:
+vote-manager-admin-results-option = {$option}: {$voters}
+vote-manager-admin-results-no-voters = ніхто


### PR DESCRIPTION
Додає червоний звіт у чат адміністраторів після завершення голосування з ніками виборців для кожного варіанта.

:cl:
- add: У чаті адміністраторів тепер показується розподіл гравців за варіантами завершеного голосування.