### PR TITLE
Збільшення ліміту синдикатських фултонів в аплінку

### DIFF
--- a/Resources/Prototypes/_Pirate/Catalog/Uplink/objectives.yml
+++ b/Resources/Prototypes/_Pirate/Catalog/Uplink/objectives.yml
@@ -10,7 +10,7 @@
   - UplinkObjectives
   conditions:
   - !type:ListingLimitedStockCondition
-    stock: 1
+    stock: 3
   - !type:BuyerWhitelistCondition
     blacklist:
       components:


### PR DESCRIPTION
## Про запит на злиття

Збільшено максимальну кількість синдикатських фултонів, доступних через аплінк, з 1 до 3.

## Чому / Баланс

Одного фултона може бути недостатньо для виконання завдань із викрадення предметів або взяття цілей у заручники. Збільшення ліміту до трьох дає зрадникам додаткові спроби, не змінюючи механіку, заряди або швидкість перезаряджання самого фултона.

## Технічні деталі

У прототипі `SyndieFulton` значення `ListingLimitedStockCondition.stock` змінено з `1` на `3`.

Інші параметри фултона не змінювалися.

## Медіа

Не потребує медіа, оскільки зміна стосується лише числового ліміту товару в аплінку.

- [x] Я дозволяю переліцензувати мої зміни під [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), коли їх буде перенесено до [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged).

## Вимоги

- [x] Я прочитав та дотримуюсь [Правил запитів на злиття та журналу змін](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я додав медіа, **АБО** цей запит на злиття не потребує медіа.

## Зміни, що порушують сумісність

Відсутні.

**Журнал змін**

:cl:
- tweak: Ліміт синдикатських фултонів в аплінку збільшено з 1 до 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Зміни балансу**
  * Збільшено обмежений запас предмета «SyndieFulton» з 1 до 3 одиниць.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->