### PR TITLE
Збільшити вагу події синдикатських дропів

### DIFF
--- a/Resources/Prototypes/_Moffstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Moffstation/GameRules/events.yml
@@ -11,7 +11,7 @@
     duration: 1
     minimumPlayers: 10
     maxOccurrences: 6 # Pirate - was 3
-    weight: 20 # Pirate - increase dead drop frequency
+    weight: 40 # Pirate - increase dead drop frequency
   - type: GameRule
     chaosScore: 40
   - type: RandomSpawnRule


### PR DESCRIPTION
## Про запит на злиття

Збільшено вагу події `SyndicateDeadDrop` з `20` до `40`.

## Чому / Баланс

Збільшення `maxOccurrences` з 3 до 6 не підвищило фактичну частоту появи події — за раунд вона зазвичай випадала не більше двох разів.

Значення `weight: 40` збільшує відносну вагу події в чотири рази порівняно з початковим значенням `10`. Максимальна кількість появ залишається рівною 6.

## Технічні деталі

У `Resources/Prototypes/_Moffstation/GameRules/events.yml`:

- `weight: 20` змінено на `weight: 40`;
- `maxOccurrences: 6` не змінювалося.

## Медіа

Не потребує медіа.

## Зміни, що порушують сумісність

Відсутні.

**Журнал змін**

:cl:
- tweak: Збільшено частоту появи синдикатських дропів. (Щоб дійсно був шанс більше 2 дропів за раунд)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Ігровий баланс**
  * Збільшено ймовірність появи події «SyndicateDeadDrop».

<!-- end of auto-generated comment: release notes by coderabbit.ai -->