### PR TITLE
shields

### DIFF
--- a/Content.Client/_Mono/PersonalShield/PersonalShieldOverlay.cs
+++ b/Content.Client/_Mono/PersonalShield/PersonalShieldOverlay.cs
@@ -75,7 +75,7 @@ public sealed partial class PersonalShieldOverlay : Overlay
 
             var size = extents * shield.Scale;
             var worldPos = _transform.GetWorldPosition(xform);
-            if (!args.WorldBounds.Intersects(Box2.CenteredAround(worldPos, size)))
+            if (!args.WorldBounds.CalcBoundingBox().Intersects(Box2.CenteredAround(worldPos, size)))
                 continue;
 
             var shader = GetShaderInstance(uid);

--- a/Content.Client/_Mono/PersonalShield/PersonalShieldOverlay.cs
+++ b/Content.Client/_Mono/PersonalShield/PersonalShieldOverlay.cs
@@ -74,6 +74,10 @@ public sealed partial class PersonalShieldOverlay : Overlay
                 continue;
 
             var size = extents * shield.Scale;
+            var worldPos = _transform.GetWorldPosition(xform);
+            if (!args.WorldBounds.Intersects(Box2.CenteredAround(worldPos, size)))
+                continue;
+
             var shader = GetShaderInstance(uid);
 
             shader.SetParameter("progress", GetProgress(shield));
@@ -92,7 +96,6 @@ public sealed partial class PersonalShieldOverlay : Overlay
 
             handle.UseShader(shader);
 
-            var worldPos = _transform.GetWorldPosition(xform);
             handle.SetTransform(Matrix3x2.Multiply(counterRot, Matrix3Helpers.CreateTranslation(worldPos)));
             handle.DrawTextureRect(Texture.White, Box2.CenteredAround(Vector2.Zero, size));
         }
@@ -140,6 +143,7 @@ public sealed partial class PersonalShieldOverlay : Overlay
             shader.Dispose();
 
         _shaderInstances.Clear();
+        _baseShader.Dispose();
     }
 
     private bool TryGetHitboxSize(EntityUid uid, SpriteComponent sprite, out Vector2 extents)

--- a/Content.Client/_Mono/PersonalShield/PersonalShieldOverlay.cs
+++ b/Content.Client/_Mono/PersonalShield/PersonalShieldOverlay.cs
@@ -1,0 +1,181 @@
+using System.Collections.Generic;
+using System.Numerics;
+using Content.Shared._Mono.PersonalShield;
+using Content.Shared.Inventory;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client._Mono.PersonalShield;
+
+public sealed partial class PersonalShieldOverlay : Overlay
+{
+    [Dependency] private IEntityManager _entManager = null!;
+
+    private static readonly ProtoId<ShaderPrototype> ShaderId = "PersonalShieldSkin";
+
+    private readonly SharedTransformSystem _transform;
+    private readonly SpriteSystem _sprite;
+    private readonly InventorySystem _inventory;
+    private readonly ShaderInstance _baseShader;
+
+    // One shader instance per shield entity: uniforms are read from the live instance when the
+    // batch is flushed, so sharing a single instance would render every shield with the last
+    // entity's parameters (e.g. one shield's color bleeding into another).
+    private readonly Dictionary<EntityUid, ShaderInstance> _shaderInstances = new();
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+
+    public PersonalShieldOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+        _transform = _entManager.System<SharedTransformSystem>();
+        _sprite = _entManager.System<SpriteSystem>();
+        _inventory = _entManager.System<InventorySystem>();
+        var protoMan = IoCManager.Resolve<IPrototypeManager>();
+        _baseShader = protoMan.Index(ShaderId).InstanceUnique();
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        if (args.MapId == MapId.Nullspace)
+            return;
+
+        var handle = args.WorldHandle;
+
+        // Cancel the eye rotation so the shield is always "upright".
+        var eyeRot = args.Viewport.Eye?.Rotation ?? Angle.Zero;
+        var counterRot = Matrix3Helpers.CreateRotation(-eyeRot);
+
+        CleanupShaderInstances();
+
+        var query = _entManager.EntityQueryEnumerator<PersonalShieldComponent>();
+        while (query.MoveNext(out var uid, out var shield))
+        {
+            if (shield.Runtime.Form <= 0f && shield.Runtime.Shatter <= 0f)
+                continue;
+
+            if (!_inventory.TryGetContainingEntity(uid, out var wearer))
+                continue;
+
+            if (!_entManager.TryGetComponent(wearer, out SpriteComponent? sprite) || !sprite.Visible)
+                continue;
+
+            if (!_entManager.TryGetComponent(wearer, out TransformComponent? xform) || xform.MapID != args.MapId)
+                continue;
+
+            if (!TryGetHitboxSize(wearer.Value, sprite, out var extents))
+                continue;
+
+            var size = extents * shield.Scale;
+            var shader = GetShaderInstance(uid);
+
+            shader.SetParameter("progress", GetProgress(shield));
+            shader.SetParameter("skin_color", shield.Color);
+            shader.SetParameter("brightness", shield.Brightness);
+            shader.SetParameter("pixel_grid", shield.PixelGrid);
+            shader.SetParameter("hex_density", shield.HexDensity);
+            shader.SetParameter("form_origin", shield.FormOrigin);
+            shader.SetParameter("fill_level", shield.FillLevel);
+            shader.SetParameter("line_level", shield.LineLevel);
+            shader.SetParameter("rim_level", shield.RimLevel);
+            shader.SetParameter("core_fade", shield.CoreFade);
+            shader.SetParameter("shard_scale", shield.ShardScale);
+            shader.SetParameter("alpha_bands", shield.AlphaBands);
+            shader.SetParameter("breath_depth", shield.BreathDepth);
+
+            handle.UseShader(shader);
+
+            var worldPos = _transform.GetWorldPosition(xform);
+            handle.SetTransform(Matrix3x2.Multiply(counterRot, Matrix3Helpers.CreateTranslation(worldPos)));
+            handle.DrawTextureRect(Texture.White, Box2.CenteredAround(Vector2.Zero, size));
+        }
+
+        handle.SetTransform(Matrix3x2.Identity);
+        handle.UseShader(null);
+    }
+
+    private ShaderInstance GetShaderInstance(EntityUid uid)
+    {
+        if (!_shaderInstances.TryGetValue(uid, out var shader))
+        {
+            shader = _baseShader.Duplicate();
+            _shaderInstances[uid] = shader;
+        }
+
+        return shader;
+    }
+
+    private void CleanupShaderInstances()
+    {
+        if (_shaderInstances.Count == 0)
+            return;
+
+        List<EntityUid>? dead = null;
+        foreach (var (uid, _) in _shaderInstances)
+        {
+            if (_entManager.Deleted(uid) || !_entManager.HasComponent<PersonalShieldComponent>(uid))
+                (dead ??= new List<EntityUid>()).Add(uid);
+        }
+
+        if (dead == null)
+            return;
+
+        foreach (var uid in dead)
+        {
+            if (_shaderInstances.Remove(uid, out var shader))
+                shader.Dispose();
+        }
+    }
+
+    protected override void DisposeBehavior()
+    {
+        foreach (var shader in _shaderInstances.Values)
+            shader.Dispose();
+
+        _shaderInstances.Clear();
+    }
+
+    private bool TryGetHitboxSize(EntityUid uid, SpriteComponent sprite, out Vector2 extents)
+    {
+        extents = Vector2.Zero;
+
+        if (_entManager.TryGetComponent(uid, out FixturesComponent? fixtures) && fixtures.FixtureCount > 0)
+        {
+            var identity = new Transform(Vector2.Zero, 0f);
+            Box2? union = null;
+
+            foreach (var fixture in fixtures.Fixtures.Values)
+            {
+                if (!fixture.Hard)
+                    continue;
+
+                var aabb = fixture.Shape.ComputeAABB(identity, 0);
+                union = union?.Union(aabb) ?? aabb;
+            }
+
+            if (union is { } box && box.Width > 0f && box.Height > 0f)
+            {
+                extents = box.Size;
+                return true;
+            }
+        }
+
+        var bounds = _sprite.GetLocalBounds((uid, sprite));
+        extents = bounds.Size;
+        return extents is { X: > 0f, Y: > 0f };
+    }
+
+    private static float GetProgress(PersonalShieldComponent shield)
+    {
+        return shield.Runtime.Shatter > 0f
+            ? 1f + MathF.Min(shield.Runtime.Shatter, 1f)
+            : shield.Runtime.Form;
+    }
+}

--- a/Content.Client/_Mono/PersonalShield/PersonalShieldSystem.cs
+++ b/Content.Client/_Mono/PersonalShield/PersonalShieldSystem.cs
@@ -1,0 +1,20 @@
+using Robust.Client.Graphics;
+
+namespace Content.Client._Mono.PersonalShield;
+
+public sealed partial class PersonalShieldSystem : EntitySystem
+{
+    [Dependency] private IOverlayManager _overlayMan = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _overlayMan.AddOverlay(new PersonalShieldOverlay());
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        _overlayMan.RemoveOverlay<PersonalShieldOverlay>();
+    }
+}

--- a/Content.Shared/Item/ItemToggle/Components/ItemToggleComponent.cs
+++ b/Content.Shared/Item/ItemToggle/Components/ItemToggleComponent.cs
@@ -42,6 +42,19 @@ public sealed partial class ItemToggleComponent : Component
     public bool WieldToggle = true;
 
     /// <summary>
+    /// Frontier: allow alt-verbs.
+    /// If this is set to true, the item can be toggled via its alternative verb (alt-click).
+    /// </summary>
+    [DataField]
+    public bool OnAltUse = false;
+
+    /// <summary>
+    /// Frontier: the priority of the alternative verb if enabled.
+    /// </summary>
+    [DataField]
+    public int AltPriority;
+
+    /// <summary>
     ///     The localized text to display in the verb to activate.
     /// </summary>
     [DataField]

--- a/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
@@ -40,6 +40,7 @@ public sealed class ItemToggleSystem : EntitySystem
         SubscribeLocalEvent<ItemToggleComponent, ItemWieldedEvent>(TurnOnOnWielded);
         SubscribeLocalEvent<ItemToggleComponent, UseInHandEvent>(OnUseInHand, before: [typeof(ClothingSystem)]); // Goobstation - order changes, batons used before equipped
         SubscribeLocalEvent<ItemToggleComponent, GetVerbsEvent<ActivationVerb>>(OnActivateVerb);
+        SubscribeLocalEvent<ItemToggleComponent, GetVerbsEvent<AlternativeVerb>>(OnAlternateVerb); // Frontier: alt-verb toggle
         SubscribeLocalEvent<ItemToggleComponent, ActivateInWorldEvent>(OnActivate);
 
         SubscribeLocalEvent<ItemToggleHotComponent, IsHotEvent>(OnIsHotEvent);
@@ -98,6 +99,41 @@ public sealed class ItemToggleSystem : EntitySystem
         args.Verbs.Add(new ActivationVerb()
         {
             Text = !ent.Comp.Activated ? Loc.GetString(ent.Comp.VerbToggleOn) : Loc.GetString(ent.Comp.VerbToggleOff),
+            Act = () =>
+            {
+                Toggle((ent.Owner, ent.Comp), user, predicted: ent.Comp.Predictable);
+            }
+        });
+    }
+
+    private void OnAlternateVerb(Entity<ItemToggleComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract || !ent.Comp.OnAltUse)
+            return;
+
+        var user = args.User;
+
+        if (ent.Comp.Activated)
+        {
+            var ev = new ItemToggleDeactivateAttemptEvent(args.User);
+            RaiseLocalEvent(ent.Owner, ref ev);
+
+            if (ev.Cancelled)
+                return;
+        }
+        else
+        {
+            var ev = new ItemToggleActivateAttemptEvent(args.User);
+            RaiseLocalEvent(ent.Owner, ref ev);
+
+            if (ev.Cancelled)
+                return;
+        }
+
+        args.Verbs.Add(new AlternativeVerb()
+        {
+            Text = !ent.Comp.Activated ? Loc.GetString(ent.Comp.VerbToggleOn) : Loc.GetString(ent.Comp.VerbToggleOff),
+            Priority = ent.Comp.AltPriority,
             Act = () =>
             {
                 Toggle((ent.Owner, ent.Comp), user, predicted: ent.Comp.Predictable);

--- a/Content.Shared/_Mono/PersonalShield/PersonalShieldComponent.cs
+++ b/Content.Shared/_Mono/PersonalShield/PersonalShieldComponent.cs
@@ -1,0 +1,166 @@
+using System.Numerics;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Mono.PersonalShield;
+
+/// <summary>
+/// Mono: New energy shields. Act as a wall until they break.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class PersonalShieldComponent : Component
+{
+    /// <summary>
+    /// Settings of the shield itself; stuff like how much damage it takes.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public PersonalShieldSettings Shield = new();
+
+    /// <summary>
+    /// Current state of the shield. We put it here so the component is """clean"""
+    /// </summary>
+    [ViewVariables, AutoNetworkedField]
+    public PersonalShieldRuntime Runtime;
+
+    /// <summary>Is the shield actually on?</summary>
+    public bool IsUp => Runtime.Form >= 1f && Runtime.Shatter <= 0f;
+
+    #region Appearance
+
+    /// <summary>Field tint. The alpha scales the strength of the whole effect.</summary>
+    [DataField, AutoNetworkedField]
+    public Color Color = Color.FromHex("#00AAFF").WithAlpha(0.95f);
+
+    /// <summary>
+    /// Multiplies the field's RGB brightness.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Brightness = 1.0f;
+
+    /// <summary>
+    /// How pixellated the shield itself is.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float PixelGrid = 96f;
+
+    /// <summary>
+    /// How many hex cells span the sprite.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float HexDensity = 4.0f;
+
+    /// <summary>
+    /// How much bigger than the wearer's hitbox the bubble is drawn.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Scale = 2.2f;
+
+    /// <summary>
+    /// How much the field hollows out toward the middle of the dome. Starch wanted this.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float CoreFade = 0.85f;
+
+    /// <summary>Strength of the wash inside the shell.</summary>
+    [DataField, AutoNetworkedField]
+    public float FillLevel = 0.08f;
+
+    /// <summary>Strength of the hex cell borders.</summary>
+    [DataField, AutoNetworkedField]
+    public float LineLevel = 0.50f;
+
+    /// <summary>Strength of the glow along the dome's limb.</summary>
+    [DataField, AutoNetworkedField]
+    public float RimLevel = 0.75f;
+
+    /// <summary>
+    /// How many alpha bands the field is posterised into.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float AlphaBands = 6f;
+
+    /// <summary>
+    /// Depth of the slow pulse over the field.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float BreathDepth = 0.08f;
+
+    /// <summary>
+    /// Where the spin-up crawl sweeps out from.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Vector2 FormOrigin = new(0f, 0f); // The Center
+
+    /// <summary>
+    /// Scale of the noise when the shield shuts off.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float ShardScale = 5f;
+
+    /// <summary>
+    /// How long the shatter animation plays for when the shield breaks.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float ShatterTime = 1.0f;
+
+    #endregion
+}
+
+/// <summary>
+/// Tuning for how a <see cref="PersonalShieldComponent"/> behaves, kept together so the
+/// shield's numbers sit under one YAML node rather than mixed in with its appearance.
+/// </summary>
+[DataDefinition, Serializable, NetSerializable]
+public sealed partial class PersonalShieldSettings
+{
+    /// <summary>How much damage the shield can take before it blows up.</summary>
+    [DataField]
+    public float MaxCharge = 60f;
+
+    /// <summary>
+    /// Charge regained per second while the shield is switched off. It does not recharge while active.
+    /// </summary>
+    [DataField]
+    public float RegenRate = 2f;
+
+    /// <summary>
+    /// How long the shield takes to spin up.
+    /// </summary>
+    [DataField]
+    public float SpinupTime = 4f;
+
+    /// <summary>
+    /// How long the shield stays dead after fracturing.
+    /// </summary>
+    [DataField]
+    public float BreakCooldown = 10f;
+
+    /// <summary>
+    /// Charge burned per second while the shield is fully formed and active. If it runs out, the shield fractures.
+    /// </summary>
+    [DataField]
+    public float PowerDraw = 1.5f;
+}
+
+
+[Serializable, NetSerializable]
+public struct PersonalShieldRuntime
+{
+    /// <summary>Damage capacity remaining.</summary>
+    public float Charge;
+
+    /// <summary>
+    /// How far the field has crawled in.
+    /// </summary>
+    public float Form;
+
+    /// <summary>
+    /// Progress of the destruction fadeout.
+    /// </summary>
+    public float Shatter;
+
+    /// <summary>
+    /// Seconds left before a fractured shield may start spinning up again.
+    /// </summary>
+    public float Offline;
+}

--- a/Content.Shared/_Mono/PersonalShield/SharedPersonalShieldSystem.cs
+++ b/Content.Shared/_Mono/PersonalShield/SharedPersonalShieldSystem.cs
@@ -1,0 +1,171 @@
+using Content.Shared.Damage;
+using Content.Shared.Examine;
+using Content.Shared.Inventory;
+using Content.Shared.Item.ItemToggle;
+using Content.Shared.Item.ItemToggle.Components;
+using Robust.Shared.Network;
+
+namespace Content.Shared._Mono.PersonalShield;
+
+public sealed partial class SharedPersonalShieldSystem : EntitySystem
+{
+    [Dependency] private INetManager _net = default!;
+    [Dependency] private ItemToggleSystem _toggle = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PersonalShieldComponent, InventoryRelayedEvent<DamageModifyEvent>>(OnDamageModify);
+        SubscribeLocalEvent<PersonalShieldComponent, ItemToggleActivateAttemptEvent>(OnActivateAttempt);
+        SubscribeLocalEvent<PersonalShieldComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<PersonalShieldComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(Entity<PersonalShieldComponent> ent, ref MapInitEvent args)
+    {
+        ent.Comp.Runtime.Charge = ent.Comp.Shield.MaxCharge;
+        Dirty(ent, ent.Comp);
+    }
+
+    private void OnDamageModify(Entity<PersonalShieldComponent> ent, ref InventoryRelayedEvent<DamageModifyEvent> args)
+    {
+        var shield = ent.Comp;
+        if (!shield.IsUp || shield.Runtime.Charge <= 0f)
+            return;
+
+        var incoming = args.Args.Damage.GetTotal().Float();
+        if (incoming <= 0f)
+            return;
+
+        var soaked = MathF.Min(incoming, shield.Runtime.Charge);
+        shield.Runtime.Charge -= soaked;
+
+        args.Args.Damage *= (incoming - soaked) / incoming;
+
+        if (shield.Runtime.Charge <= 0f)
+            Fracture(ent); // Uh oh.
+        else
+            Dirty(ent, shield);
+    }
+
+    private void OnActivateAttempt(Entity<PersonalShieldComponent> ent, ref ItemToggleActivateAttemptEvent args)
+    {
+        var runtime = ent.Comp.Runtime;
+        if (runtime.Offline <= 0f && runtime.Shatter <= 0f)
+            return;
+
+        args.Cancelled = true;
+        args.Popup = Loc.GetString("personal-shield-toggle-fractured",
+            ("seconds", (int) MathF.Ceiling(runtime.Offline)));
+    }
+
+    private void OnExamined(Entity<PersonalShieldComponent> ent, ref ExaminedEvent args)
+    {
+        var shield = ent.Comp;
+        string msg;
+
+        if (shield.Runtime.Shatter > 0f)
+            msg = Loc.GetString("personal-shield-examine-broken");
+        else if (shield.Runtime.Offline > 0f)
+            msg = Loc.GetString("personal-shield-examine-offline",
+                ("seconds", (int)MathF.Ceiling(shield.Runtime.Offline)));
+        else if (shield.IsUp)
+            msg = Loc.GetString("personal-shield-examine-up",
+                ("percent", (int)MathF.Round(shield.Runtime.Charge / MathF.Max(shield.Shield.MaxCharge, 1f) * 100f)));
+        else if (shield.Runtime.Form > 0f)
+            msg = Loc.GetString("personal-shield-examine-spinup",
+                ("percent", (int)MathF.Round(shield.Runtime.Form * 100f)));
+        else
+            msg = Loc.GetString("personal-shield-examine-down");
+
+        args.PushMarkup(msg);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_net.IsClient)
+            return;
+
+        var query = EntityQueryEnumerator<PersonalShieldComponent>();
+        while (query.MoveNext(out var uid, out var shield))
+        {
+            var ent = (uid, shield);
+            var before = shield.Runtime;
+            var cfg = shield.Shield;
+
+            if (shield.Runtime.Shatter > 0f)
+            {
+                shield.Runtime.Shatter += frameTime / MathF.Max(shield.ShatterTime, 0.01f);
+                if (shield.Runtime.Shatter >= 1f)
+                {
+                    shield.Runtime.Shatter = 0f;
+                    shield.Runtime.Form = 0f;
+                }
+
+                DirtyIfChanged(ent, before);
+                continue;
+            }
+
+            if (shield.Runtime.Offline > 0f)
+            {
+                shield.Runtime.Offline = MathF.Max(shield.Runtime.Offline - frameTime, 0f);
+                shield.Runtime.Charge = MathF.Min(shield.Runtime.Charge + cfg.RegenRate * frameTime, cfg.MaxCharge);
+                DirtyIfChanged(ent, before);
+                continue;
+            }
+
+            var running = !TryComp<ItemToggleComponent>(uid, out var toggle) || toggle.Activated;
+            var step = frameTime / MathF.Max(cfg.SpinupTime, 0.01f);
+
+            if (running)
+            {
+                shield.Runtime.Form = MathF.Min(shield.Runtime.Form + step, 1f);
+
+                if (shield.Runtime.Form >= 1f)
+                {
+                    // Fully formed: burns charge while active.
+                    shield.Runtime.Charge = MathF.Max(shield.Runtime.Charge - cfg.PowerDraw * frameTime, 0f);
+                    if (shield.Runtime.Charge <= 0f)
+                        Fracture(ent);
+                }
+            }
+            else
+            {
+                // Switched off: the bubble deflates and the charge recharges.
+                if (shield.Runtime.Form > 0f)
+                    shield.Runtime.Form = MathF.Max(shield.Runtime.Form - step, 0f);
+
+                shield.Runtime.Charge = MathF.Min(shield.Runtime.Charge + cfg.RegenRate * frameTime, cfg.MaxCharge);
+            }
+
+            DirtyIfChanged(ent, before);
+        }
+    }
+
+    // Oops!
+    public void Fracture(Entity<PersonalShieldComponent> ent)
+    {
+        ent.Comp.Runtime.Shatter = float.Epsilon;
+        ent.Comp.Runtime.Charge = 0f;
+        ent.Comp.Runtime.Offline = ent.Comp.Shield.BreakCooldown;
+        Dirty(ent, ent.Comp);
+        _toggle.TryDeactivate(ent.Owner);
+    }
+
+    private void DirtyIfChanged(Entity<PersonalShieldComponent> ent, PersonalShieldRuntime before)
+    {
+        var now = ent.Comp.Runtime;
+        if (MathHelper.CloseTo(before.Form, now.Form)
+            && MathHelper.CloseTo(before.Shatter, now.Shatter)
+            && MathHelper.CloseTo(before.Charge, now.Charge)
+            && MathHelper.CloseTo(before.Offline, now.Offline))
+        {
+            return;
+        }
+
+        Dirty(ent, ent.Comp);
+    }
+}

--- a/Content.Shared/_Mono/PersonalShield/SharedPersonalShieldSystem.cs
+++ b/Content.Shared/_Mono/PersonalShield/SharedPersonalShieldSystem.cs
@@ -11,6 +11,7 @@ public sealed partial class SharedPersonalShieldSystem : EntitySystem
 {
     [Dependency] private INetManager _net = default!;
     [Dependency] private ItemToggleSystem _toggle = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
 
     public override void Initialize()
     {
@@ -30,18 +31,30 @@ public sealed partial class SharedPersonalShieldSystem : EntitySystem
 
     private void OnDamageModify(Entity<PersonalShieldComponent> ent, ref InventoryRelayedEvent<DamageModifyEvent> args)
     {
+        // Armor-piercing damage never raises a DamageModifyEvent (see DamageableSystem),
+        // so it inherently bypasses the shield.
+
         var shield = ent.Comp;
         if (!shield.IsUp || shield.Runtime.Charge <= 0f)
             return;
 
-        var incoming = args.Args.Damage.GetTotal().Float();
+        // Only positive damage soaks the shield; healing is left untouched.
+        var incoming = DamageSpecifier.GetPositive(args.Args.Damage).GetTotal().Float();
         if (incoming <= 0f)
             return;
 
         var soaked = MathF.Min(incoming, shield.Runtime.Charge);
         shield.Runtime.Charge -= soaked;
 
-        args.Args.Damage *= (incoming - soaked) / incoming;
+        var scale = (incoming - soaked) / incoming;
+        if (!MathHelper.CloseTo(scale, 1f))
+        {
+            foreach (var (type, value) in args.Args.Damage.DamageDict)
+            {
+                if (value > 0)
+                    args.Args.Damage.DamageDict[type] = value * scale;
+            }
+        }
 
         if (shield.Runtime.Charge <= 0f)
             Fracture(ent); // Uh oh.
@@ -117,7 +130,11 @@ public sealed partial class SharedPersonalShieldSystem : EntitySystem
                 continue;
             }
 
-            var running = !TryComp<ItemToggleComponent>(uid, out var toggle) || toggle.Activated;
+            // The shield only runs while worn in an inventory slot and toggled on.
+            var worn = _inventory.TryGetContainingEntity(uid, out _);
+            var running = worn
+                          && TryComp<ItemToggleComponent>(uid, out var toggle)
+                          && toggle.Activated;
             var step = frameTime / MathF.Max(cfg.SpinupTime, 0.01f);
 
             if (running)

--- a/Content.Shared/_Mono/PersonalShield/SharedPersonalShieldSystem.cs
+++ b/Content.Shared/_Mono/PersonalShield/SharedPersonalShieldSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Armor;
 using Content.Shared.Damage;
 using Content.Shared.Examine;
 using Content.Shared.Inventory;
@@ -17,7 +18,10 @@ public sealed partial class SharedPersonalShieldSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<PersonalShieldComponent, InventoryRelayedEvent<DamageModifyEvent>>(OnDamageModify);
+        // Soak the raw hit before armor coefficients are applied, so the charge is spent
+        // 1:1 with incoming damage rather than with the post-armor remainder.
+        SubscribeLocalEvent<PersonalShieldComponent, InventoryRelayedEvent<DamageModifyEvent>>(OnDamageModify,
+            before: [typeof(SharedArmorSystem)]);
         SubscribeLocalEvent<PersonalShieldComponent, ItemToggleActivateAttemptEvent>(OnActivateAttempt);
         SubscribeLocalEvent<PersonalShieldComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<PersonalShieldComponent, MapInitEvent>(OnMapInit);

--- a/Resources/Locale/en-US/_Mono/personal-shield.ftl
+++ b/Resources/Locale/en-US/_Mono/personal-shield.ftl
@@ -1,5 +1,5 @@
 personal-shield-examine-up = The shield is [color=#00AAFF]up[/color], at [color=#00AAFF]{ $percent }%[/color] capacity.
-personal-shield-examine-spinup = The shield is [color=orange]spinning up[/color].
+personal-shield-examine-spinup = The shield is [color=orange]spinning up[/color] ({ $percent }%).
 personal-shield-examine-broken = The shield is [color=red]shutting down[/color].
 personal-shield-examine-offline = The shield is [color=red]respooling[/color]. { $seconds } seconds until it restarts.
 personal-shield-examine-down = The shield is [color=darkgray]down[/color].

--- a/Resources/Locale/en-US/_Mono/personal-shield.ftl
+++ b/Resources/Locale/en-US/_Mono/personal-shield.ftl
@@ -1,0 +1,8 @@
+personal-shield-examine-up = The shield is [color=#00AAFF]up[/color], at [color=#00AAFF]{ $percent }%[/color] capacity.
+personal-shield-examine-spinup = The shield is [color=orange]spinning up[/color].
+personal-shield-examine-broken = The shield is [color=red]shutting down[/color].
+personal-shield-examine-offline = The shield is [color=red]respooling[/color]. { $seconds } seconds until it restarts.
+personal-shield-examine-down = The shield is [color=darkgray]down[/color].
+personal-shield-toggle-fractured = Shield respooling. { $seconds } seconds remaining.
+personal-shield-toggle-up = Shield raised.
+personal-shield-toggle-down = Shield lowered.

--- a/Resources/Locale/uk-UA/_Mono/personal-shield.ftl
+++ b/Resources/Locale/uk-UA/_Mono/personal-shield.ftl
@@ -1,8 +1,18 @@
 personal-shield-examine-up = Щит [color=#00AAFF]активний[/color], заряд [color=#00AAFF]{ $percent }%[/color].
-personal-shield-examine-spinup = Щит [color=orange]розгортається[/color].
+personal-shield-examine-spinup = Щит [color=orange]розгортається[/color] ({ $percent }%).
 personal-shield-examine-broken = Щит [color=red]вимикається[/color].
-personal-shield-examine-offline = Щит [color=red]перезаряджається[/color]. { $seconds } секунд до перезапуску.
+personal-shield-examine-offline = Щит [color=red]перезаряджається[/color]. {$seconds ->
+    [one] { $seconds } секунда
+    [few] { $seconds } секунди
+    [many] { $seconds } секунд
+    *[other] { $seconds } секунд
+} до перезапуску.
 personal-shield-examine-down = Щит [color=darkgray]вимкнений[/color].
-personal-shield-toggle-fractured = Перезаряджання щита. Залишилось { $seconds } секунд.
+personal-shield-toggle-fractured = Перезаряджання щита. Залишилось {$seconds ->
+    [one] { $seconds } секунда
+    [few] { $seconds } секунди
+    [many] { $seconds } секунд
+    *[other] { $seconds } секунд
+}.
 personal-shield-toggle-up = Щит піднято.
 personal-shield-toggle-down = Щит опущено.

--- a/Resources/Locale/uk-UA/_Mono/personal-shield.ftl
+++ b/Resources/Locale/uk-UA/_Mono/personal-shield.ftl
@@ -1,0 +1,8 @@
+personal-shield-examine-up = Щит [color=#00AAFF]активний[/color], заряд [color=#00AAFF]{ $percent }%[/color].
+personal-shield-examine-spinup = Щит [color=orange]розгортається[/color].
+personal-shield-examine-broken = Щит [color=red]вимикається[/color].
+personal-shield-examine-offline = Щит [color=red]перезаряджається[/color]. { $seconds } секунд до перезапуску.
+personal-shield-examine-down = Щит [color=darkgray]вимкнений[/color].
+personal-shield-toggle-fractured = Перезаряджання щита. Залишилось { $seconds } секунд.
+personal-shield-toggle-up = Щит піднято.
+personal-shield-toggle-down = Щит опущено.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -311,7 +311,7 @@
 
 # Armor covering multiple body parts including limbs
 - type: entity
-  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseSyndicateContraband ]
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseSyndicateContraband, MonoPersonalShieldClothing ]
   id: ClothingOuterArmorRaid
   name: syndicate raid suit
   description: A somewhat flexible and well-armored suit with a powerful shoulder mounted flashlight manufactured in the Gorlex Marauder's iconic blood-red color scheme, it does not protect its wearer from space.
@@ -325,6 +325,8 @@
       shader: unshaded
   - type: Clothing
     sprite: Clothing/OuterClothing/Armor/syndie-raid.rsi
+  - type: PersonalShield
+    color: "#A31616F2"
   - type: Armor
     # Goob start
     coverage:
@@ -343,11 +345,11 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.3
-        Slash: 0.3
-        Piercing: 0.3
-        Heat: 0.3
-        Caustic: 0.3
+        Blunt: 0.33
+        Slash: 0.33
+        Piercing: 0.33
+        Heat: 0.33
+        Caustic: 0.33
     # Goob end
   - type: ExplosionResistance
     damageCoefficient: 0.35

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -309,7 +309,7 @@
 
 # Armor covering multiple body parts including limbs
 - type: entity
-  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseSyndicateContraband ]
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseSyndicateContraband, MonoPersonalShieldClothing ]
   id: ClothingOuterArmorRaid
   name: syndicate raid suit
   description: A somewhat flexible and well-armored suit with a powerful shoulder mounted flashlight manufactured in the Gorlex Marauder's iconic blood-red color scheme, it does not protect its wearer from space.
@@ -323,6 +323,8 @@
       shader: unshaded
   - type: Clothing
     sprite: Clothing/OuterClothing/Armor/syndie-raid.rsi
+  - type: PersonalShield
+    color: "#A31616F2"
   - type: Armor
     # Goob start
     coverage:
@@ -341,11 +343,11 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.3
-        Slash: 0.3
-        Piercing: 0.3
-        Heat: 0.3
-        Caustic: 0.3
+        Blunt: 0.33
+        Slash: 0.33
+        Piercing: 0.33
+        Heat: 0.33
+        Caustic: 0.33
     # Goob end
   - type: ExplosionResistance
     damageCoefficient: 0.35

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1333,7 +1333,7 @@
 
 #ERT Chaplain Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingOuterHardsuitSyndie ]
+  parent: [ BaseCentcommContraband, ClothingOuterHardsuitSyndie, MonoPersonalShieldClothing ]
   id: ClothingOuterHardsuitERTChaplain
   name: ERT chaplain's hardsuit # Goob edit
   description: A protective hardsuit worn by the chaplains of an Emergency Response Team. # Goob edit
@@ -1342,6 +1342,17 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertchaplain.rsi #if you change this, please update the humanoid.yml with a better markers sprite.
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertchaplain.rsi
+  - type: PersonalShield
+    color: "#3A7DCDF2"
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.5
+        Heat: 0.5
+        Radiation: 0.5
+        Caustic: 0.5
   - type: ToggleableClothing # Goobstation - Modsuits change
     clothingPrototypes:
       head: ClothingHeadHelmetHardsuitERTChaplain
@@ -1367,7 +1378,7 @@
 
 #ERT Medic Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingOuterHardsuitSyndieMedic ]
+  parent: [ BaseCentcommContraband, ClothingOuterHardsuitSyndieMedic, MonoPersonalShieldClothing ]
   id: ClothingOuterHardsuitERTMedical
   name: ERT medic's hardsuit # Goob edit
   description: A protective hardsuit worn by the medics of an emergency response team. # Goob edit
@@ -1376,13 +1387,24 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertmedical.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertmedical.rsi
+  - type: PersonalShield
+    color: "#3A7DCDF2"
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.5
+        Heat: 0.5
+        Radiation: 0.5
+        Caustic: 0.5
   - type: ToggleableClothing # Goobstation - Modsuits change
     clothingPrototypes:
       head: ClothingHeadHelmetHardsuitERTMedical
 
 #ERT Security Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingOuterHardsuitSyndie ]
+  parent: [ BaseCentcommContraband, ClothingOuterHardsuitSyndie, MonoPersonalShieldClothing ]
   id: ClothingOuterHardsuitERTSecurity
   name: ERT security's hardsuit # Goob edit
   description: A protective hardsuit worn by the security officers of an emergency response team. # Goob edit
@@ -1391,6 +1413,17 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertsecurity.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertsecurity.rsi
+  - type: PersonalShield
+    color: "#3A7DCDF2"
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.5
+        Heat: 0.5
+        Radiation: 0.5
+        Caustic: 0.5
   - type: ToggleableClothing # Goobstation - Modsuits change
     clothingPrototypes:
       head: ClothingHeadHelmetHardsuitERTSecurity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -967,7 +967,7 @@
 
 #Syndicate Elite Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseSyndicateContraband]
+  parent: [ClothingOuterHardsuitBase, BaseSyndicateContraband, MonoPersonalShieldClothing]
   id: ClothingOuterHardsuitSyndieElite
   name: syndicate elite hardsuit # Goob edit
   description: An elite version of the blood-red hardsuit, with improved mobility and fireproofing. Property of Gorlex Marauders. # Goob edit
@@ -976,6 +976,8 @@
     sprite: Clothing/OuterClothing/Hardsuits/syndieelite.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/syndieelite.rsi
+  - type: PersonalShield
+    color: "#A31616F2"
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
@@ -997,12 +999,12 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.55
-        Slash: 0.55
-        Piercing: 0.55
-        Heat: 0.2
+        Blunt: 0.61
+        Slash: 0.61
+        Piercing: 0.61
+        Heat: 0.22
         Radiation: 0.01
-        Caustic: 0.4
+        Caustic: 0.44
   - type: Item
     size: Huge
   - type: ClothingSpeedModifier
@@ -1024,7 +1026,7 @@
         Blunt: 6 # Pirate ^
 
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseSyndicateContraband]
+  parent: [ClothingOuterHardsuitBase, BaseSyndicateContraband, MonoPersonalShieldClothing]
   id: ClothingOuterHardsuitSyndieCommander
   name: syndicate commander hardsuit # Goob edit
   description: A bulked up version of the blood-red hardsuit, purpose-built for the commander of a syndicate operative squad. Has significantly improved armor for those deadly front-lines firefights. # Goob edit
@@ -1033,6 +1035,8 @@
     sprite: Clothing/OuterClothing/Hardsuits/syndiecommander.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/syndiecommander.rsi
+  - type: PersonalShield
+    color: "#A31616F2"
   - type: PressureProtection
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
@@ -1049,12 +1053,12 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.35
-        Slash: 0.35
-        Piercing: 0.3
-        Heat: 0.45
-        Radiation: 0.2
-        Caustic: 0.4
+        Blunt: 0.39
+        Slash: 0.39
+        Piercing: 0.33
+        Heat: 0.5
+        Radiation: 0.22
+        Caustic: 0.44
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
@@ -1078,7 +1082,7 @@
 
 #Cybersun Juggernaut Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseSyndicateContraband]
+  parent: [ClothingOuterHardsuitBase, BaseSyndicateContraband, MonoPersonalShieldClothing]
   id: ClothingOuterHardsuitJuggernaut
   name: cybersun juggernaut suit
   description: A suit made by the cutting edge R&D department at Cybersun to be hyper resilient.
@@ -1087,6 +1091,8 @@
     sprite: Clothing/OuterClothing/Hardsuits/cybersun.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/cybersun.rsi
+  - type: PersonalShield
+    color: "#D62828F2"
   - type: PressureProtection
     highPressureMultiplier: 0.2
     lowPressureMultiplier: 1000
@@ -1103,12 +1109,12 @@
       NerveDamage: 1
     modifiers:
       coefficients:
-        Blunt: 0.2
-        Slash: 0.2
-        Piercing: 0.2
-        Heat: 0.2
-        Radiation: 0.2
-        Caustic: 0.2
+        Blunt: 0.22
+        Slash: 0.22
+        Piercing: 0.22
+        Heat: 0.22
+        Radiation: 0.22
+        Caustic: 0.22
   - type: ClothingSpeedModifier
     walkModifier: 0.65
     sprintModifier: 0.65
@@ -1133,7 +1139,7 @@
 
 #Wizard Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, ClothingOuterWizardBaseArmor, BaseMagicalContraband] # Goob edit
+  parent: [ClothingOuterHardsuitBase, ClothingOuterWizardBaseArmor, BaseMagicalContraband, MonoPersonalShieldClothing] # Goob edit
   id: ClothingOuterHardsuitWizard
   name: wizard hardsuit # Goob edit
   description: A bizarre gem-encrusted suit that radiates magical energies.
@@ -1142,6 +1148,8 @@
     sprite: Clothing/OuterClothing/Hardsuits/wizard.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/wizard.rsi
+  - type: PersonalShield
+    color: "#9B59B6F2"
   - type: PressureProtection
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
@@ -1154,12 +1162,12 @@
       NerveDamage: 1
     modifiers:
       coefficients:
-        Blunt: 0.35
-        Slash: 0.35
-        Piercing: 0.35
-        Heat: 0.35
-        Radiation: 0.05
-        Caustic: 0.1
+        Blunt: 0.39
+        Slash: 0.39
+        Piercing: 0.39
+        Heat: 0.39
+        Radiation: 0.06
+        Caustic: 0.11
   - type: ClothingSpeedModifier
     walkModifier: 0.9 # Goob edit
     sprintModifier: 0.9 # Goob edit
@@ -1308,7 +1316,7 @@
 #CENTCOMM / ERT HARDSUITS
 #ERT Leader Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingOuterHardsuitSyndieCommander ]
+  parent: [ BaseCentcommContraband, ClothingOuterHardsuitSyndieCommander, MonoPersonalShieldClothing ]
   id: ClothingOuterHardsuitERTLeader
   name: ERT leader's hardsuit # Goob edit
   description: A protective hardsuit worn by the leader of an emergency response team. # Goob edit
@@ -1317,6 +1325,8 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertleader.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertleader.rsi
+  - type: PersonalShield
+    color: "#3A7DCDF2"
   - type: ToggleableClothing # Goobstation - Modsuits change
     clothingPrototypes:
       head: ClothingHeadHelmetHardsuitERTLeader
@@ -1347,6 +1357,8 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertengineer.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertengineer.rsi
+  - type: PersonalShield
+    color: "#3A7DCDF2"
   - type: ToggleableClothing # Goobstation - Modsuits change
     clothingPrototypes:
       head: ClothingHeadHelmetHardsuitERTEngineer
@@ -1398,13 +1410,15 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertjanitor.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertjanitor.rsi
+  - type: PersonalShield
+    color: "#3A7DCDF2"
   - type: ToggleableClothing # Goobstation - Modsuits change
     clothingPrototypes:
       head: ClothingHeadHelmetHardsuitERTJanitor
 
 #Deathsquad
 - type: entity # Goobstation - Start
-  parent: [ BaseCentcommContraband, ClothingOuterHardsuitBase ]
+  parent: [ BaseCentcommContraband, ClothingOuterHardsuitBase, MonoPersonalShieldClothing ]
   id: ClothingOuterHardsuitDeathsquad # Todo - This should be a modsuit when those are done.
   name: PI-52 "Lucifer" hardsuit # Goob edit
   description: A famous hardsuit used by Central Command's death-squadrons, often shown in movies by Nanotrasen intended to increase recruitment. # Goob edit
@@ -1413,6 +1427,8 @@
     sprite: Clothing/OuterClothing/Hardsuits/deathsquad.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/deathsquad.rsi
+  - type: PersonalShield
+    color: "#00A3FFF2"
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
@@ -1440,14 +1456,14 @@
       NerveDamage: 1
     modifiers:
       coefficients:
-        Blunt: 0.1 # Best armor in the game - Yeah no shit.
-        Slash: 0.1
-        Piercing: 0.1
-        Heat: 0.1
-        Cold: 0.1
-        Cellular: 0.1
-        Radiation: 0.1
-        Caustic: 0.1
+        Blunt: 0.11 # Best armor in the game - Yeah no shit.
+        Slash: 0.11
+        Piercing: 0.11
+        Heat: 0.11
+        Cold: 0.11
+        Cellular: 0.11
+        Radiation: 0.11
+        Caustic: 0.11
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/armour.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/armour.yml
@@ -73,6 +73,8 @@
       shader: unshaded
   - type: Clothing
     sprite: _Goobstation/Clothing/OuterClothing/Armor/helldiver.rsi
+  - type: PersonalShield
+    color: "#F5C518F2"
   - type: TemperatureProtection
     heatingCoefficient: 0.1
     coolingCoefficient: 0.1

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -31,14 +31,14 @@
       NerveDamage: 1
     modifiers:
       coefficients:
-        Blunt: 0.01
-        Slash: 0.01
-        Piercing: 0.01
-        Heat: 0.01
-        Cold: 0.01
-        Shock: 0.01
-        Caustic: 0.01
-        Radiation: 0.01
+        Blunt: 0.011
+        Slash: 0.011
+        Piercing: 0.011
+        Heat: 0.011
+        Cold: 0.011
+        Shock: 0.011
+        Caustic: 0.011
+        Radiation: 0.011
   - type: ClothingSpeedModifier
     walkModifier: 0.70
     sprintModifier: 0.70
@@ -174,6 +174,8 @@
   components:
   - type: Sprite
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/dreadnought.rsi
+  - type: Item
+    size: Ginormous #damn its hard to spell
   - type: Clothing
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/dreadnought.rsi
     equipDelay: 15

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -3,7 +3,7 @@
 # Chronolegioneer Hardsuit
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ClothingOuterHardsuitBase, MonoPersonalShieldClothing]
   id: ClothingOuterHardsuitChronolegioneer
   name: futuristic hardsuit
   description: A hardsuit covered in an unknown material that protects against most material and temporal damage.
@@ -12,6 +12,8 @@
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/chronolegioneer.rsi
   - type: Clothing
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/chronolegioneer.rsi
+  - type: PersonalShield
+    color: "#FFFFFFF2"
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
@@ -61,7 +63,7 @@
 # Blueshield Hardsuit
 
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseCentcommContraband]
+  parent: [ClothingOuterHardsuitBase, BaseCentcommContraband, MonoPersonalShieldClothing]
   id: ClothingOuterHardsuitBlueshieldLight
   name: "'praetorian' escort hardsuit"
   description: A hardsuit designed for an elite bodyguard. This particular one is made of a lighter metal, allowing for more maneuverability.
@@ -70,6 +72,8 @@
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/bsolight.rsi
   - type: Clothing
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/bsolight.rsi
+  - type: PersonalShield
+    color: "#4A90D9F2"
   - type: PressureProtection
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
@@ -84,12 +88,12 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.65
-        Heat: 0.65
-        Radiation: 0.6
-        Caustic: 0.6
+        Blunt: 0.66
+        Slash: 0.66
+        Piercing: 0.72
+        Heat: 0.72
+        Radiation: 0.66
+        Caustic: 0.66
   - type: ClothingSpeedModifier
     sprintModifier: 0.9
     walkModifier: 0.9
@@ -163,19 +167,19 @@
 # cybersun dreadnought suit
 
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, BaseSyndicateAnchoredContraband ]
+  parent: [ClothingOuterHardsuitBase, BaseSyndicateAnchoredContraband, MonoPersonalShieldClothing]
   id: ClothingOuterHardsuitCybersunDreadnought
   name: Cybersun dreadnought suit
   description: The Syndicate places its glory on your shoulders, do not disappoint.
   components:
   - type: Sprite
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/dreadnought.rsi
-  - type: Item
-    size: Ginormous #damn its hard to spell
   - type: Clothing
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/dreadnought.rsi
     equipDelay: 15
     unequipDelay: 600 # if i add the unremovable comp then you couldnt even put this on
+  - type: PersonalShield
+    color: "#D62828F2"
   - type: PressureProtection
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
@@ -192,12 +196,12 @@
       NerveDamage: 0.9
     modifiers:
       coefficients:
-        Blunt: 0.1
-        Slash: 0.1 # holy shit bruv
-        Piercing: 0.1
-        Heat: 0.1
-        Radiation: 0.25 # do people even know rad ammo exists? anyway making rad its weakness is kinda fair
-        Caustic: 0.4
+        Blunt: 0.11
+        Slash: 0.11 # holy shit bruv
+        Piercing: 0.11
+        Heat: 0.11
+        Radiation: 0.28 # do people even know rad ammo exists? anyway making rad its weakness is kinda fair
+        Caustic: 0.44
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.5
@@ -268,7 +272,7 @@
 
 # Head of Security's experimental voidsuit
 - type: entity
-  parent: ClothingOuterHardsuitSecurityRed
+  parent: [ClothingOuterHardsuitSecurityRed, MonoPersonalShieldClothing]
   id: ClothingOuterHardsuitHeadOfSecurityExperimental
   name: FI-52 "Honor Guard" parade hardsuit
   description: A special hardsuit that protects against hazardous, low pressure environments. Has an experimental inbuilt stimulant autoinjector system.
@@ -277,6 +281,17 @@
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/hos-expi.rsi
   - type: Clothing
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/hos-expi.rsi
+  - type: PersonalShield
+    color: "#3A7DCDF2"
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.72
+        Slash: 0.72
+        Piercing: 0.72
+        Heat: 0.88
+        Radiation: 0.55
+        Caustic: 0.55
   - type: ToggleableClothing
     clothingPrototypes:
       head: ClothingHeadHelmetHardsuitHeadOfSecurityExperimental
@@ -291,7 +306,7 @@
 # Nanorep catalog Hardsuit
 
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseCentcommContraband]
+  parent: [ClothingOuterHardsuitBase, BaseCentcommContraband, MonoPersonalShieldClothing]
   id: ClothingOuterHardsuitExperimentalNanorep
   name: "NTX5-Mirrorduss"
   description: A crude dark exosuit of reinforced plating, etched with faintly glowing Bluespace circuits. You can tell someone attempted to scratch out part of the text — Prototype No. 2
@@ -300,6 +315,8 @@
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/ntr_experimental.rsi
   - type: Clothing
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/ntr_experimental.rsi
+  - type: PersonalShield
+    color: "#2ECC71F2"
   - type: PressureProtection
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
@@ -314,12 +331,12 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.75
-        Heat: 0.8
-        Radiation: 0.7
-        Caustic: 0.7
+        Blunt: 0.88
+        Slash: 0.88
+        Piercing: 0.83
+        Heat: 0.88
+        Radiation: 0.77
+        Caustic: 0.77
   - type: ClothingSpeedModifier
     sprintModifier: 0.95
     walkModifier: 0.95

--- a/Resources/Prototypes/_Mono/Entities/Clothing/base_shielding.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/base_shielding.yml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Mono: abstract parent granting a PersonalShield to high-tier combat suits.
+# Balanced as a flavour addition: it soaks a few hits, breaks, and respools.
+# Suits inheriting from this override the shield color (and optionally the numbers).
+
+- type: entity
+  abstract: true
+  id: MonoPersonalShieldClothing
+  components:
+  - type: PersonalShield
+    shield:
+      maxCharge: 40
+      regenRate: 0.5 # recharge per second while switched off - a full refill takes 80s
+      spinupTime: 2
+      breakCooldown: 12
+      powerDraw: 0.5 # burn per second while the shield is up - damage soaks from the same pool
+  - type: ItemToggle
+    onUse: false
+    onActivate: true
+    onAltUse: true
+    popupActivate: personal-shield-toggle-up
+    popupDeactivate: personal-shield-toggle-down
+    soundActivate:
+      path: /Audio/Weapons/ebladeon.ogg
+    soundDeactivate:
+      path: /Audio/Weapons/ebladeoff.ogg
+    soundFailToActivate:
+      path: /Audio/Machines/button.ogg
+      params:
+        variation: 0.250

--- a/Resources/Prototypes/_Mono/Shaders/personal_shields.yml
+++ b/Resources/Prototypes/_Mono/Shaders/personal_shields.yml
@@ -1,0 +1,7 @@
+# WARNING: Vibecoded. This shader is entirely vibecoded. Here be dragons.
+# While the shader has been tested extensively and I can somewhat comprehend it,
+# I have no way of confirming it will be stable outside of intended use.
+- type: shader
+  id: PersonalShieldSkin
+  kind: source
+  path: "/Textures/_Mono/Shaders/shield_skin.swsl"

--- a/Resources/Textures/_Mono/Shaders/shield_skin.swsl
+++ b/Resources/Textures/_Mono/Shaders/shield_skin.swsl
@@ -1,0 +1,175 @@
+light_mode unshaded;
+
+// Monolith: energy shield skin — a procedural hexfield dome, entirely
+// textureless (the whole pattern is shader math). Reused for both the planetary
+// shield (drawn over a planet disc) and the personal shield (drawn as a bubble
+// over a mob by PersonalShieldOverlay). The quad's UV is treated as a unit disc
+// (r = 1 at the quad edge), bulged into fake sphere coordinates so the hex cells
+// foreshorten toward the limb, then composed from a per-cell shimmering fill,
+// bright hex border lines, and a limb rim glow.
+//
+// `progress` runs 0 -> 2 in three phases:
+//   0.0 -> 1.0  the field crawls in across the dome from the top (activation).
+//   1.0 -> 1.8  the field shatters: a perlin dissolve eats it away in ragged
+//               noisy shards, each flashing hot right as it breaks off.
+//   1.8 -> 2.0  fully gone (invisible tail, so the clock can reset seamlessly).
+
+uniform highp float progress;
+uniform highp vec4 skin_color;
+
+// Multiplies the field's RGB — >1 pushes the colours hot/bloomy, <1 dims them.
+// Alpha (overall opacity) still comes from skin_color.a.
+uniform highp float brightness;
+
+// Pixellation: number of quantisation cells across the quad. Higher = finer (less
+// chunky); at/below 1 the spatial snap is skipped entirely and the field renders
+// smooth. Set by the overlay from the shield's PixelGrid field.
+uniform highp float pixel_grid;
+
+// Hex density: how many hex cells span the dome. Lower = fewer, larger cells. Set
+// by the overlay from the shield's HexDensity field.
+uniform highp float hex_density;
+
+// Formation origin, in disc space (-1..1, r = 1 at the dome edge): the point the
+// activation crawl sweeps out from. (0, -0.85) is the top of the dome. Set by the
+// overlay from the shield's FormOrigin field.
+uniform highp vec2 form_origin;
+
+// Strengths of the three layers: the wash inside the shell, the hex cell borders, and
+// the glow along the limb.
+uniform highp float fill_level;
+uniform highp float line_level;
+uniform highp float rim_level;
+
+// How much the field hollows out toward the middle. 0 fills the whole dome evenly; 1
+// leaves the centre almost clear and concentrates everything near the rim, so the
+// wearer stays visible through it the way a sci-fi bubble should.
+uniform highp float core_fade;
+
+// Frequency of the shatter noise. Higher = smaller, finer shards.
+uniform highp float shard_scale;
+
+// Posterise bands (lower = chunkier stepping) and depth of the slow pulse.
+uniform highp float alpha_bands;
+uniform highp float breath_depth;
+
+highp float hash21(highp vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+// Value noise: smooth interpolated hash lattice. Used for the shatter dissolve so
+// the break front is organic and ragged rather than a clean sweep.
+highp float vnoise(highp vec2 p) {
+    highp vec2 i = floor(p);
+    highp vec2 f = fract(p);
+    highp float a = hash21(i);
+    highp float b = hash21(i + vec2(1.0, 0.0));
+    highp float c = hash21(i + vec2(0.0, 1.0));
+    highp float d = hash21(i + vec2(1.0, 1.0));
+    highp vec2 u = f * f * (3.0 - 2.0 * f);
+    return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+}
+
+// Signed-ish distance to the hex cell border: 0 at the centre, 0.5 at an edge.
+highp float hexDist(highp vec2 p) {
+    p = abs(p);
+    return max(dot(p, vec2(0.5, 0.866025)), p.x);
+}
+
+// Hex tiling: returns (edge distance, cell id hash) for the cell containing uv.
+highp vec2 hexCell(highp vec2 uv) {
+    highp vec2 r = vec2(1.0, 1.732051);
+    highp vec2 h = r * 0.5;
+    highp vec2 a = mod(uv, r) - h;
+    highp vec2 b = mod(uv - h, r) - h;
+    highp float useB = step(dot(b, b), dot(a, a));
+    highp vec2 gv = mix(a, b, useB);
+    highp vec2 id = uv - gv;
+    return vec2(hexDist(gv), hash21(id));
+}
+
+void fragment() {
+    // Pixel-art quantisation: snap the sample point to a coarse grid and step the
+    // clock at ~8 fps, so the field is chunky in space AND time — smooth per-frame
+    // motion on a pixel grid reads as cheap; steppy motion reads as sprite animation.
+    // pixel_grid <= 1 disables the spatial snap (smooth field) for small bubbles
+    // where a coarse grid looks too blocky.
+    highp vec2 uvq = UV;
+    if (pixel_grid > 1.0)
+        uvq = (floor(UV * pixel_grid) + vec2(0.5)) / pixel_grid;
+    highp float t = floor(TIME * 8.0) / 8.0;
+
+    // Disc space: r = 1 at the quad's inscribed circle (the overlay sizes the quad
+    // to the sprite, so the field hugs the disc).
+    highp vec2 p = (uvq - vec2(0.5)) * 2.0;
+    highp float r = length(p);
+
+    // Hard disc mask with a little AA; everything below multiplies into this.
+    highp float mask = 1.0 - smoothstep(0.97, 1.0, r);
+
+    // Fake dome: z is the shell height (1 centre → 0 limb). The equal-angle bulge
+    // asin(r)/r runs the hex grid faster toward the limb, so cells visibly
+    // foreshorten there — reads as a curved shell, not wallpaper.
+    highp float rc = min(r, 1.0);
+    highp float z = sqrt(max(1.0 - rc * rc, 0.0));
+    highp float warp = asin(rc) / max(rc, 0.0001);
+    highp vec2 q = p * warp;
+
+    highp vec2 cell = hexCell(q * hex_density);
+    highp float edge = cell.x;
+    highp float id = cell.y;
+
+    // Phase split: form is the 0 → 1 crawl parameter; shatter is the 0 → 1 dissolve
+    // parameter mapped from progress 1.0 → 1.8 (progress ≥ 1.8 leaves it clamped at
+    // 1, i.e. fully broken → invisible, for the 1.8 → 2.0 reset tail).
+    highp float form = clamp(progress, 0.0, 1.0);
+    highp float shatter = clamp((progress - 1.0) / 0.8, 0.0, 1.0);
+
+    // Formation crawl outward from the configurable origin.
+    highp float front = distance(p, form_origin) * 0.5;
+    highp float jitter = (id - 0.5) * 0.12;
+    highp float appear = step(front + jitter, form);
+    highp float fresh = smoothstep(0.25, 0.0, form - (front + jitter));
+
+    // Per-cell shimmer so the field feels energised without strobing.
+    highp float shimmer = 0.75 + 0.25 * sin(t * 1.7 + id * 6.2832);
+
+    // Edge weighting: (1 - z) is 0 dead centre and 1 out at the limb. Fading the wash and
+    // the hex lines by it hollows the dome out, so you look THROUGH the middle and the
+    // structure only reads near the edges — the usual sci-fi bubble. core_fade = 0 restores
+    // the old evenly-filled shell.
+    highp float limb = 1.0 - z;
+    highp float edgeWeight = mix(1.0, limb * limb, clamp(core_fade, 0.0, 1.0));
+
+    // Faint cell fill, brighter borders, hot pop-in, and the limb glow. The pop-in flash is
+    // NOT edge-weighted: it should read across the whole dome as the field sweeps in.
+    highp float border = smoothstep(0.42, 0.5, edge);
+    highp float fill = fill_level * shimmer * edgeWeight;
+    highp float lines = line_level * border * edgeWeight;
+    highp float rim = pow(limb, 3.0) * rim_level;
+
+    highp float a = (fill + lines + fresh * 0.6 + rim) * appear * mask;
+
+    // Shatter dissolve: every bit of the dome gets a break threshold from a noisy
+    // field (spatial perlin blended with per-cell jitter) so it comes apart in
+    // ragged clumps, not a ruler line. As `shatter` climbs past a fragment's
+    // threshold it winks out; fragments right at the front flash hot for the beat
+    // they break off, selling the shatter.
+    // Break threshold, scaled into [0, 0.85] so even the last-to-go fragment (plus
+    // its dissolve window and glow band) fully clears before `shatter` reaches 1 —
+    // otherwise the highest-threshold cells freeze mid-fade and never disappear.
+    highp float thr = clamp(vnoise(q * shard_scale) * 0.7 + id * 0.3, 0.0, 1.0) * 0.85;
+    highp float shard = 1.0 - smoothstep(thr, thr + 0.1, shatter);
+    highp float breakGlow = smoothstep(0.12, 0.0, abs(shatter - thr)) * step(0.001, shatter);
+    a = a * shard + breakGlow * 0.7 * mask;
+
+    // Slow breath over the whole shell — alive, never flickering off.
+    a *= (1.0 - breath_depth) + breath_depth * sin(t * 0.9);
+
+    // Posterise into a handful of alpha bands: no smooth gradients, just the
+    // stepped shading pixel art actually has.
+    highp float bands = max(alpha_bands, 1.0);
+    a = floor(clamp(a, 0.0, 1.0) * bands + 0.5) / bands;
+
+    COLOR = vec4(skin_color.rgb * brightness, skin_color.a * a);
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Iced-Coded <volkogon212@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Правила (Англійською): https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- ПРИМІТКА: Увесь код у цьому репозиторії використовує ліцензію AGPL-3.0-or-later.
Заголовки специфікації REUSE або окремі файли .license вказують на додаткову ліцензію (наприклад MPL або MIT) виключно для того, щоб полегшити інтеграцію для проєктів, що не використовують ліцензію AGPL. Ця додаткова ліцензія не скасовує того факту, що AGPL-3.0-or-later залишається основною та обов'язковою ліцензією.
Розкоментуйте та змініть наступний рядок, якщо ви бажаєте змінити ліцензію з AGPL. -->
<!--- ЛІЦЕНЗІЯ: AGPL -->
## Про запит на злиття
<!-- Що ви змінили? -->

## Чому / Баланс
<!-- Опишіть як це змінить ігровий баланс, або поясніть чому ці зміни були внесені. Відмітьте усі пов'язані діалоги або проблеми. -->

## Технічні деталі
<!-- Опишіть усі технічні зміни. -->

## Медіа
<!-- Прикріпляйте медіа якщо запит на злиття робить геймплейні зміни (одяг, предмети, фічі, тощо).
Малі фікси або переробки є винятком. -->

## Вимоги
<!-- Підтвердіть наступне, записавши X у квадратні дужки [X]: -->
- [ ] Я прочитав та дотримуюсь [Правил запитів на злиття та журналу змін](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] Я додав медіа, **АБО** цей запит на злиття не потребує медіа.
<!-- Ви повинні розуміти, що недотримування пунктів вище може бути підставою для закриття вашого запиту. -->

## Зміни, що порушують сумісність
<!-- Перелічте усі зміни, які порушують сумісність (зміни публічних класів, методів, перейменування прототипів, тощо) та надайте інструкції для їх виправлення. -->

Баланс: Щит має один спільний заряд (40). В активному стані витрачає 0.5/с, поглинання шкоди знімає заряд 1:1. При вичерпанні — ламається і стає недоступним на 12 секунд. Заряд відновлюється лише коли щит вимкнено (0.5/с, ~80 с до повного). Костюми зі щитами отримали -10% броні: зі щитом вони помітно міцніші в коротких перестрілках, без щита — трохи слабші за колишній варіант. Також на щити не впливає ЕМП, оскільки їх заряд не залежить від батарейок. 

**Журнал змін**
<!-- Додайте запис до журналу змін, аби гравці знали про нові функції або зміни, які впливають на геймплей.
Обов'язково прочитайте правила та винесіть цей шаблон з блоку коментарів, аби він став видимим.
Запис обов'язково має містити символ :cl:, аби бот міг розпізнати зміни та автоматично додав їх до гри.
Прибирати цей коментар не обов'язково, проте, якщо ви хочете аби ваші зміни були у журналі змін - розкоментуйте блок нижче.-->
:cl:
- add: Додано нову систему персональних енергетичних щитів для костюмів. Щит утворює навколо власника купол, що поглинає шкоду, ламається після вичерпання заряду та перезаряджається лише у вимкненому стані.
- add: Щити встановлено на топові костюми: Дредноут та Juggernaut Cybersun, елітний і командирський костюми Синдикату, рейдерський костюм, костюм Блющита, експериментальний костюм ГСБ, NTX5-Mirrorduss, костюми ЕРТ та Загону смерті, костюм чарівника й костюм Хроно-легіонера.
- add: Колір щита відповідає фракції костюма.
- add: Щит вмикається через альтернативну взаємодію (alt-click) або верб перемикання.
- add: Щит витрачає заряд двома шляхами: 0.5 заряду на секунду в активному стані та 1 заряд за кожну одиницю поглинутої шкоди.
- add: Перезарядка щита триває ~80 секунд і відбувається лише у вимкненому стані.
- tweak: Броню костюмів зі щитами знижено приблизно на 10% — без щита костюм трохи слабший за колишній, зі щитом — міцніший.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Нові функції**
  * Додано персональні енергетичні щити для бронекостюмів із зарядом, регенерацією, активацією, вимкненням і відновленням після руйнування.
  * Щити відображаються як процедурні кольорові оболонки з ефектами формування, мерехтіння та руйнування.
  * Додано перегляд поточного стану й заряду щита.

* **Покращення**
  * Предмети з перемиканням можна активувати альтернативною дією, зокрема через Alt-клік.
  * Персональні щити додано до широкого набору бойових костюмів із різними кольорами та параметрами.
  * Оновлено характеристики захисту деяких бронекостюмів.

* **Локалізація**
  * Додано повідомлення про стани й перемикання щита українською та англійською мовами.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->