### PR TITLE
Optimize client frame-time hotspots

### DIFF
--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Content.Shared._Shitmed.Body.Events; // Shitmed Change
 using Content.Client.DisplacementMap;
 using Content.Client.Examine;
@@ -65,17 +64,20 @@ namespace Content.Client.Hands.Systems
             if (args.Current is not HandsComponentState state)
                 return;
 
-            var newHands = state.Hands.Keys.Except(ent.Comp.Hands.Keys); // hands that were added between states
-            var oldHands = ent.Comp.Hands.Keys.Except(state.Hands.Keys); // hands that were removed between states
-
-            foreach (var handId in oldHands)
+            // Remove from the end because RemoveHand also updates SortedHands.
+            for (var i = ent.Comp.SortedHands.Count - 1; i >= 0; i--)
             {
-                RemoveHand(ent.AsNullable(), handId);
+                var handId = ent.Comp.SortedHands[i];
+                if (!state.Hands.ContainsKey(handId))
+                    RemoveHand(ent.AsNullable(), handId);
             }
 
-            foreach (var handId in state.SortedHands.Intersect(newHands))
+            foreach (var handId in state.SortedHands)
             {
-                AddHand(ent.AsNullable(), handId, state.Hands[handId]);
+                if (ent.Comp.Hands.ContainsKey(handId) || !state.Hands.TryGetValue(handId, out var hand))
+                    continue;
+
+                AddHand(ent.AsNullable(), handId, hand);
             }
             ent.Comp.SortedHands = new (state.SortedHands);
 

--- a/Content.Client/Movement/Systems/ContentEyeSystem.cs
+++ b/Content.Client/Movement/Systems/ContentEyeSystem.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using System.Numerics;
+using Content.Client.Eye;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
 using Robust.Client.Player;
@@ -58,21 +59,26 @@ public sealed class ContentEyeSystem : SharedContentEyeSystem
     public override void FrameUpdate(float frameTime)
     {
         base.FrameUpdate(frameTime);
-        var eyeEntities = AllEntityQuery<ContentEyeComponent, EyeComponent>();
-        while (eyeEntities.MoveNext(out var entity, out ContentEyeComponent? contentComponent, out EyeComponent? eyeComponent))
-        {
-            UpdateEyeOffset((entity, eyeComponent));
-        }
+        UpdateActiveEyeOffsets();
     }
 
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
         // TODO: Ideally we wouldn't want this to run in both FrameUpdate and Update, but we kind of have to since the visual update happens in FrameUpdate, but interaction update happens in Update. It's a workaround and a better solution should be found.
-        var eyeEntities = AllEntityQuery<ContentEyeComponent, EyeComponent>();
-        while (eyeEntities.MoveNext(out var entity, out ContentEyeComponent? contentComponent, out EyeComponent? eyeComponent))
+        UpdateActiveEyeOffsets();
+    }
+
+    private void UpdateActiveEyeOffsets()
+    {
+        var eyeEntities = AllEntityQuery<LerpingEyeComponent, ContentEyeComponent, EyeComponent>();
+        while (eyeEntities.MoveNext(
+                   out var entity,
+                   out LerpingEyeComponent? _,
+                   out ContentEyeComponent? _,
+                   out EyeComponent? eye))
         {
-            UpdateEyeOffset((entity, eyeComponent));
+            UpdateEyeOffset((entity, eye));
         }
     }
 }

--- a/Content.Goobstation.UIKit/UserInterface/Controls/CustomRichTextEntry.cs
+++ b/Content.Goobstation.UIKit/UserInterface/Controls/CustomRichTextEntry.cs
@@ -261,7 +261,7 @@ public struct CustomRichTextEntry
         float lineHeightScale = 1)
     {
         var screenHandle = (DrawingHandleScreen) handle;
-        // TODO: It should precalculate, instead of drawing, calculate and draw again
+        // The first pass calculates bounds and positions controls. It must not render content.
         var bounds = DrawBoxContent(
                 tagManager,
                 handle,
@@ -271,7 +271,8 @@ public struct CustomRichTextEntry
                 scrollBarPixelSize,
                 context,
                 uiScale,
-                lineHeightScale);
+                lineHeightScale,
+                drawContent: false);
 
         // Draw background box
         if (IsInBox)
@@ -292,7 +293,7 @@ public struct CustomRichTextEntry
         }
 
         // And draw actual content
-        DrawBoxContent(tagManager, handle, defaultFont, drawBox, verticalOffset, scrollBarPixelSize, context, uiScale, lineHeightScale);
+        DrawBoxContent(tagManager, handle, defaultFont, drawBox, verticalOffset, scrollBarPixelSize, context, uiScale, lineHeightScale, drawContent: true);
     }
 
     private readonly UIBox2 DrawBoxContent(
@@ -304,7 +305,8 @@ public struct CustomRichTextEntry
         Vector2i scrollBarPixelSize,
         MarkupDrawingContext context,
         float uiScale,
-        float lineHeightScale = 1)
+        float lineHeightScale = 1,
+        bool drawContent = true)
     {
         context.Clear();
         context.Color.Push(_defaultColor);
@@ -348,7 +350,9 @@ public struct CustomRichTextEntry
                     lineBreakIndex += 1;
                 }
 
-                var advance = font.DrawChar(handle, rune, baseLine, uiScale, color);
+                var advance = drawContent
+                    ? font.DrawChar(handle, rune, baseLine, uiScale, color)
+                    : font.TryGetCharMetrics(rune, uiScale, out var metrics) ? metrics.Advance : 0;
                 baseLine += new Vector2(advance, 0);
 
                 globalBreakCounter += 1;
@@ -358,7 +362,7 @@ public struct CustomRichTextEntry
                 continue;
 
             // Controls may have been previously hidden via HideControls due to being "out-of frame".
-            // If this ever gets replaced with RectClipContents / scissor box testing, this can be removed.
+            // They must be visible while measuring or the layout system reports a zero desired size.
             var staticSprite = control as StaticSpriteView;
             if (staticSprite is not null)
                 staticSprite.IsVisible = true;
@@ -367,35 +371,39 @@ public struct CustomRichTextEntry
 
             var invertedScale = 1f / uiScale;
             var pos = new Vector2(baseLine.X * invertedScale, (baseLine.Y - defaultFont.GetAscent(uiScale)) * invertedScale);
-            LayoutContainer.SetPosition(control, pos);
             control.Measure(new Vector2(Width, Height));
-            if (staticSprite is not null &&
-                staticSprite.IsVisible &&
-                staticSprite.Entity is not null &&
-                _entManager.TryGetComponent<MetaDataComponent>(staticSprite.Entity, out var metaData) &&
-                _entManager.TryGetComponent<SpriteComponent>(staticSprite.Entity, out var spriteComp) &&
-                !metaData.Deleted)
+            if (drawContent)
             {
-                var spritePos = new Vector2(
-                        pos.X + (staticSprite.SetWidth/2),
-                        pos.Y + (staticSprite.SetHeight/2));
-                float spriteScaleX;
-                float spriteScaleY;
-                if (spriteComp.Icon is not null)
-                {
-                    spriteScaleX = staticSprite.SetWidth / spriteComp.Icon.Default.Size.X;
-                    spriteScaleY = staticSprite.SetHeight / spriteComp.Icon.Default.Size.Y;
-                }
-                else
-                {
-                    spriteScaleX = 1f;
-                    spriteScaleY = 1f;
-                }
+                LayoutContainer.SetPosition(control, pos);
 
-                screenHandle.DrawEntity(staticSprite.Entity.Value,
-                        spritePos * uiScale,
-                        new Vector2(spriteScaleX, spriteScaleY) * uiScale,
-                        Angle.Zero);
+                if (staticSprite is not null &&
+                    staticSprite.IsVisible &&
+                    staticSprite.Entity is not null &&
+                    _entManager.TryGetComponent<MetaDataComponent>(staticSprite.Entity, out var metaData) &&
+                    _entManager.TryGetComponent<SpriteComponent>(staticSprite.Entity, out var spriteComp) &&
+                    !metaData.Deleted)
+                {
+                    var spritePos = new Vector2(
+                            pos.X + (staticSprite.SetWidth/2),
+                            pos.Y + (staticSprite.SetHeight/2));
+                    float spriteScaleX;
+                    float spriteScaleY;
+                    if (spriteComp.Icon is not null)
+                    {
+                        spriteScaleX = staticSprite.SetWidth / spriteComp.Icon.Default.Size.X;
+                        spriteScaleY = staticSprite.SetHeight / spriteComp.Icon.Default.Size.Y;
+                    }
+                    else
+                    {
+                        spriteScaleX = 1f;
+                        spriteScaleY = 1f;
+                    }
+
+                    screenHandle.DrawEntity(staticSprite.Entity.Value,
+                            spritePos * uiScale,
+                            new Vector2(spriteScaleX, spriteScaleY) * uiScale,
+                            Angle.Zero);
+                }
             }
 
             var advanceX = control.SetWidth;


### PR DESCRIPTION
## Про запит на злиття
Оптимізує три клієнтські hot path, виявлені під час профілювання активної ігрової сесії.

## Чому / Баланс
Зменшує зайву роботу та алокації на клієнті, щоб скоротити просідання frame time. Ігровий баланс і поведінка не змінюються.

## Технічні деталі
- Замінено LINQ Except/Intersect у синхронізації рук на прямі перевірки словників і безпечне зворотне видалення.
- Оновлення eye offset обмежено активними LerpingEyeComponent замість подвійного обходу всіх реплікованих eye щокадру.
- Перший layout-pass CustomRichTextEntry тепер лише вимірює текст і controls; фактичний текст та entity рендеряться один раз у другому проході.

Перевірка: dotnet build Content.Client/Content.Client.csproj --no-restore (0 errors).

## Медіа
Не потрібно: візуальна поведінка не змінюється.

- [ ] Я дозволяю переліцензувати мої зміни під GAG v1.0, коли їх буде перенесено до GoobStation Reforged.

## Вимоги
- [x] Я прочитав та дотримуюсь правил запитів на злиття та журналу змін.
- [x] Цей запит на злиття не потребує медіа.

## Зміни, що порушують сумісність
Немає.

**Журнал змін**

:cl:
- fix: Оптимізовано кілька клієнтських систем для зменшення просідань FPS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Покращення**
  - Покращено синхронізацію стану рук: зайві руки своєчасно видаляються, а нові додаються без дублювання.
  - Оптимізовано оновлення зміщення очей для коректнішої роботи анімацій.
  - Покращено розрахунок розмірів і позиціонування елементів у полях форматованого тексту.
  - Виправлено відображення фону, вмісту та вбудованих елементів під час складного компонування тексту.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->