### PR TITLE
ghost is kill

### DIFF
--- a/Content.Pirate.Client/CustomGhostSpriteSystem/CustomGhostVisualizer.cs
+++ b/Content.Pirate.Client/CustomGhostSpriteSystem/CustomGhostVisualizer.cs
@@ -1,4 +1,4 @@
-using Content.Client.Ghost;
+using System.Numerics;
 using Content.Shared.Ghost;
 using Content.Pirate.Shared.CustomGhostSystem;
 using Robust.Client.GameObjects;
@@ -25,7 +25,6 @@ public sealed class CustomGhostVisualizer : VisualizerSystem<GhostComponent>
                 try
                 {
                     args.Sprite.LayerSetState(0, state);
-                    return;
                 }
                 catch
                 {
@@ -43,14 +42,20 @@ public sealed class CustomGhostVisualizer : VisualizerSystem<GhostComponent>
                             }
                         }
                     }
-                    return;
                 }
             }
             else
             {
                 args.Sprite.LayerSetRSI(0, spriteData);
-                return;
             }
+
+            if (!AppearanceSystem.TryGetData<float>(uid, CustomGhostAppearance.Scale, out var scale, args.Component))
+                scale = 1f;
+
+            args.Sprite.LayerSetScale(0, new Vector2(scale, scale));
+
+            // Зберігаємо прозорість привида.
+            return;
         }
 
         if (AppearanceSystem.TryGetData<float>(uid, CustomGhostAppearance.AlphaOverride, out var alpha, args.Component))

--- a/Content.Pirate.Common/CCVar/CCVars.CustomGhost.cs
+++ b/Content.Pirate.Common/CCVar/CCVars.CustomGhost.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Pirate.Common.CCVar;
+
+public sealed partial class PirateCVars
+{
+    #region Custom ghosts
+
+    /// <summary>Maximum side of drawn content, in pixels; 0 removes the limit entirely.</summary>
+    public static readonly CVarDef<int> CustomGhostMaxSize =
+        CVarDef.Create("pirate.custom_ghost_max_size", 28, CVar.SERVERONLY);
+
+    #endregion
+}

--- a/Content.Pirate.Server/CustomGhostSpriteSystem/CustomGhostSpriteSystem.cs
+++ b/Content.Pirate.Server/CustomGhostSpriteSystem/CustomGhostSpriteSystem.cs
@@ -1,7 +1,10 @@
 using Content.Server.Ghost.Components;
 using Content.Shared.Ghost;
 using Content.Pirate.Shared.CustomGhostSystem;
+using Content.Pirate.Common.CCVar;
 using Robust.Server.GameObjects;
+using Robust.Shared.Configuration;
+using Robust.Shared.ContentPack;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
@@ -12,12 +15,29 @@ public sealed class CustomGhostSpriteSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
+    [Dependency] private readonly IResourceManager _resourceManager = default!;
+    [Dependency] private readonly IConfigurationManager _configuration = default!;
+    [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
 
+    private GhostSpriteMeasurer _measurer = default!;
 
     public override void Initialize()
     {
         base.Initialize();
+        _measurer = new GhostSpriteMeasurer(_resourceManager);
         SubscribeLocalEvent<PlayerAttachedEvent>(OnPlayerAttached);
+        Subs.CVar(_configuration, PirateCVars.CustomGhostMaxSize, OnMaxSizeChanged);
+    }
+
+    private void OnMaxSizeChanged(int value)
+    {
+        foreach (var session in _playerManager.Sessions)
+        {
+            if (session.AttachedEntity is not { } uid || !HasComp<GhostComponent>(uid))
+                continue;
+
+            TrySetCustomSprite(uid, session.Name);
+        }
     }
 
     private void OnPlayerAttached(PlayerAttachedEvent args)
@@ -29,7 +49,7 @@ public sealed class CustomGhostSpriteSystem : EntitySystem
     }
 
 
-    public void TrySetCustomSprite(EntityUid ghostUid, string ckey)
+    public bool TrySetCustomSprite(EntityUid ghostUid, string ckey)
     {
         var prototypes = _prototypeManager.EnumeratePrototypes<CustomGhostPrototype>();
 
@@ -100,6 +120,14 @@ public sealed class CustomGhostSpriteSystem : EntitySystem
                     CustomGhostAppearance.Sprite,
                     spriteData);
 
+                _appearanceSystem.SetData(ghostUid,
+                    CustomGhostAppearance.Scale,
+                    _measurer.GetScale(
+                        chosenRsi,
+                        chosenState,
+                        customGhostPrototype.MaxSize,
+                        _configuration.GetCVar(PirateCVars.CustomGhostMaxSize)));
+
                 if (customGhostPrototype.AlphaOverride > 0)
                 {
                     _appearanceSystem.SetData(ghostUid,
@@ -119,8 +147,10 @@ public sealed class CustomGhostSpriteSystem : EntitySystem
                     // MetaData(ghostUid).EntityDescription = customGhostPrototype.GhostDescription;
                 }
 
-                return;
+                return true;
             }
         }
+
+        return false;
     }
 }

--- a/Content.Pirate.Server/CustomGhostSpriteSystem/GhostSpriteMeasurer.cs
+++ b/Content.Pirate.Server/CustomGhostSpriteSystem/GhostSpriteMeasurer.cs
@@ -1,0 +1,189 @@
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Robust.Shared.ContentPack;
+using Robust.Shared.Utility;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Content.Pirate.Server.CustomGhostSpriteSystem;
+
+public sealed class GhostSpriteMeasurer
+{
+    private static readonly ResPath TextureRoot = new("/Textures");
+
+    private readonly IResourceManager _resourceManager;
+
+    private readonly Dictionary<(string Rsi, string? State), int> _contentEdges = new();
+    private readonly Dictionary<string, RsiMeta?> _metas = new();
+
+    public GhostSpriteMeasurer(IResourceManager resourceManager)
+    {
+        _resourceManager = resourceManager;
+    }
+
+    public float GetScale(ResPath rsi, string? state, float maxSize, int maxSquare)
+    {
+        if (maxSize <= 0f || maxSquare <= 0)
+            return 1f;
+
+        var limit = maxSquare * maxSize;
+        float actual;
+
+        if (TryGetContentEdge(rsi, state, out var contentEdge))
+        {
+            actual = contentEdge;
+        }
+        else if (TryGetMeta(rsi) is { } meta)
+        {
+            // Якщо пікселі недоступні, використовуємо розмір кадру RSI.
+            actual = Math.Max(meta.Width, meta.Height);
+        }
+        else
+        {
+            return 1f;
+        }
+
+        if (actual <= 0f || actual <= limit)
+            return 1f;
+
+        return limit / actual;
+    }
+
+    private bool TryGetContentEdge(ResPath rsi, string? state, out int edge)
+    {
+        var key = (rsi.ToString(), state);
+        if (_contentEdges.TryGetValue(key, out edge))
+            return edge > 0;
+
+        edge = 0;
+
+        if (TryGetMeta(rsi) is not { } meta || meta.Width <= 0 || meta.Height <= 0)
+        {
+            _contentEdges[key] = 0;
+            return false;
+        }
+
+        var frameWidth = meta.Width;
+        var frameHeight = meta.Height;
+        var states = state != null ? new[] { state } : meta.States;
+
+        var maxWidth = 0;
+        var maxHeight = 0;
+
+        foreach (var stateName in states)
+        {
+            MeasureFile(TextureRoot / rsi / $"{stateName}.png", frameWidth, frameHeight, ref maxWidth, ref maxHeight);
+        }
+
+        // У зібраних збірках RSI може бути атласом .rsic.
+        if (maxWidth == 0 && maxHeight == 0)
+            MeasureFile((TextureRoot / rsi).WithExtension("rsic"), frameWidth, frameHeight, ref maxWidth, ref maxHeight);
+
+        edge = Math.Max(maxWidth, maxHeight);
+        _contentEdges[key] = edge;
+        return edge > 0;
+    }
+
+    private void MeasureFile(ResPath path, int frameWidth, int frameHeight, ref int maxWidth, ref int maxHeight)
+    {
+        if (!_resourceManager.ContentFileExists(path))
+            return;
+
+        try
+        {
+            using var stream = _resourceManager.ContentFileRead(path);
+            using var image = Image.Load<Rgba32>(stream);
+            MeasureSheet(image, frameWidth, frameHeight, ref maxWidth, ref maxHeight);
+        }
+        catch (Exception)
+        {
+        }
+    }
+
+    private static void MeasureSheet(Image<Rgba32> image, int frameWidth, int frameHeight, ref int maxWidth, ref int maxHeight)
+    {
+        var columns = image.Width / frameWidth;
+        var rows = image.Height / frameHeight;
+
+        for (var row = 0; row < rows; row++)
+        {
+            for (var column = 0; column < columns; column++)
+            {
+                var left = int.MaxValue;
+                var right = -1;
+                var top = int.MaxValue;
+                var bottom = -1;
+
+                for (var y = 0; y < frameHeight; y++)
+                {
+                    for (var x = 0; x < frameWidth; x++)
+                    {
+                        if (image[column * frameWidth + x, row * frameHeight + y].A == 0)
+                            continue;
+
+                        if (x < left)
+                            left = x;
+                        if (x > right)
+                            right = x;
+                        if (y < top)
+                            top = y;
+                        if (y > bottom)
+                            bottom = y;
+                    }
+                }
+
+                if (right < 0)
+                    continue;
+
+                maxWidth = Math.Max(maxWidth, right - left + 1);
+                maxHeight = Math.Max(maxHeight, bottom - top + 1);
+            }
+        }
+    }
+
+    private RsiMeta? TryGetMeta(ResPath rsi)
+    {
+        var key = rsi.ToString();
+        if (_metas.TryGetValue(key, out var cached))
+            return cached;
+
+        RsiMeta? meta = null;
+
+        try
+        {
+            var path = TextureRoot / rsi / "meta.json";
+            if (_resourceManager.ContentFileExists(path))
+            {
+                using var stream = _resourceManager.ContentFileRead(path);
+                using var document = JsonDocument.Parse(stream);
+                var root = document.RootElement;
+
+                if (root.TryGetProperty("size", out var size)
+                    && size.TryGetProperty("x", out var x)
+                    && size.TryGetProperty("y", out var y))
+                {
+                    var states = root.TryGetProperty("states", out var statesElement)
+                                 && statesElement.ValueKind == JsonValueKind.Array
+                        ? statesElement.EnumerateArray()
+                            .Where(e => e.ValueKind == JsonValueKind.Object && e.TryGetProperty("name", out _))
+                            .Select(e => e.GetProperty("name").GetString())
+                            .Where(s => !string.IsNullOrEmpty(s))
+                            .Select(s => s!)
+                            .ToArray()
+                        : Array.Empty<string>();
+
+                    meta = new RsiMeta(x.GetInt32(), y.GetInt32(), states);
+                }
+            }
+        }
+        catch (Exception)
+        {
+        }
+
+        _metas[key] = meta;
+        return meta;
+    }
+
+    private sealed record RsiMeta(int Width, int Height, string[] States);
+}

--- a/Content.Pirate.Shared/CustomGhostSystem/CustomGhostPrototype.cs
+++ b/Content.Pirate.Shared/CustomGhostSystem/CustomGhostPrototype.cs
@@ -24,6 +24,10 @@ public sealed partial class CustomGhostPrototype : IPrototype
     [DataField("alpha")]
     public float AlphaOverride { get; set; } = -1;
 
+    /// <summary>Multiplier for the server-wide pixel limit; 0 disables it.</summary>
+    [DataField("maxSize")]
+    public float MaxSize { get; set; } = 1f;
+
     [DataField("ghostName")]
     public string GhostName = string.Empty;
 
@@ -35,5 +39,6 @@ public sealed partial class CustomGhostPrototype : IPrototype
 public enum CustomGhostAppearance
 {
     Sprite,
-    AlphaOverride
+    AlphaOverride,
+    Scale
 }


### PR DESCRIPTION
## Чому / Баланс
Дістали літаючі фанери на 5x3 тайлів, які перекривають половину екрана. Для контексту, розмір дефолт госта - 17x23, найбільші кастомні гости займають - 100x80, 100x100, 100x137

## Зміни, що порушують сумісність

**Журнал змін**
:cl:
- add: кастомні гости стискаються до розміру в 28x28 підкселів (можна підтюнити через sudo cvar pirate.custom_ghost_max_size). Більше ніяких фанер на пів екрана


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Додано автоматичне масштабування користувацьких спрайтів привидів відповідно до їхнього фактичного розміру.
  * Додано налаштування максимального розміру спрайтів; значення `0` вимикає обмеження.
  * Додано індивідуальний множник максимального розміру для прототипів привидів.
  * Зміна обмеження автоматично оновлює активні спрайти привидів.
  * Некоректні або недоступні ресурси тепер пропускаються без переривання обробки.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->