### PR TITLE
Allow security borg lethal mode on emergency alert levels

### DIFF
--- a/Resources/Prototypes/_Pirate/Security/security_borg.yml
+++ b/Resources/Prototypes/_Pirate/Security/security_borg.yml
@@ -59,7 +59,12 @@
     safeMode: 0
     lethalMode: 1
     allowedAlertLevels:
+    - amber
     - red
+    - gamma
+    - delta
+    - violet
+    - omicron
   - type: Unremoveable
   - type: GunExecutionBlacklist
 


### PR DESCRIPTION
## Зміни
- Дозволено летальний режим охоронного кіборга на кодах `amber`, `red`, `gamma`, `delta`, `violet` та `omicron`.
- `epsilon` навмисно не додано.

Логіка скидання летального режиму при переході на недозволений код залишається без змін.
:cl:
- add: Додав коди тривог до леталу кіборга

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Зміни**
  * Розширено перелік рівнів тривоги, за яких `WeaponPDW9TaserBorg` може використовувати летальний режим.
  * Додано рівні: amber, gamma, delta, violet та omicron; рівень red залишено без змін.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->