### PR TITLE
Відкрити всі скіни охоронного кіборга

### DIFF
--- a/Content.Client/Silicons/Borgs/BorgSwitchableTypeSystem.cs
+++ b/Content.Client/Silicons/Borgs/BorgSwitchableTypeSystem.cs
@@ -96,7 +96,7 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
             TryComp(entity, out SpriteMovementComponent? movement) &&
             movement.MovementLayers.TryGetValue("movement", out var movementLayer))
         {
-            movementLayer.State = prototype.SpriteBodyState;
+            movementLayer.State = bodyState;
         }
     }
 }

--- a/Content.Client/Silicons/Borgs/BorgSwitchableTypeSystem.cs
+++ b/Content.Client/Silicons/Borgs/BorgSwitchableTypeSystem.cs
@@ -46,13 +46,18 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
         BorgTypePrototype prototype,
         BorgSubtypePrototype subtypePrototype)
     {
+        // Pirate: allow subtype RSIs to use skin-specific state names.
+        var bodyState = subtypePrototype.SpriteBodyState ?? prototype.SpriteBodyState;
+        var hasMindState = subtypePrototype.SpriteHasMindState ?? prototype.SpriteHasMindState;
+        var noMindState = subtypePrototype.SpriteNoMindState ?? prototype.SpriteNoMindState;
+        var toggleLightState = subtypePrototype.SpriteToggleLightState ?? prototype.SpriteToggleLightState;
         var hasMovementState = prototype.SpriteBodyMovementState is null;
 
         if (TryComp(entity, out SpriteComponent? sprite))
         {
-            _sprite.LayerSetRsiState((entity, sprite), BorgVisualLayers.Body, prototype.SpriteBodyState);
-            _sprite.LayerSetRsiState((entity, sprite), BorgVisualLayers.Light, prototype.SpriteBodyState);
-            _sprite.LayerSetRsiState((entity, sprite), BorgVisualLayers.LightStatus, prototype.SpriteBodyState);
+            _sprite.LayerSetRsiState((entity, sprite), BorgVisualLayers.Body, bodyState);
+            _sprite.LayerSetRsiState((entity, sprite), BorgVisualLayers.Light, bodyState);
+            _sprite.LayerSetRsiState((entity, sprite), BorgVisualLayers.LightStatus, bodyState);
 
             var rsiPath = SpriteSpecifierSerializer.TextureRoot / subtypePrototype.SpritePath;
             if (_resourceCache.TryGetResource<RSIResource>(rsiPath, out var resource))
@@ -64,8 +69,8 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
                 if (prototype.SpriteBodyMovementState is { } movementState)
                     hasMovementState = resource.RSI.TryGetState(movementState, out _);
             }
-            _sprite.LayerSetRsiState((entity, sprite), BorgVisualLayers.Body, prototype.SpriteBodyState);
-            _sprite.LayerSetRsiState((entity, sprite), BorgVisualLayers.LightStatus, prototype.SpriteToggleLightState);
+            _sprite.LayerSetRsiState((entity, sprite), BorgVisualLayers.Body, bodyState);
+            _sprite.LayerSetRsiState((entity, sprite), BorgVisualLayers.LightStatus, toggleLightState);
             _sprite.SetScale((entity, sprite), prototype.SpriteScale); // Pirate: source quadborg art uses a custom sprite scale.
             sprite.NoRotation = prototype.SpriteNoRotation; // Pirate: source quadborg art uses directional states.
         }
@@ -74,8 +79,8 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
         {
             _borgSystem.SetMindStates(
                 (entity.Owner, chassis),
-                prototype.SpriteHasMindState,
-                prototype.SpriteNoMindState);
+                hasMindState,
+                noMindState);
 
             if (TryComp(entity, out AppearanceComponent? appearance))
             {

--- a/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
@@ -55,7 +55,10 @@ public sealed partial class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeS
         {
             _borgSystem.SetTransponderSprite(
                 (ent.Owner, transponder),
-                new SpriteSpecifier.Rsi(subtypePrototype.SpritePath, prototype.SpriteBodyState)); // goob - Use the subtype `SpritePath` instead of a hardcoded rsi
+                // Pirate: use the subtype-specific body state for the transponder.
+                new SpriteSpecifier.Rsi(
+                    subtypePrototype.SpritePath,
+                    subtypePrototype.SpriteBodyState ?? prototype.SpriteBodyState)); // goob - Use the subtype `SpritePath` instead of a hardcoded rsi
 
             _borgSystem.SetTransponderName(
                 (ent.Owner, transponder),

--- a/Content.Shared/Silicons/Borgs/BorgSubtypePrototype.cs
+++ b/Content.Shared/Silicons/Borgs/BorgSubtypePrototype.cs
@@ -31,4 +31,20 @@ public sealed partial class BorgSubtypePrototype : IPrototype
     /// </summary>
     [DataField]
     public required ProtoId<BorgTypePrototype> ParentBorgType = "generic";
+
+    // Pirate: some downstream subtype RSIs use skin-specific state names.
+    /// <summary>
+    /// Optional sprite states for subtype RSIs whose state names differ from the parent borg type.
+    /// </summary>
+    [DataField]
+    public string? SpriteBodyState { get; set; }
+
+    [DataField]
+    public string? SpriteHasMindState { get; set; }
+
+    [DataField]
+    public string? SpriteNoMindState { get; set; }
+
+    [DataField]
+    public string? SpriteToggleLightState { get; set; }
 }

--- a/Resources/Prototypes/_Pirate/Security/security_borg.yml
+++ b/Resources/Prototypes/_Pirate/Security/security_borg.yml
@@ -300,6 +300,122 @@
   spritePath: _Pirate/Mobs/Silicon/Chassis/security.rsi
   dummyPrototype: BorgChassisSecurity
 
+# Pirate: security skins use the same RSI with skin-specific state names.
+- type: borgSubtype
+  id: security_borg
+  parentBorgType: security
+  spritePath: _Pirate/Mobs/Silicon/Chassis/security.rsi
+  spriteBodyState: borg
+  spriteHasMindState: borg_e
+  spriteNoMindState: borg_e_r
+  spriteToggleLightState: borg_l
+  dummyPrototype: BorgChassisSecurityBorg
+
+- type: borgSubtype
+  id: security_red_knight
+  parentBorgType: security
+  spritePath: _Pirate/Mobs/Silicon/Chassis/security.rsi
+  spriteBodyState: red-knight
+  spriteHasMindState: red-knight_e
+  spriteNoMindState: red-knight_e_r
+  spriteToggleLightState: red-knight_l
+  dummyPrototype: BorgChassisSecurityRedKnight
+
+- type: borgSubtype
+  id: security_black_knight
+  parentBorgType: security
+  spritePath: _Pirate/Mobs/Silicon/Chassis/security.rsi
+  spriteBodyState: black-knight
+  spriteHasMindState: black-knight_e
+  spriteNoMindState: black-knight_e_r
+  spriteToggleLightState: black-knight_l
+  dummyPrototype: BorgChassisSecurityBlackKnight
+
+- type: borgSubtype
+  id: security_noble
+  parentBorgType: security
+  spritePath: _Pirate/Mobs/Silicon/Chassis/security.rsi
+  spriteBodyState: noble
+  spriteHasMindState: noble_e
+  spriteNoMindState: noble_e_r
+  spriteToggleLightState: noble_l
+  dummyPrototype: BorgChassisSecurityNoble
+
+- type: borgSubtype
+  id: security_cricket
+  parentBorgType: security
+  spritePath: _Pirate/Mobs/Silicon/Chassis/security.rsi
+  spriteBodyState: cricket
+  spriteHasMindState: cricket_e
+  spriteNoMindState: cricket_e_r
+  spriteToggleLightState: cricket_l
+  dummyPrototype: BorgChassisSecurityCricket
+
+- type: borgSubtype
+  id: security_heavy
+  parentBorgType: security
+  spritePath: _Pirate/Mobs/Silicon/Chassis/security.rsi
+  spriteBodyState: heavy
+  spriteHasMindState: heavy_e
+  spriteNoMindState: heavy_e_r
+  spriteToggleLightState: heavy_l
+  dummyPrototype: BorgChassisSecurityHeavy
+
+# Pirate: hidden preview entities for the selectable security borg skins.
+- type: entity
+  id: BorgChassisSecurityBorg
+  parent: BorgChassisSecurity
+  name: security cyborg
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: BorgSwitchableSubtype
+    borgSubtype: security_borg
+
+- type: entity
+  id: BorgChassisSecurityRedKnight
+  parent: BorgChassisSecurity
+  name: security cyborg
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: BorgSwitchableSubtype
+    borgSubtype: security_red_knight
+
+- type: entity
+  id: BorgChassisSecurityBlackKnight
+  parent: BorgChassisSecurity
+  name: security cyborg
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: BorgSwitchableSubtype
+    borgSubtype: security_black_knight
+
+- type: entity
+  id: BorgChassisSecurityNoble
+  parent: BorgChassisSecurity
+  name: security cyborg
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: BorgSwitchableSubtype
+    borgSubtype: security_noble
+
+- type: entity
+  id: BorgChassisSecurityCricket
+  parent: BorgChassisSecurity
+  name: security cyborg
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: BorgSwitchableSubtype
+    borgSubtype: security_cricket
+
+- type: entity
+  id: BorgChassisSecurityHeavy
+  parent: BorgChassisSecurity
+  name: security cyborg
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: BorgSwitchableSubtype
+    borgSubtype: security_heavy
+
 - type: siliconLaw
   id: SecurityCyborg1
   order: 1


### PR DESCRIPTION
Додано вибір усіх доступних скінів охоронного кіборга.

:cl:
- fix: Відкрито всі доступні скіни охоронного кіборга у виборі борга.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Додано шість доступних варіантів зовнішності охоронних кіборгів: стандартний, червоний лицар, чорний лицар, дворянин, цвіркун і важкий.
  * Для кожного варіанта доступне окреме приховане шасі-прев’ю.

* **Покращення**
  * Візуальні стани кіборга тепер можуть налаштовуватися окремо для кожного підтипу.
  * Підтримуються індивідуальні стани тіла, індикатора підсвічування та відображення наявності свідомості з автоматичним використанням стандартних значень, якщо налаштування не задані.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->