### PR TITLE
Return low stamina debuff

### DIFF
--- a/Content.Shared/Damage/Components/StaminaComponent.cs
+++ b/Content.Shared/Damage/Components/StaminaComponent.cs
@@ -109,8 +109,8 @@ public sealed partial class StaminaComponent : Component
     /// <summary>
     /// Thresholds that determine an entity's slowdown as a function of stamina damage, in percentages.
     /// </summary>
-    [DataField] // Goob edit. No slowdown. todo goobstation refactor sprint shit so it isnt as dependent on stamina its kinda annoying to wrangle both at the same time.
-    public Dictionary<FixedPoint2, float> StunModifierThresholds = new() { {0, 1f } }; // Goob edit, 0.7 -> 1, 0.5 -> 1
+    [DataField]
+    public Dictionary<FixedPoint2, float> StunModifierThresholds = new() { { 0, 1f }, { 0.65, 0.75f }, { 0.85, 0.5f } }; // Pirate edit - was { { 0, 1f } }
 
 
     #region Animation Data

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -1243,7 +1243,7 @@
   - type: Ammo
     muzzleFlash: MuzzleFlashEffectOmnilaser # Pirate
   - type: StaminaDamageOnCollide
-    damage: 12 # Goob edit
+    damage: 6 # Pirate edit - was 12
   - type: Projectile
     impactEffect: BulletImpactEffectDisabler
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -323,7 +323,7 @@
   - type: Ammo
     muzzleFlash: MuzzleFlashEffectOmnilaser # Pirate
   - type: StaminaDamageOnCollide
-    damage: 20 # Goob edit
+    damage: 10 # Pirate edit - was 20
   - type: Projectile
     impactEffect: BulletImpactEffectDisabler
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -47,7 +47,7 @@
     angle: 0
     animation: WeaponArcThrust
   - type: StaminaDamageOnHit # goob edited
-    damage: 15
+    damage: 8 # Pirate edit - was 15
     overtime: 40
     lightAttackDamageMultiplier: 4
     lightAttackOvertimeDamageMultiplier: 0


### PR DESCRIPTION

**Журнал змін**
:cl:
- add: Повернено дебаф на швидкість при малій кількості стаміни: 100-36% дебаф 0%;    35-16% дебаф 25%;    15-0 дебаф 50%
- tweak: Нерф дизайберів в 2 рази
- tweak: Нерф станбатона в 2 рази


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Зміни балансу**
  * Зменшено шкоду витривалості від електрошокера, кулі-дизейблера та її SMG-версії.
  * Додано поступове уповільнення персонажів залежно від отриманої шкоди витривалості: до 75% і 50% швидкості на вищих порогах.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->