### PR TITLE
Показувати «Ентропія» для фейкового гріншифту

### DIFF
--- a/Resources/Prototypes/_Pirate/game_presets.yml
+++ b/Resources/Prototypes/_Pirate/game_presets.yml
@@ -30,8 +30,19 @@
   id: SecretCosmicCultGreenshift
   alias:
     - secretcosmiccultgreenshift
-    - secretentropygreenshift
+  name: secret-title
+  description: secret-description
+  showInVote: false
+  rules:
+    - SpaceTrafficControlFriendlyEventScheduler
+    - BasicRoundstartVariation
+    - PsionicEventsScheduler # Pirate
+
+- type: gamePreset
+  id: EntropyGreenshift
+  alias:
     - entropygreenshift
+    - secretentropygreenshift
   name: secretplus-mid-title
   description: secretplus-mid-description
   showInVote: false

--- a/Resources/Prototypes/_Pirate/game_presets.yml
+++ b/Resources/Prototypes/_Pirate/game_presets.yml
@@ -32,8 +32,8 @@
     - secretcosmiccultgreenshift
     - secretentropygreenshift
     - entropygreenshift
-  name: monument-interface-entropy-title
-  description: secret-description
+  name: secretplus-mid-title
+  description: secretplus-mid-description
   showInVote: false
   rules:
     - SpaceTrafficControlFriendlyEventScheduler

--- a/Resources/Prototypes/_Pirate/game_presets.yml
+++ b/Resources/Prototypes/_Pirate/game_presets.yml
@@ -32,7 +32,7 @@
     - secretcosmiccultgreenshift
     - secretentropygreenshift
     - entropygreenshift
-  name: secret-title
+  name: monument-interface-entropy-title
   description: secret-description
   showInVote: false
   rules:


### PR DESCRIPTION
Додає окремий пресет `EntropyGreenshift`: він запускає Greenshift, але показує в лобі назву й опис режиму «Ентропія».

:cl:
- add: окремий фейковий Greenshift-пресет «Ентропія»