### PR TITLE
Виправити розгортання скафандра найманця

### DIFF
--- a/Resources/Prototypes/_Pirate/BountyHunter/Entities/bounty_hunter_items.yml
+++ b/Resources/Prototypes/_Pirate/BountyHunter/Entities/bounty_hunter_items.yml
@@ -192,7 +192,8 @@
         Heat: 0.6
         Caustic: 0.7
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitMercenary
+    clothingPrototypes:
+      head: ClothingHeadHelmetHardsuitMercenary
   - type: ClothingSpeedModifier
     walkModifier: 0.95
     sprintModifier: 0.95


### PR DESCRIPTION
Виправлено розгортання шолома скафандра найманця.

:cl:
- fix: Скафандр найманця знову розгортає шолом.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Виправлення**
  * Оновлено комплектацію скафандра найманця: шолом тепер належним чином пов’язаний із перемиканням елементів одягу.
  * Це забезпечує коректне відображення та зміну шолома разом зі скафандром.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->