### PR TITLE
Обмеження ОБЩ за кількістю командування

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -103,9 +103,10 @@ namespace Content.Server.GameTicking
                 if (job is null)
                     continue;
 
+                var assignedJob = job.Value;
                 var ev = new IsRoleAllowedEvent(
                     _playerManager.GetSessionById(player),
-                    new List<ProtoId<JobPrototype>> { job },
+                    new List<ProtoId<JobPrototype>> { assignedJob },
                     null);
                 RaiseLocalEvent(ref ev);
 

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -96,6 +96,23 @@ namespace Content.Server.GameTicking
 
             _stationJobs.AssignOverflowJobs(ref assignedJobs, playerNetIds, profiles, spawnableStations);
 
+            // Pirate: round-start assignment bypasses SpawnPlayer's role check. Revalidate
+            // assigned roles before spawning so restricted roles remain in the lobby.
+            foreach (var (player, (job, _)) in assignedJobs.ToArray())
+            {
+                if (job is null)
+                    continue;
+
+                var ev = new IsRoleAllowedEvent(
+                    _playerManager.GetSessionById(player),
+                    new List<ProtoId<JobPrototype>> { job },
+                    null);
+                RaiseLocalEvent(ref ev);
+
+                if (ev.Cancelled)
+                    assignedJobs[player] = (null, EntityUid.Invalid);
+            }
+
             // Calculate extended access for stations.
             var stationJobCounts = spawnableStations.ToDictionary(e => e, _ => 0);
             foreach (var (netUser, (job, station)) in assignedJobs)

--- a/Content.Server/_Pirate/Roles/BlueshieldOfficerRestrictionSystem.cs
+++ b/Content.Server/_Pirate/Roles/BlueshieldOfficerRestrictionSystem.cs
@@ -8,7 +8,8 @@ using Robust.Shared.Prototypes;
 namespace Content.Server._Pirate.Roles;
 
 /// <summary>
-/// Keeps the Blueshield Officer from joining before enough command staff are present.
+/// Keeps the Blueshield Officer from joining before enough command staff are present,
+/// including round-start assignments.
 /// </summary>
 public sealed class BlueshieldOfficerRestrictionSystem : EntitySystem
 {

--- a/Content.Server/_Pirate/Roles/BlueshieldOfficerRestrictionSystem.cs
+++ b/Content.Server/_Pirate/Roles/BlueshieldOfficerRestrictionSystem.cs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server.GameTicking.Events;
+using Content.Server.Revolutionary.Components;
+using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Pirate.Roles;
+
+/// <summary>
+/// Keeps the Blueshield Officer from joining before enough command staff are present.
+/// </summary>
+public sealed class BlueshieldOfficerRestrictionSystem : EntitySystem
+{
+    // Pirate: three command members is practical for the server's usual population.
+    private const int RequiredCommandStaff = 3;
+    private static readonly ProtoId<JobPrototype> BlueshieldOfficerJob = "BlueshieldOfficer";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        // Late joins use GetDisallowedJobsEvent; explicit job requests use IsRoleAllowedEvent.
+        SubscribeLocalEvent<GetDisallowedJobsEvent>(OnGetDisallowedJobs);
+        SubscribeLocalEvent<IsRoleAllowedEvent>(OnIsRoleAllowed);
+    }
+
+    private void OnGetDisallowedJobs(ref GetDisallowedJobsEvent ev)
+    {
+        if (!HasEnoughCommandStaff())
+            ev.Jobs.Add(BlueshieldOfficerJob);
+    }
+
+    private void OnIsRoleAllowed(ref IsRoleAllowedEvent ev)
+    {
+        if (ev.Jobs?.Contains(BlueshieldOfficerJob) == true && !HasEnoughCommandStaff())
+            ev.Cancelled = true;
+    }
+
+    private bool HasEnoughCommandStaff()
+    {
+        var count = 0;
+        var query = EntityQueryEnumerator<CommandStaffComponent>();
+
+        while (query.MoveNext(out _, out var commandStaff))
+        {
+            if (!commandStaff.Enabled)
+                continue;
+
+            count++;
+            if (count >= RequiredCommandStaff)
+                return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Обмежує приєднання за ОБЩ до появи в раунді щонайменше трьох членів командування. Це діє і для пізнього входу, і для готових гравців на старті раунду: заборонений гравець залишається в лобі.

:cl:
- tweak: ОБЩ може приєднатися лише після появи трьох членів командування.