### PR TITLE
Збільшити частоту синдикатських дропів

### DIFF
--- a/Resources/Prototypes/_Moffstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/events.yml
@@ -10,8 +10,8 @@
     earliestStart: 20
     duration: 1
     minimumPlayers: 10
-    maxOccurrences: 3
-    weight: 10
+    maxOccurrences: 6 # Pirate - was 3
+    weight: 20 # Pirate - increase dead drop frequency
   - type: GameRule
     chaosScore: 40
   - type: RandomSpawnRule


### PR DESCRIPTION
Збільшено вагу синдикатських дропів удвічі та максимальну кількість появ за раунд з 3 до 6.

:cl:
- tweak: Синдикатські дропи тепер трапляються частіше й можуть з'явитися до шести разів за раунд.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Збільшено максимальну кількість появ події «SyndicateDeadDrop» з 3 до 6.
  * Підвищено ймовірність появи цієї події вдвічі.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->