### PR TITLE
fix: guard terminating cuff cleanup

### DIFF
--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -413,6 +413,10 @@ namespace Content.Shared.Cuffs
         /// </summary>
         private void OnHandCountChanged(Entity<CuffableComponent> ent, ref HandCountChangedEvent message)
         {
+            // Pirate: modular suit cleanup can remove hands while the owner or its cuffs are being deleted.
+            if (EntityManager.IsQueuedForDeletion(ent.Owner) || TerminatingOrDeleted(ent.Owner))
+                return;
+
             // TODO: either don't store a container ref, or make it actually nullable.
             if (ent.Comp.Container == default!)
                 return;
@@ -422,11 +426,13 @@ namespace Content.Shared.Cuffs
 
             while (ent.Comp.CuffedHandCount > handCount && ent.Comp.CuffedHandCount > 0)
             {
-                dirty = true;
-
                 var handcuffContainer = ent.Comp.Container;
                 var handcuffEntity = handcuffContainer.ContainedEntities[^1];
 
+                if (EntityManager.IsQueuedForDeletion(handcuffEntity) || TerminatingOrDeleted(handcuffEntity))
+                    break;
+
+                dirty = true;
                 _transform.PlaceNextTo(handcuffEntity, ent.Owner);
             }
 

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -430,7 +430,14 @@ namespace Content.Shared.Cuffs
                 var handcuffEntity = handcuffContainer.ContainedEntities[^1];
 
                 if (EntityManager.IsQueuedForDeletion(handcuffEntity) || TerminatingOrDeleted(handcuffEntity))
-                    break;
+                {
+                    if (Deleted(handcuffEntity) ||
+                        !_container.Remove(handcuffEntity, handcuffContainer, reparent: false, force: true))
+                        break;
+
+                    dirty = true;
+                    continue;
+                }
 
                 dirty = true;
                 _transform.PlaceNextTo(handcuffEntity, ent.Owner);


### PR DESCRIPTION
:cl:
- fix: Прибирання раунду більше не спричиняє спам помилками від terminating наручників.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Виправлення помилок**
  * Покращено обробку наручників під час видалення або завершення роботи сутностей.
  * Запобігли помилкам і некоректному зменшенню кількості наручників під час очищення модульних костюмів.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->