### PR TITLE
Fix MODsuits on corpses and shoeless species

### DIFF
--- a/Content.Pirate.Server/ModularSuit/ModularSuitSystem.cs
+++ b/Content.Pirate.Server/ModularSuit/ModularSuitSystem.cs
@@ -615,18 +615,12 @@ public sealed partial class ModularSuitSystem : SharedModularSuitSystem
         return false;
     }
 
-    private bool AllRequiredPartsDeployed(EntityUid suit)
+    private bool AllRequiredPartsDeployed(Entity<ModularSuitComponent> suit)
     {
         if (!TryComp<ModularSuitEquippedComponent>(suit, out var equipped))
             return false;
 
-        var requiredParts = new HashSet<SuitPartType>
-        {
-            SuitPartType.Helmet,
-            SuitPartType.Torso,
-            SuitPartType.Gloves,
-            SuitPartType.Boots
-        };
+        var requiredParts = GetRequiredParts(suit);
 
         foreach (var partUid in equipped.EquippedParts.Values)
         {
@@ -635,6 +629,31 @@ public sealed partial class ModularSuitSystem : SharedModularSuitSystem
         }
 
         return requiredParts.Count == 0;
+    }
+
+    private HashSet<SuitPartType> GetRequiredParts(Entity<ModularSuitComponent> suit)
+    {
+        var requiredParts = new HashSet<SuitPartType>
+        {
+            SuitPartType.Helmet,
+            SuitPartType.Torso,
+            SuitPartType.Gloves,
+            SuitPartType.Boots
+        };
+
+        if (suit.Comp.Wearer is not { } wearer)
+            return requiredParts;
+
+        if (!Inventory.HasSlot(wearer, "head"))
+            requiredParts.Remove(SuitPartType.Helmet);
+        if (!Inventory.HasSlot(wearer, "outerClothing"))
+            requiredParts.Remove(SuitPartType.Torso);
+        if (!Inventory.HasSlot(wearer, "gloves"))
+            requiredParts.Remove(SuitPartType.Gloves);
+        if (!Inventory.HasSlot(wearer, "shoes"))
+            requiredParts.Remove(SuitPartType.Boots);
+
+        return requiredParts;
     }
 
     private bool TryStartSuitUnsealing(Entity<ModularSuitComponent> suit, EntityUid user)
@@ -865,13 +884,7 @@ public sealed partial class ModularSuitSystem : SharedModularSuitSystem
             return;
         }
 
-        var requiredParts = new HashSet<SuitPartType>
-        {
-            SuitPartType.Helmet,
-            SuitPartType.Torso,
-            SuitPartType.Gloves,
-            SuitPartType.Boots
-        };
+        var requiredParts = GetRequiredParts((uid, suit));
 
         var partContainer = Container.GetContainer(uid, PartContainer);
         foreach (var part in partContainer.ContainedEntities)

--- a/Content.Pirate.Shared/ModularSuit/SharedModularSuitSystem.cs
+++ b/Content.Pirate.Shared/ModularSuit/SharedModularSuitSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Interaction.Components;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Item.ItemToggle;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Mobs;
 using Content.Shared.Popups;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
@@ -45,6 +46,7 @@ public abstract partial class SharedModularSuitSystem : EntitySystem
 
         SubscribeLocalEvent<ModularSuitComponent, ClothingGotEquippedEvent>(OnEquipped);
         SubscribeLocalEvent<ModularSuitComponent, GotUnequippedEvent>(OnUnequipped);
+        SubscribeLocalEvent<ModularSuitCarrierComponent, MobStateChangedEvent>(OnWearerMobStateChanged);
 
         SubscribeLocalEvent<ModularSuitPartComponent, BeingEquippedAttemptEvent>(OnPartEquippedAttempt);
         SubscribeLocalEvent<ModularSuitPartComponent, GotUnequippedEvent>(OnPartUnequipped);
@@ -222,6 +224,19 @@ public abstract partial class SharedModularSuitSystem : EntitySystem
         ent.Comp.Wearer = null;
         RemComp<ModularSuitCarrierComponent>(args.Equipee);
         _uiSystem.CloseUi(ent.Owner, ModularSuitUiKey.Key, args.Equipee);
+    }
+
+    private void OnWearerMobStateChanged(Entity<ModularSuitCarrierComponent> ent, ref MobStateChangedEvent args)
+    {
+        if (args.NewMobState != MobState.Dead ||
+            ent.Comp.CurrentSlot is not { } slot ||
+            !Inventory.TryGetSlotEntity(ent.Owner, slot, out var suitUid) ||
+            !TryComp<ModularSuitComponent>(suitUid.Value, out var suit))
+        {
+            return;
+        }
+
+        SetActive((suitUid.Value, suit), false);
     }
 
     private void DeploySuit(Entity<ModularSuitComponent> ent, EntityUid wearer)


### PR DESCRIPTION
Виправлено зняття активних MOD-костюмів із мертвих персонажів та герметизацію для видів без окремих слотів спорядження.

:cl:
- fix: MOD-костюми тепер можна зняти з мертвого носія, а йові та діони можуть повністю їх активувати.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Модульні костюми тепер враховують доступні слоти інвентарю носія під час визначення необхідних частин.
  * Частини, для яких немає відповідних слотів, більше не блокують складання костюма.
* **Виправлення**
  * Костюм автоматично деактивується, коли його носій помирає.
  * Перевірка комплектності костюма стала коректнішою для різних конфігурацій носія.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->