### PR TITLE
fix merc id card

### DIFF
--- a/Resources/Prototypes/_Pirate/Loadouts/mercenary.yml
+++ b/Resources/Prototypes/_Pirate/Loadouts/mercenary.yml
@@ -12,5 +12,5 @@
     outerClothing: ClothingOuterVestWebMerc
     pocket1: WeaponLaserSvalinn
     pocket2: RadioHandheld
-    id: AgentIDCard
+    id: MercenaryIDCard
     mask: ClothingMaskGasMerc

--- a/Resources/Prototypes/_Pirate/Mercenary/identification_cards.yml
+++ b/Resources/Prototypes/_Pirate/Mercenary/identification_cards.yml
@@ -1,0 +1,34 @@
+- type: entity
+  parent: [IDCardStandard, BaseChameleon]
+  id: MercenaryIDCard
+  name: mercenary ID card
+  suffix: Mercenary
+  components:
+  - type: Access
+    tags:
+    - Maintenance
+    - SyndicateAgent
+  - type: Sprite
+    layers:
+    - state: default
+    - state: idpassenger
+  - type: AgentIDCard
+  - type: UIRequiresLock
+  - type: ActivatableUI
+    key: enum.AgentIDCardUiKey.Key
+    verbText: agent-id-open-ui-verb
+  - type: Tag
+    tags:
+    - DoorBumpOpener
+  - type: ChameleonClothing
+    slot: [idcard]
+    default: PassengerIDCard
+    requireTag: WhitelistChameleonIdCard
+  - type: UserInterface
+    interfaces:
+      enum.AgentIDCardUiKey.Key:
+        type: AgentIDCardBoundUserInterface
+      enum.ChameleonUiKey.Key:
+        type: ChameleonBoundUserInterface
+  - type: NanoChatCard
+    listNumber: false


### PR DESCRIPTION
**Журнал змін**
:cl:
- fix: картка найманця не втрачає свій доступ і він більше не запертий в себе на шатлі


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Додано ID-картку найманця з доступом до технічних зон і синдикатських об’єктів.
  * Картку можна редагувати через інтерфейс Agent ID та змінювати її зовнішній вигляд.
  * Додано підтримку відкривання дверей поштовхом і використання NanoChat без номера списку.
* **Зміни**
  * Спорядження найманця тепер містить спеціальну ID-картку найманця замість картки агента.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->