### PR TITLE
Виправити доступ до контрактів і Fulton

### DIFF
--- a/Content.Client/_Impstation/Uplink/UplinkBoundUserInterface.cs
+++ b/Content.Client/_Impstation/Uplink/UplinkBoundUserInterface.cs
@@ -30,7 +30,8 @@ public sealed class UplinkBoundUserInterface(EntityUid owner, Enum uiKey) : Boun
         _menu.Owner = Owner; // Pirate: reputation checks use the actual store entity.
 
         _menu.Stylesheet = "Syndicate";
-        _menu.ContractsButton.Visible = EntMan.HasComponent<StoreContractsComponent>(Owner) &&
+        _menu.ContractsButton.Visible = EntMan.TryGetComponent<StoreContractsComponent>(Owner, out var contracts) &&
+                                        contracts.Mind != null &&
                                         !EntMan.HasComponent<PdaComponent>(Owner);
         _menu.OnContractsPressed += _ => SendMessage(new StoreShowContractsMessage());
 

--- a/Content.Server/_Pirate/Traitor/ExtractionFultonSystem.cs
+++ b/Content.Server/_Pirate/Traitor/ExtractionFultonSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Charges.Systems;
 using Content.Shared.Cuffs;
 using Content.Shared.Cuffs.Components;
 using Content.Shared.DoAfter;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Mind;
 using Content.Shared.Mobs.Components;
@@ -28,6 +29,7 @@ public sealed class ExtractionFultonSystem : SharedExtractionFultonSystem
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedFultonSystem _fulton = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
 
     public override void Initialize()
@@ -124,7 +126,9 @@ public sealed class ExtractionFultonSystem : SharedExtractionFultonSystem
             return false;
         }
 
-        if (_container.IsEntityInContainer(target))
+        // Items in a user's hands are still in a ContainerSlot, but should be
+        // attachable without forcing the user to drop the objective first.
+        if (_container.IsEntityInContainer(target) && !_hands.IsHolding(user, target))
         {
             Popup.PopupEntity(Loc.GetString("extraction-fulton-inside-container"), target, user);
             return false;

--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -17,6 +17,7 @@
     tags:
     - Write
     - Pen
+  - type: StoreContracts # Pirate: register contracts UI for pen uplinks.
   - type: UserInterface # Goob starting here
     interfaces:
       enum.PenSpinUiKey.Key:

--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -22,7 +22,9 @@
       enum.PenSpinUiKey.Key:
         type: PenSpinBoundUserInterface
       enum.StoreUiKey.Key:
-        type: StoreBoundUserInterface
+        type: UplinkBoundUserInterface # Pirate: expose the contract hub on pen uplinks.
+      enum.ContractsUiKey.Key: # Pirate
+        type: ContractsBUI
   - type: ActivatableUI
     key: enum.PenSpinUiKey.Key
     inHandsOnly: true

--- a/Resources/Prototypes/_Pirate/Catalog/Uplink/objectives.yml
+++ b/Resources/Prototypes/_Pirate/Catalog/Uplink/objectives.yml
@@ -9,7 +9,6 @@
   categories:
   - UplinkObjectives
   conditions:
-  - !type:ObjectiveUnlockCondition
   - !type:ListingLimitedStockCondition
     stock: 1
   - !type:BuyerWhitelistCondition


### PR DESCRIPTION
Виправлено доступ до контрактів через uplink і використання Fulton для цілей у руках. Категорія Fulton тепер доступна одразу в uplink.

:cl:
- fix: Виправлено доступ до контрактів через ручку uplink.
- tweak: Категорія Fulton доступна без попереднього відкриття магазину завдань.
- fix: Предмети в руках можна прикріплювати до Fulton.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Нові можливості**
  - Предмети, що перебувають у контейнерах, тепер можна приєднувати до Fulton, якщо їх тримають у руках. Інші об’єкти в контейнерах і надалі відхиляються.
  - Для ручки додано доступ до інтерфейсу контрактів і оновлено інтерфейс магазину.

- **Зміни ігрового процесу**
  - Придбання SyndieFulton більше не потребує виконання умови розблокування; обмеження запасу та доступності для покупців не змінено.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->