### PR TITLE
Port DeltaV fugitive ghost role

### DIFF
--- a/Content.Server/_Pirate/StationEvents/Components/FugitiveRuleComponent.cs
+++ b/Content.Server/_Pirate/StationEvents/Components/FugitiveRuleComponent.cs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server._Pirate.StationEvents.GameRules;
+using Content.Shared.Dataset;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Server._Pirate.StationEvents.Components;
+
+/// <summary>
+/// Announces a fugitive and delivers their warrant after a delay.
+/// </summary>
+[RegisterComponent, Access(typeof(FugitiveRule))]
+[AutoGenerateComponentPause]
+public sealed partial class FugitiveRuleComponent : Component
+{
+    [DataField]
+    public LocId Announcement = "station-event-fugitive-hunt-announcement";
+
+    [DataField]
+    public LocId Sender = "fugitive-announcement-GALPOL";
+
+    [DataField]
+    public Color Color = Color.Yellow;
+
+    [DataField]
+    public EntProtoId ReportPaper = "PaperFugitiveReport";
+
+    [DataField]
+    public TimeSpan AnnounceDelay = TimeSpan.FromMinutes(5);
+
+    [DataField]
+    public EntityUid? Station;
+
+    [DataField]
+    public string Report = string.Empty;
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
+    public TimeSpan? NextAnnounce;
+
+    [DataField]
+    public ProtoId<LocalizedDatasetPrototype> CrimesDataset = "FugitiveCrimes";
+
+    [DataField]
+    public int MinCrimes = 2;
+
+    [DataField]
+    public int MaxCrimes = 7;
+
+    [DataField]
+    public int MinCounts = 1;
+
+    [DataField]
+    public int MaxCounts = 4;
+}

--- a/Content.Server/_Pirate/StationEvents/GameRules/FugitiveRule.cs
+++ b/Content.Server/_Pirate/StationEvents/GameRules/FugitiveRule.cs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server._Pirate.StationEvents.Components;
+using Content.Server.Antag;
+using Content.Server.Communications;
+using Content.Server.StationEvents.Events;
+using Content.Shared.Forensics.Components;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Ghost;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Humanoid;
+using Content.Shared.Inventory;
+using Content.Shared.Paper;
+using Content.Shared.Popups;
+using Content.Shared.Random.Helpers;
+using Content.Shared.Silicons.StationAi;
+using Content.Shared.Storage.EntitySystems;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Utility;
+
+namespace Content.Server._Pirate.StationEvents.GameRules;
+
+public sealed class FugitiveRule : StationEventSystem<FugitiveRuleComponent>
+{
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly PaperSystem _paper = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedStorageSystem _storage = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<FugitiveRuleComponent, AfterAntagEntitySelectedEvent>(OnEntitySelected);
+    }
+
+    protected override void ActiveTick(EntityUid uid, FugitiveRuleComponent comp, GameRuleComponent rule, float frameTime)
+    {
+        if (comp.NextAnnounce is not { } next || next > Timing.CurTime)
+            return;
+
+        var announcement = Loc.GetString(comp.Announcement);
+        var sender = Loc.GetString(comp.Sender);
+        ChatSystem.DispatchGlobalAnnouncement(announcement, sender: sender, colorOverride: comp.Color);
+
+        var query = EntityQueryEnumerator<TransformComponent, CommunicationsConsoleComponent>();
+        var consoles = new List<TransformComponent>();
+        while (query.MoveNext(out var console, out var xform, out _))
+        {
+            if (StationSystem.GetOwningStation(console, xform) != comp.Station ||
+                HasComp<GhostComponent>(console) ||
+                HasComp<StationAiHeldComponent>(console))
+            {
+                continue;
+            }
+
+            consoles.Add(xform);
+        }
+
+        foreach (var xform in consoles)
+        {
+            SpawnReport(comp, xform);
+        }
+
+        comp.NextAnnounce = null;
+        RemCompDeferred(uid, comp);
+    }
+
+    private void OnEntitySelected(Entity<FugitiveRuleComponent> ent, ref AfterAntagEntitySelectedEvent args)
+    {
+        var (uid, comp) = ent;
+        if (comp.NextAnnounce != null)
+        {
+            Log.Error("Fugitive rule spawning multiple fugitives is not supported.");
+            return;
+        }
+
+        var fugitive = args.EntityUid;
+        comp.Report = GenerateReport(fugitive, comp).ToMarkup();
+        comp.Station = StationSystem.GetOwningStation(fugitive);
+        comp.NextAnnounce = Timing.CurTime + comp.AnnounceDelay;
+
+        _popup.PopupEntity(Loc.GetString("fugitive-spawn"), fugitive, fugitive);
+
+        var report = SpawnReport(comp, Transform(fugitive));
+        if (_inventory.TryGetSlotEntity(fugitive, "back", out var backpack))
+            _storage.Insert(backpack.Value, report, out _, playSound: false);
+        else
+            _hands.TryPickup(fugitive, report);
+    }
+
+    private Entity<PaperComponent> SpawnReport(FugitiveRuleComponent rule, TransformComponent xform)
+    {
+        var report = Spawn(rule.ReportPaper, xform.Coordinates);
+        var paper = Comp<PaperComponent>(report);
+        var entity = (report, paper);
+        _paper.SetContent(entity, rule.Report);
+        return entity;
+    }
+
+    private FormattedMessage GenerateReport(EntityUid uid, FugitiveRuleComponent rule)
+    {
+        var report = new FormattedMessage();
+        report.AddMarkupOrThrow(Loc.GetString("fugitive-report-title"));
+        report.PushNewline();
+        report.PushNewline();
+        report.AddMarkupOrThrow(Loc.GetString("fugitive-report-first-line"));
+        report.PushNewline();
+        report.PushNewline();
+
+        if (!TryComp<HumanoidAppearanceComponent>(uid, out var humanoid))
+        {
+            report.AddMarkupOrThrow(Loc.GetString("fugitive-report-inhuman", ("name", uid)));
+            return report;
+        }
+
+        var species = PrototypeManager.Index(humanoid.Species);
+        report.AddMarkupOrThrow(Loc.GetString("fugitive-report-morphotype", ("species", Loc.GetString(species.Name))));
+        report.PushNewline();
+        report.AddMarkupOrThrow(Loc.GetString("fugitive-report-age", ("age", humanoid.Age)));
+        report.PushNewline();
+        report.AddMarkupOrThrow(Loc.GetString("fugitive-report-sex", ("sex", humanoid.Sex.ToString())));
+        report.PushNewline();
+
+        if (TryComp<PhysicsComponent>(uid, out var physics))
+        {
+            report.AddMarkupOrThrow(Loc.GetString("fugitive-report-weight", ("weight", Math.Round(physics.FixturesMass))));
+            report.PushNewline();
+        }
+
+        report.AddMarkupOrThrow(RobustRandom.Next(0, 2) switch
+        {
+            0 => Loc.GetString("fugitive-report-detail-dna", ("dna", GetDna(uid))),
+            _ => Loc.GetString("fugitive-report-detail-prints", ("prints", GetPrints(uid))),
+        });
+        report.PushNewline();
+        report.PushNewline();
+        report.AddMarkupOrThrow(Loc.GetString("fugitive-report-crimes-header"));
+        report.PushNewline();
+        AddCharges(report, rule);
+        report.PushNewline();
+        report.AddMarkupOrThrow(Loc.GetString("fugitive-report-last-line"));
+
+        return report;
+    }
+
+    private string GetDna(EntityUid uid)
+    {
+        return CompOrNull<DnaComponent>(uid)?.DNA ?? "?";
+    }
+
+    private string GetPrints(EntityUid uid)
+    {
+        return CompOrNull<FingerprintComponent>(uid)?.Fingerprint ?? "?";
+    }
+
+    private void AddCharges(FormattedMessage report, FugitiveRuleComponent rule)
+    {
+        var crimeTypes = PrototypeManager.Index(rule.CrimesDataset);
+        var crimes = new HashSet<LocId>();
+        var total = RobustRandom.Next(rule.MinCrimes, rule.MaxCrimes + 1);
+        while (crimes.Count < total)
+        {
+            crimes.Add(RobustRandom.Pick(crimeTypes));
+        }
+
+        foreach (var crime in crimes)
+        {
+            var count = RobustRandom.Next(rule.MinCounts, rule.MaxCounts + 1);
+            report.AddMarkupOrThrow(Loc.GetString("fugitive-report-crime", ("crime", Loc.GetString(crime)), ("count", count)));
+            report.PushNewline();
+        }
+    }
+}

--- a/Content.Shared/_Pirate/Roles/Components/FugitiveRoleComponent.cs
+++ b/Content.Shared/_Pirate/Roles/Components/FugitiveRoleComponent.cs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Roles.Components;
+
+namespace Content.Shared._Pirate.Roles.Components;
+
+[RegisterComponent]
+public sealed partial class FugitiveRoleComponent : BaseMindRoleComponent;

--- a/Resources/Locale/en-US/_DV/fugitive/fugitive.ftl
+++ b/Resources/Locale/en-US/_DV/fugitive/fugitive.ftl
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+roles-antag-fugitive-name = Fugitive
+roles-antag-fugitive-objective = Stay on the run for your crimes.
+role-subtype-fugitive = Fugitive
+
+ghost-role-information-fugitive-name = Fugitive
+ghost-role-information-fugitive-description = You are an escaped prisoner. Make it out alive.
+ghost-role-information-fugitive-rules = You are a light solo antagonist. Focus on laying low and escaping rather than directly engaging Security. Do not murderbone.
+fugitive-spawn-point-name = fugitive spawn point
+
+fugitive-round-end-agent-name = Fugitive
+fugitive-spawn = You fall from the ceiling!
+
+station-event-fugitive-hunt-announcement = Please check communications consoles for a sensitive message.
+fugitive-announcement-GALPOL = GALPOL
+
+fugitive-report-title = WANTED FUGITIVE!
+fugitive-report-first-line = An escaped fugitive has been spotted in the sector and disguised their identity. They may be a stowaway on a station somewhere.
+fugitive-report-inhuman = {CAPITALIZE(THE($name))} {CONJUGATE-BE($name)} inhuman. We have no further details.
+fugitive-report-morphotype = MORPHOTYPE: {$species}
+fugitive-report-age = AGE: {$age}
+fugitive-report-sex = SEX: {$sex ->
+    [Male] M
+    [Female] F
+    *[none] N/A
+}
+fugitive-report-weight = WEIGHT: {$weight} kg
+fugitive-report-detail-dna = DNA: {$dna}
+fugitive-report-detail-prints = FINGERPRINT: {$prints}
+fugitive-report-crimes-header = The above individual is wanted across the sector for the following:
+fugitive-report-crime = - {$count ->
+    [1] One count
+    *[other] {$count} counts
+} of {$crime}
+fugitive-report-last-line = GALPOL is entrusting Nanotrasen with securing this individual and conducting a trial at Central Command. Please ensure they are kept alive and brought to Central Command.
+
+fugitive-crime-1 = Murder
+fugitive-crime-2 = Terrorism
+fugitive-crime-3 = Grand Sabotage
+fugitive-crime-4 = Prevention of Revival
+fugitive-crime-5 = Sedition
+fugitive-crime-6 = Breach of Custody
+fugitive-crime-7 = Manslaughter
+fugitive-crime-8 = Kidnapping
+fugitive-crime-9 = Grand Possession
+fugitive-crime-10 = Noöspheric Tampering
+fugitive-crime-11 = Sabotage
+fugitive-crime-12 = Abuse of Power
+fugitive-crime-13 = Grand Larceny
+fugitive-crime-14 = Black Marketeering
+fugitive-crime-15 = Assault
+fugitive-crime-16 = Breaking and Entering
+fugitive-crime-17 = Rioting
+fugitive-crime-18 = Endangerment
+fugitive-crime-19 = Possession
+fugitive-crime-20 = Obstruction of Justice
+fugitive-crime-21 = Perjury
+fugitive-crime-22 = False Report
+fugitive-crime-23 = Contempt of Court
+fugitive-crime-24 = Identity Theft
+
+objective-condition-fugitive-escape-title = Evade law enforcement
+objective-condition-fugitive-escape-description = You will never atone for your crimes. Blend into the crowd and escape on the evacuation shuttle.
+
+fugitive-stash-name = fugitive's stash
+fugitive-stash-description = These supplies got you out of jail and hopefully they will keep you out of it.
+fugitive-stash-window-title = Fugitive Stash
+fugitive-stash-window-description = Choose {$maxCount} kit to help you elude the authorities. The choice is final.
+
+fugitive-set-hitman-name = hitman's kit
+fugitive-set-hitman-description = A loaded Viper, a spare magazine, and a brown briefcase for armed self-defense.
+fugitive-set-saboteur-name = saboteur's kit
+fugitive-set-saboteur-description = Two EMP grenades, a brick of C4, and a gas mask for sabotage.
+fugitive-set-ghost-name = ghost's kit
+fugitive-set-ghost-description = Two smoke grenades, a Scram implanter, and a ghost sheet for disappearing during a chase.
+fugitive-set-leverage-name = leverage kit
+fugitive-set-leverage-description = Handcuffs, a bola, and a death acidifier implanter for turning a pursuer into leverage.
+fugitive-set-infiltrator-name = infiltrator's kit
+fugitive-set-infiltrator-description = An Agent ID, a freedom implanter, and a Syndicate gas mask for changing identity and access.
+fugitive-set-disruptor-name = disruptor's kit
+fugitive-set-disruptor-description = A cryptographic sequencer and a camera bug for compromising station systems.
+
+fugitive-report-paper-name = fugitive report
+fugitive-report-paper-description = An arrest warrant for a space fugitive sent from GALPOL.
+fugitive-galpol-stamp-name = GALPOL rubber stamp
+fugitive-galpol-stamp-description = A rubber stamp for important documents concerning intergalactic security affairs.
+stamp-component-stamped-name-GALPOL = GALPOL

--- a/Resources/Locale/en-US/_DV/fugitive/fugitive.ftl
+++ b/Resources/Locale/en-US/_DV/fugitive/fugitive.ftl
@@ -7,7 +7,7 @@ role-subtype-fugitive = Fugitive
 ghost-role-information-fugitive-name = Fugitive
 ghost-role-information-fugitive-description = You are an escaped prisoner. Make it out alive.
 ghost-role-information-fugitive-rules = You are a light solo antagonist. Focus on laying low and escaping rather than directly engaging Security. Do not murderbone.
-fugitive-spawn-point-name = fugitive spawn point
+ent-SpawnPointGhostFugitive = fugitive spawn point
 
 fugitive-round-end-agent-name = Fugitive
 fugitive-spawn = You fall from the ceiling!
@@ -60,11 +60,11 @@ fugitive-crime-22 = False Report
 fugitive-crime-23 = Contempt of Court
 fugitive-crime-24 = Identity Theft
 
-objective-condition-fugitive-escape-title = Evade law enforcement
-objective-condition-fugitive-escape-description = You will never atone for your crimes. Blend into the crowd and escape on the evacuation shuttle.
+ent-FugitiveEscapeObjective = Evade law enforcement
+    .desc = You will never atone for your crimes. Blend into the crowd and escape on the evacuation shuttle.
 
-fugitive-stash-name = fugitive's stash
-fugitive-stash-description = These supplies got you out of jail and hopefully they will keep you out of it.
+ent-FugitiveStash = fugitive's stash
+    .desc = These supplies got you out of jail and hopefully they will keep you out of it.
 fugitive-stash-window-title = Fugitive Stash
 fugitive-stash-window-description = Choose {$maxCount} kit to help you elude the authorities. The choice is final.
 
@@ -81,8 +81,8 @@ fugitive-set-infiltrator-description = An Agent ID, a freedom implanter, and a S
 fugitive-set-disruptor-name = disruptor's kit
 fugitive-set-disruptor-description = A cryptographic sequencer and a camera bug for compromising station systems.
 
-fugitive-report-paper-name = fugitive report
-fugitive-report-paper-description = An arrest warrant for a space fugitive sent from GALPOL.
-fugitive-galpol-stamp-name = GALPOL rubber stamp
-fugitive-galpol-stamp-description = A rubber stamp for important documents concerning intergalactic security affairs.
+ent-PaperFugitiveReport = fugitive report
+    .desc = An arrest warrant for a space fugitive sent from GALPOL.
+ent-RubberStampGalpol = GALPOL rubber stamp
+    .desc = A rubber stamp for important documents concerning intergalactic security affairs.
 stamp-component-stamped-name-GALPOL = GALPOL

--- a/Resources/Locale/en-US/_DV/fugitive/fugitive.ftl
+++ b/Resources/Locale/en-US/_DV/fugitive/fugitive.ftl
@@ -65,8 +65,6 @@ ent-FugitiveEscapeObjective = Evade law enforcement
 
 ent-FugitiveStash = fugitive's stash
     .desc = These supplies got you out of jail and hopefully they will keep you out of it.
-fugitive-stash-window-title = Fugitive Stash
-fugitive-stash-window-description = Choose {$maxCount} kit to help you elude the authorities. The choice is final.
 
 fugitive-set-hitman-name = hitman's kit
 fugitive-set-hitman-description = A loaded Viper, a spare magazine, and a brown briefcase for armed self-defense.

--- a/Resources/Locale/uk-UA/_Pirate/fugitive/fugitive.ftl
+++ b/Resources/Locale/uk-UA/_Pirate/fugitive/fugitive.ftl
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+roles-antag-fugitive-name = Утікач
+roles-antag-fugitive-objective = Залишайтеся на волі попри свої злочини.
+role-subtype-fugitive = Утікач
+
+ghost-role-information-fugitive-name = Утікач
+ghost-role-information-fugitive-description = Ви втекли з в'язниці. Виберіться звідси живим.
+ghost-role-information-fugitive-rules = Ви легкий антагоніст-одинак. Переховуйтеся й уникайте Служби Безпеки, а не атакуйте її безпосередньо. Не влаштовуйте безпричинної різанини.
+fugitive-spawn-point-name = точка появи Утікача
+
+fugitive-round-end-agent-name = Утікач
+fugitive-spawn = Ви падаєте зі стелі!
+
+station-event-fugitive-hunt-announcement = Перевірте комунікаційні консолі: надійшло конфіденційне повідомлення.
+fugitive-announcement-GALPOL = GALPOL
+
+fugitive-report-title = РОЗШУКУЄТЬСЯ ВТІКАЧ!
+fugitive-report-first-line = У секторі помічено втікача, який приховав свою особу. Він може переховуватися на одній зі станцій.
+fugitive-report-inhuman = {$name} не є гуманоїдом. Інших відомостей немає.
+fugitive-report-morphotype = МОРФОТИП: {$species}
+fugitive-report-age = ВІК: {$age}
+fugitive-report-sex = СТАТЬ: {$sex ->
+    [Male] Ч
+    [Female] Ж
+    *[none] Н/Д
+}
+fugitive-report-weight = МАСА: {$weight} кг
+fugitive-report-detail-dna = ДНК: {$dna}
+fugitive-report-detail-prints = ВІДБИТКИ ПАЛЬЦІВ: {$prints}
+fugitive-report-crimes-header = Цю особу розшукують у всьому секторі за такі злочини:
+fugitive-report-crime = - {$count ->
+    [1] Один епізод
+    *[other] {$count} епізодів
+} за статтею «{$crime}»
+fugitive-report-last-line = GALPOL доручає Nanotrasen затримати цю особу й доправити її на суд до Центрального Командування. Забезпечте доставлення втікача живим.
+
+fugitive-crime-1 = Вбивство
+fugitive-crime-2 = Тероризм
+fugitive-crime-3 = Тяжкий саботаж
+fugitive-crime-4 = Перешкоджання відродженню
+fugitive-crime-5 = Заколот
+fugitive-crime-6 = Втеча з-під варти
+fugitive-crime-7 = Ненавмисне вбивство
+fugitive-crime-8 = Викрадення
+fugitive-crime-9 = Зберігання великої кількості контрабанди
+fugitive-crime-10 = Ноосферне втручання
+fugitive-crime-11 = Саботаж
+fugitive-crime-12 = Зловживання владою
+fugitive-crime-13 = Крадіжка у великих розмірах
+fugitive-crime-14 = Торгівля на чорному ринку
+fugitive-crime-15 = Напад
+fugitive-crime-16 = Незаконне проникнення
+fugitive-crime-17 = Масові заворушення
+fugitive-crime-18 = Створення небезпеки
+fugitive-crime-19 = Незаконне зберігання
+fugitive-crime-20 = Перешкоджання правосуддю
+fugitive-crime-21 = Лжесвідчення
+fugitive-crime-22 = Неправдиве повідомлення
+fugitive-crime-23 = Неповага до суду
+fugitive-crime-24 = Викрадення особистості
+
+objective-condition-fugitive-escape-title = Уникайте правосуддя
+objective-condition-fugitive-escape-description = Змішайтеся з натовпом і живим покиньте станцію на евакуаційному шатлі.
+
+fugitive-stash-name = схованка Утікача
+fugitive-stash-description = Ці припаси допомогли вам утекти з в'язниці й мають допомогти залишитися на волі.
+fugitive-stash-window-title = Схованка Утікача
+fugitive-stash-window-description = Оберіть {$maxCount} комплект, який допоможе уникнути переслідування. Змінити вибір буде неможливо.
+
+fugitive-set-hitman-name = комплект кілера
+fugitive-set-hitman-description = Заряджений Viper, запасний магазин і коричнева валіза для озброєного самозахисту.
+fugitive-set-saboteur-name = комплект диверсанта
+fugitive-set-saboteur-description = Дві EMP-гранати, заряд C4 і протигаз для диверсій.
+fugitive-set-ghost-name = комплект привида
+fugitive-set-ghost-description = Дві димові гранати, Scram-імплантер і костюм-простирадло для зникнення під час погоні.
+fugitive-set-leverage-name = комплект важелів впливу
+fugitive-set-leverage-description = Двоє кайданків, бола й кислотний імплантер, щоб перетворити переслідувача на заручника.
+fugitive-set-infiltrator-name = комплект інфільтратора
+fugitive-set-infiltrator-description = Агентська ID-картка, імплантер свободи й протигаз Синдикату для зміни особи та доступів.
+fugitive-set-disruptor-name = комплект дестабілізатора
+fugitive-set-disruptor-description = Криптографічний секвенсор і пристрій підключення до камер для злому систем станції.
+
+fugitive-report-paper-name = орієнтування на Утікача
+fugitive-report-paper-description = Ордер на арешт космічного втікача, надісланий GALPOL.
+fugitive-galpol-stamp-name = печатка GALPOL
+fugitive-galpol-stamp-description = Печатка для важливих документів у справах міжгалактичної безпеки.
+stamp-component-stamped-name-GALPOL = GALPOL

--- a/Resources/Locale/uk-UA/_Pirate/fugitive/fugitive.ftl
+++ b/Resources/Locale/uk-UA/_Pirate/fugitive/fugitive.ftl
@@ -5,8 +5,8 @@ roles-antag-fugitive-objective = Залишайтеся на волі попри
 role-subtype-fugitive = Утікач
 
 ghost-role-information-fugitive-name = Утікач
-ghost-role-information-fugitive-description = Ви втекли з в'язниці. Виберіться звідси живим.
-ghost-role-information-fugitive-rules = Ви легкий антагоніст-одинак. Переховуйтеся й уникайте Служби Безпеки, а не атакуйте її безпосередньо. Не влаштовуйте безпричинної різанини.
+ghost-role-information-fugitive-description = Ви втекли з в'язниці. Утечіть звідси та виживіть.
+ghost-role-information-fugitive-rules = Ваша мета: переховуватися й уникати Служби Безпеки, а не атакувати її безпосередньо. Не влаштовуйте безпричинної різанини.
 fugitive-spawn-point-name = точка появи Утікача
 
 fugitive-round-end-agent-name = Утікач
@@ -16,7 +16,7 @@ station-event-fugitive-hunt-announcement = Перевірте комунікац
 fugitive-announcement-GALPOL = GALPOL
 
 fugitive-report-title = РОЗШУКУЄТЬСЯ ВТІКАЧ!
-fugitive-report-first-line = У секторі помічено втікача, який приховав свою особу. Він може переховуватися на одній зі станцій.
+fugitive-report-first-line = У секторі помічено особу, яка втекла та приховала свою ідентичність. Ця особа може переховуватися на одній зі станцій.
 fugitive-report-inhuman = {$name} не є гуманоїдом. Інших відомостей немає.
 fugitive-report-morphotype = МОРФОТИП: {$species}
 fugitive-report-age = ВІК: {$age}
@@ -33,7 +33,7 @@ fugitive-report-crime = - {$count ->
     [1] Один епізод
     *[other] {$count} епізодів
 } за статтею «{$crime}»
-fugitive-report-last-line = GALPOL доручає Nanotrasen затримати цю особу й доправити її на суд до Центрального Командування. Забезпечте доставлення втікача живим.
+fugitive-report-last-line = GALPOL доручає Nanotrasen затримати цю особу й доправити її на суд до Центрального Командування. Забезпечте затримання без летальних наслідків.
 
 fugitive-crime-1 = Вбивство
 fugitive-crime-2 = Тероризм
@@ -61,7 +61,7 @@ fugitive-crime-23 = Неповага до суду
 fugitive-crime-24 = Викрадення особистості
 
 objective-condition-fugitive-escape-title = Уникайте правосуддя
-objective-condition-fugitive-escape-description = Змішайтеся з натовпом і живим покиньте станцію на евакуаційному шатлі.
+objective-condition-fugitive-escape-description = Змішайтеся з натовпом, виживіть і покиньте станцію на евакуаційному шатлі.
 
 fugitive-stash-name = схованка Утікача
 fugitive-stash-description = Ці припаси допомогли вам утекти з в'язниці й мають допомогти залишитися на волі.

--- a/Resources/Locale/uk-UA/_Pirate/fugitive/fugitive.ftl
+++ b/Resources/Locale/uk-UA/_Pirate/fugitive/fugitive.ftl
@@ -7,7 +7,7 @@ role-subtype-fugitive = Утікач
 ghost-role-information-fugitive-name = Утікач
 ghost-role-information-fugitive-description = Ви втекли з в'язниці. Утечіть звідси та виживіть.
 ghost-role-information-fugitive-rules = Ваша мета: переховуватися й уникати Служби Безпеки, а не атакувати її безпосередньо. Не влаштовуйте безпричинної різанини.
-fugitive-spawn-point-name = точка появи Утікача
+ent-SpawnPointGhostFugitive = точка появи Утікача
 
 fugitive-round-end-agent-name = Утікач
 fugitive-spawn = Ви падаєте зі стелі!
@@ -60,11 +60,11 @@ fugitive-crime-22 = Неправдиве повідомлення
 fugitive-crime-23 = Неповага до суду
 fugitive-crime-24 = Викрадення особистості
 
-objective-condition-fugitive-escape-title = Уникайте правосуддя
-objective-condition-fugitive-escape-description = Змішайтеся з натовпом, виживіть і покиньте станцію на евакуаційному шатлі.
+ent-FugitiveEscapeObjective = Уникайте правосуддя
+    .desc = Змішайтеся з натовпом, виживіть і покиньте станцію на евакуаційному шатлі.
 
-fugitive-stash-name = схованка Утікача
-fugitive-stash-description = Ці припаси допомогли вам утекти з в'язниці й мають допомогти залишитися на волі.
+ent-FugitiveStash = схованка Утікача
+    .desc = Ці припаси допомогли вам утекти з в'язниці й мають допомогти залишитися на волі.
 fugitive-stash-window-title = Схованка Утікача
 fugitive-stash-window-description = Оберіть {$maxCount} комплект, який допоможе уникнути переслідування. Змінити вибір буде неможливо.
 
@@ -81,8 +81,8 @@ fugitive-set-infiltrator-description = Агентська ID-картка, ім�
 fugitive-set-disruptor-name = комплект дестабілізатора
 fugitive-set-disruptor-description = Криптографічний секвенсор і пристрій підключення до камер для злому систем станції.
 
-fugitive-report-paper-name = орієнтування на Утікача
-fugitive-report-paper-description = Ордер на арешт космічного втікача, надісланий GALPOL.
-fugitive-galpol-stamp-name = печатка GALPOL
-fugitive-galpol-stamp-description = Печатка для важливих документів у справах міжгалактичної безпеки.
+ent-PaperFugitiveReport = орієнтування на Утікача
+    .desc = Ордер на арешт космічного втікача, надісланий GALPOL.
+ent-RubberStampGalpol = печатка GALPOL
+    .desc = Печатка для важливих документів у справах міжгалактичної безпеки.
 stamp-component-stamped-name-GALPOL = GALPOL

--- a/Resources/Locale/uk-UA/_Pirate/fugitive/fugitive.ftl
+++ b/Resources/Locale/uk-UA/_Pirate/fugitive/fugitive.ftl
@@ -60,7 +60,7 @@ fugitive-crime-22 = Неправдиве повідомлення
 fugitive-crime-23 = Неповага до суду
 fugitive-crime-24 = Викрадення особистості
 
-ent-FugitiveEscapeObjective = Уникайте правосуддя
+ent-FugitiveEscapeObjective = Уникайте правоохоронців
     .desc = Змішайтеся з натовпом, виживіть і покиньте станцію на евакуаційному шатлі.
 
 ent-FugitiveStash = схованка Утікача

--- a/Resources/Locale/uk-UA/_Pirate/fugitive/fugitive.ftl
+++ b/Resources/Locale/uk-UA/_Pirate/fugitive/fugitive.ftl
@@ -65,8 +65,6 @@ ent-FugitiveEscapeObjective = Уникайте правосуддя
 
 ent-FugitiveStash = схованка Утікача
     .desc = Ці припаси допомогли вам утекти з в'язниці й мають допомогти залишитися на волі.
-fugitive-stash-window-title = Схованка Утікача
-fugitive-stash-window-description = Оберіть {$maxCount} комплект, який допоможе уникнути переслідування. Змінити вибір буде неможливо.
 
 fugitive-set-hitman-name = комплект кілера
 fugitive-set-hitman-description = Заряджений Viper, запасний магазин і коричнева валіза для озброєного самозахисту.

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -42,6 +42,7 @@
     children:
     - id: ClosetSkeleton
     - id: KingRatMigration
+    - id: Fugitive # Pirate
     - id: BorerSpawn # Pirate
     - id: ListeningPost # Pirate
     # - id: RevenantSpawn # Goob

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
@@ -30,8 +30,8 @@
 - type: entity
   parent: PaperStationWarrant
   id: PaperFugitiveReport
-  name: fugitive-report-paper-name
-  description: fugitive-report-paper-description
+  name: fugitive report # Pirate: entity localization uses the automatic ent-* keys.
+  description: An arrest warrant for a space fugitive sent from GALPOL.
   components: # Pirate: GALPOL warrants arrive prestamped.
   - type: Paper
     stampState: paper_stamp-centcom

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
@@ -37,7 +37,7 @@
     stampState: paper_stamp-centcom
     stampedBy:
     - stampedColor: "#3db010"
-      stampedName: GALPOL
+      stampedName: stamp-component-stamped-name-GALPOL
 
 - type: entity
   parent: Paper

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
@@ -30,8 +30,14 @@
 - type: entity
   parent: PaperStationWarrant
   id: PaperFugitiveReport
-  name: fugitive report
-  description: An arrest warrant for a space fugitive sent from GALPOL.
+  name: fugitive-report-paper-name
+  description: fugitive-report-paper-description
+  components: # Pirate: GALPOL warrants arrive prestamped.
+  - type: Paper
+    stampState: paper_stamp-centcom
+    stampedBy:
+    - stampedColor: "#3db010"
+      stampedName: GALPOL
 
 - type: entity
   parent: Paper

--- a/Resources/Prototypes/_Pirate/Fugitive/fugitive.yml
+++ b/Resources/Prototypes/_Pirate/Fugitive/fugitive.yml
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: antag
+  id: Fugitive
+  name: roles-antag-fugitive-name
+  antagonist: true
+  objective: roles-antag-fugitive-objective
+  requirements:
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 1h
+
+- type: entity
+  parent: BaseMindRoleAntag
+  id: MindRoleFugitive
+  name: Fugitive Role
+  components:
+  - type: MindRole
+    subtype: role-subtype-fugitive
+    antagPrototype: Fugitive
+    exclusiveAntag: true
+  - type: FugitiveRole
+
+- type: entity
+  categories: [ HideSpawnMenu, Spawner ]
+  parent: BaseAntagSpawner
+  id: SpawnPointGhostFugitive
+  name: fugitive-spawn-point-name
+  components:
+  - type: GhostRole
+    name: ghost-role-information-fugitive-name
+    description: ghost-role-information-fugitive-description
+    rules: ghost-role-information-fugitive-rules
+    mindRoles:
+    - MindRoleFugitive
+
+- type: startingGear
+  id: FugitiveGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitPrisoner
+    ears: ClothingHeadsetGrey
+    gloves: ClothingHandsGlovesColorYellow
+    back: ClothingBackpackSatchel
+    shoes: ClothingShoesChameleonNoSlips
+    id: PassengerPDA
+  inhand:
+  - ToolboxElectricalFilled
+  storage:
+    back:
+    - FugitiveStash
+
+- type: entity
+  abstract: true
+  parent: BaseObjective
+  id: BaseFugitiveObjective
+  components:
+  - type: Objective
+    issuer: objective-issuer-self
+    difficulty: 1
+  - type: RoleRequirement
+    roles:
+    - FugitiveRole
+
+- type: entity
+  parent: [ BaseFugitiveObjective, BaseLivingObjective ]
+  id: FugitiveEscapeObjective
+  name: objective-condition-fugitive-escape-title
+  description: objective-condition-fugitive-escape-description
+  components:
+  - type: Objective
+    icon:
+      sprite: Markers/jobs.rsi
+      state: prisoner
+  - type: EscapeShuttleCondition
+
+- type: entity
+  parent: ToolboxThief
+  id: FugitiveStash
+  name: fugitive-stash-name
+  description: fugitive-stash-description
+  components:
+  - type: ThiefUndeterminedBackpack
+    maxSelectedSets: 1
+    toolName: fugitive-stash-window-title
+    toolDesc: fugitive-stash-window-description
+    possibleSets:
+    - FugitiveHitman
+    - FugitiveSaboteur
+    - FugitiveGhost
+    - FugitiveLeverage
+    - FugitiveInfiltrator
+    - FugitiveDisruptor
+
+- type: thiefBackpackSet
+  id: FugitiveHitman
+  name: fugitive-set-hitman-name
+  description: fugitive-set-hitman-description
+  sprite:
+    sprite: Objects/Weapons/Guns/Pistols/viper.rsi
+    state: icon
+  content:
+  - WeaponPistolViper
+  - MagazinePistol
+  - BriefcaseBrown
+
+- type: thiefBackpackSet
+  id: FugitiveSaboteur
+  name: fugitive-set-saboteur-name
+  description: fugitive-set-saboteur-description
+  sprite:
+    sprite: Objects/Weapons/Grenades/empgrenade.rsi
+    state: icon
+  content:
+  - EmpGrenade
+  - EmpGrenade
+  - C4
+  - ClothingMaskGas
+
+- type: thiefBackpackSet
+  id: FugitiveGhost
+  name: fugitive-set-ghost-name
+  description: fugitive-set-ghost-description
+  sprite:
+    sprite: Objects/Weapons/Grenades/smoke.rsi
+    state: icon
+  content:
+  - SmokeGrenade
+  - SmokeGrenade
+  - ScramImplanter
+  - ClothingOuterGhostSheet
+
+- type: thiefBackpackSet
+  id: FugitiveLeverage
+  name: fugitive-set-leverage-name
+  description: fugitive-set-leverage-description
+  sprite:
+    sprite: Objects/Misc/handcuffs.rsi
+    state: handcuff
+  content:
+  - DeathAcidifierImplanter
+  - Handcuffs
+  - Handcuffs
+  - Bola
+
+- type: thiefBackpackSet
+  id: FugitiveInfiltrator
+  name: fugitive-set-infiltrator-name
+  description: fugitive-set-infiltrator-description
+  sprite:
+    entity: AgentIDCard
+  content:
+  - AgentIDCard
+  - FreedomImplanter
+  - ClothingMaskGasSyndicate
+
+- type: thiefBackpackSet
+  id: FugitiveDisruptor
+  name: fugitive-set-disruptor-name
+  description: fugitive-set-disruptor-description
+  sprite:
+    sprite: Objects/Tools/emag.rsi
+    state: icon
+  content:
+  - Emag
+  - CameraBug
+
+- type: localizedDataset
+  id: FugitiveCrimes
+  values:
+    prefix: fugitive-crime-
+    count: 24
+
+- type: entity
+  parent: BaseGameRule
+  id: Fugitive
+  components:
+  - type: GameRule
+    chaosScore: 100 # Pirate: required by the local chaos scheduler.
+  - type: StationEvent
+    weight: 7
+    reoccurrenceDelay: 5
+    minimumPlayers: 40
+    earliestStart: 25
+    duration: null
+    eventType: HostilesSpawn
+  - type: VentSpawnRule # Pirate: local equivalent of DeltaV's midround-antag spawn fallback.
+  # Pirate: PrecognitionResult is unavailable in the local psionics implementation.
+  - type: FugitiveRule
+  - type: AntagLoadProfileRule
+  - type: AntagObjectives
+    objectives:
+    - FugitiveEscapeObjective
+  - type: AntagSelection
+    selectionTime: PostPlayerSpawn
+    agentName: fugitive-round-end-agent-name
+    definitions:
+    - spawnerPrototype: SpawnPointGhostFugitive
+      min: 1
+      max: 1
+      pickPlayer: false
+      startingGear: FugitiveGear
+      roleLoadout:
+      - RoleSurvivalStandard
+      components:
+      - type: RandomMetadata
+        nameSegments:
+        - NamesFakeHumanFirst
+        - NamesFakeHumanLast
+        nameFormat: name-format-standard
+      - type: RandomHumanoidAppearance
+        randomizeName: false
+        # Pirate: the local component has no keepGender option.
+      - type: EmitSoundOnSpawn
+        sound: /Audio/Effects/clang.ogg
+      mindRoles:
+      - MindRoleFugitive
+  - type: Tag
+    tags:
+    - MidroundAntag
+
+- type: entity
+  name: fugitive-galpol-stamp-name
+  parent: RubberStampBase
+  id: RubberStampGalpol
+  categories: [ DoNotMap ]
+  description: fugitive-galpol-stamp-description
+  components:
+  - type: Stamp
+    stampedName: stamp-component-stamped-name-GALPOL
+    stampedColor: "#3db010"
+    stampState: paper_stamp-centcom
+  - type: Sprite
+    state: stamp-centcom

--- a/Resources/Prototypes/_Pirate/Fugitive/fugitive.yml
+++ b/Resources/Prototypes/_Pirate/Fugitive/fugitive.yml
@@ -79,10 +79,8 @@
   name: fugitive's stash
   description: These supplies got you out of jail and hopefully they will keep you out of it.
   components:
-  - type: ThiefUndeterminedBackpack
+  - type: SetSelector
     maxSelectedSets: 1
-    toolName: fugitive-stash-window-title
-    toolDesc: fugitive-stash-window-description
     possibleSets:
     - FugitiveHitman
     - FugitiveSaboteur
@@ -91,7 +89,7 @@
     - FugitiveInfiltrator
     - FugitiveDisruptor
 
-- type: thiefBackpackSet
+- type: selectableSet
   id: FugitiveHitman
   name: fugitive-set-hitman-name
   description: fugitive-set-hitman-description
@@ -103,7 +101,7 @@
   - MagazinePistol
   - BriefcaseBrown
 
-- type: thiefBackpackSet
+- type: selectableSet
   id: FugitiveSaboteur
   name: fugitive-set-saboteur-name
   description: fugitive-set-saboteur-description
@@ -116,7 +114,7 @@
   - C4
   - ClothingMaskGas
 
-- type: thiefBackpackSet
+- type: selectableSet
   id: FugitiveGhost
   name: fugitive-set-ghost-name
   description: fugitive-set-ghost-description
@@ -129,7 +127,7 @@
   - ScramImplanter
   - ClothingOuterGhostSheet
 
-- type: thiefBackpackSet
+- type: selectableSet
   id: FugitiveLeverage
   name: fugitive-set-leverage-name
   description: fugitive-set-leverage-description
@@ -142,7 +140,7 @@
   - Handcuffs
   - Bola
 
-- type: thiefBackpackSet
+- type: selectableSet
   id: FugitiveInfiltrator
   name: fugitive-set-infiltrator-name
   description: fugitive-set-infiltrator-description
@@ -153,7 +151,7 @@
   - FreedomImplanter
   - ClothingMaskGasSyndicate
 
-- type: thiefBackpackSet
+- type: selectableSet
   id: FugitiveDisruptor
   name: fugitive-set-disruptor-name
   description: fugitive-set-disruptor-description

--- a/Resources/Prototypes/_Pirate/Fugitive/fugitive.yml
+++ b/Resources/Prototypes/_Pirate/Fugitive/fugitive.yml
@@ -25,7 +25,7 @@
   categories: [ HideSpawnMenu, Spawner ]
   parent: BaseAntagSpawner
   id: SpawnPointGhostFugitive
-  name: fugitive-spawn-point-name
+  name: fugitive spawn point
   components:
   - type: GhostRole
     name: ghost-role-information-fugitive-name
@@ -64,8 +64,8 @@
 - type: entity
   parent: [ BaseFugitiveObjective, BaseLivingObjective ]
   id: FugitiveEscapeObjective
-  name: objective-condition-fugitive-escape-title
-  description: objective-condition-fugitive-escape-description
+  name: evade law enforcement
+  description: Blend into the crowd and escape on the evacuation shuttle.
   components:
   - type: Objective
     icon:
@@ -76,8 +76,8 @@
 - type: entity
   parent: ToolboxThief
   id: FugitiveStash
-  name: fugitive-stash-name
-  description: fugitive-stash-description
+  name: fugitive's stash
+  description: These supplies got you out of jail and hopefully they will keep you out of it.
   components:
   - type: ThiefUndeterminedBackpack
     maxSelectedSets: 1
@@ -219,11 +219,11 @@
     - MidroundAntag
 
 - type: entity
-  name: fugitive-galpol-stamp-name
+  name: GALPOL rubber stamp
   parent: RubberStampBase
   id: RubberStampGalpol
   categories: [ DoNotMap ]
-  description: fugitive-galpol-stamp-description
+  description: A rubber stamp for important documents concerning intergalactic security affairs.
   components:
   - type: Stamp
     stampedName: stamp-component-stamped-name-GALPOL

--- a/Resources/Prototypes/_Pirate/GameRules/secret_tp.yml
+++ b/Resources/Prototypes/_Pirate/GameRules/secret_tp.yml
@@ -32,6 +32,7 @@
       - id: ClosetSkeleton
       - id: DragonSpawn
       - id: KingRatMigration
+      - id: Fugitive
       - id: NinjaSpawn
       - id: SleeperAgents
       - id: BingleSpawn


### PR DESCRIPTION
Портує midround ghost-role Утікача з DeltaV із шістьма комплектами спорядження та орієнтуванням GALPOL.

:cl:
- add: Додано midround ghost-role Утікача з шістьма комплектами спорядження.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Додано роль антагоніста «Утікач» із випадковою особою, злочинами, спорядженням і завданням дістатися схованки.
  * На станції з’являються орієнтування з описом утікача, біометричними даними та переліком злочинів.
  * Звіти можна знайти серед стартових предметів і отримати через комунікаційні консолі.
  * Додано шість варіантів спорядження та спеціальні предмети GALPOL із печатками.

* **Локалізація**
  * Додано повні англійські й українські назви, описи, оголошення, цілі та правила події.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->