### PR TITLE
Виправити крафти демонології

### DIFF
--- a/Content.Server/Construction/Conditions/MinSolution.cs
+++ b/Content.Server/Construction/Conditions/MinSolution.cs
@@ -39,7 +39,8 @@ public sealed partial class MinSolution : IGraphCondition
         if (!containerSys.TryGetSolution(uid, Solution, out _, out var solution))
             return false;
 
-        solution.TryGetReagentQuantity(Reagent, out var quantity);
+        // Pirate: sampled blood carries reagent data, but construction only cares about the reagent prototype.
+        var quantity = solution.GetTotalPrototypeQuantity(Reagent.Prototype);
         return quantity >= Quantity;
     }
 
@@ -52,7 +53,8 @@ public sealed partial class MinSolution : IGraphCondition
         if (!containerSys.TryGetSolution(uid, Solution, out _, out var solution))
             return false;
 
-        solution.TryGetReagentQuantity(Reagent, out var quantity);
+        // Pirate: keep examine progress consistent with the construction condition above.
+        var quantity = solution.GetTotalPrototypeQuantity(Reagent.Prototype);
 
         // already has enough so dont show examine
         if (quantity >= Quantity)

--- a/Resources/Prototypes/_Pirate/Demonology/Recipes/Crafting/Graphs/enchanting.yml
+++ b/Resources/Prototypes/_Pirate/Demonology/Recipes/Crafting/Graphs/enchanting.yml
@@ -7,8 +7,11 @@
     edges:
     - to: finish
       steps:
-      - material: Paper
-        amount: 1
+      - tag: Paper
+        name: construction-graph-tag-paper
+        icon:
+          sprite: Objects/Misc/bureaucracy.rsi
+          state: paper
         doAfter: 1
   - node: finish
     entity: EnchantingScrollEmpty


### PR DESCRIPTION
Виправлено крафт наповненої пробірки з кров'ю та порожнього сувою демонології.

:cl:
- fix: Виправлено крафт наповненої пробірки з кров'ю та демонологічного сувою.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Покращення**
  - Умови перевірки реагентів тепер точніше враховують загальну кількість потрібної речовини.
  - Огляд об’єктів коректніше відображає доступну кількість реагенту.

- **Створення предметів**
  - Для виготовлення зачарованих сувоїв папір тепер відображається з локалізованою назвою та відповідною іконкою.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->