### PR TITLE
Пояснити обмеження входу за офіцера Блакитного Щита

### DIFF
--- a/Content.Client/LateJoin/LateJoinGui.cs
+++ b/Content.Client/LateJoin/LateJoinGui.cs
@@ -45,6 +45,10 @@ namespace Content.Client.LateJoin
 
         private readonly Control _base;
 
+        // Pirate: this role has a server-side population gate that the regular
+        // client-side role requirements cannot evaluate.
+        private const string BlueshieldOfficerJob = "BlueshieldOfficer";
+
         public LateJoinGui()
         {
             MinSize = SetSize = new Vector2(360, 560);
@@ -239,6 +243,13 @@ namespace Content.Client.LateJoin
 
                         var jobButton = new JobButton(jobLabel, prototype.ID, prototype.LocalizedName, value);
 
+                        var restrictionTooltip = prototype.ID == BlueshieldOfficerJob
+                            ? Loc.GetString("blueshield-officer-restriction")
+                            : null;
+
+                        if (restrictionTooltip is not null)
+                            jobButton.ToolTip = restrictionTooltip;
+
                         var jobSelector = new BoxContainer
                         {
                             Orientation = LayoutOrientation.Horizontal,
@@ -268,7 +279,12 @@ namespace Content.Client.LateJoin
                             if (!reason.IsEmpty)
                             {
                                 var tooltip = new Tooltip();
-                                tooltip.SetMessage(reason);
+                                var message = restrictionTooltip is null
+                                    ? reason
+                                    : FormattedMessage.FromMarkupPermissive(
+                                        $"{reason.ToMarkup()}\n{FormattedMessage.EscapeText(restrictionTooltip)}");
+                                tooltip.SetMessage(message);
+                                jobButton.ToolTip = null;
                                 jobButton.TooltipSupplier = _ => tooltip;
                             }
 

--- a/Content.Server/GameTicking/Events/IsRoleAllowedEvent.cs
+++ b/Content.Server/GameTicking/Events/IsRoleAllowedEvent.cs
@@ -10,15 +10,23 @@ namespace Content.Server.GameTicking.Events;
 /// <param name="player">The player.</param>
 /// <param name="jobs">Optional list of job prototype IDs</param>
 /// <param name="antags">Optional list of antag prototype IDs</param>
+/// <param name="cancelReason">Optional player-facing explanation when the role is denied.</param>
 [ByRefEvent]
 public struct IsRoleAllowedEvent(
     ICommonSession player,
     List<ProtoId<JobPrototype>>? jobs,
     List<ProtoId<AntagPrototype>>? antags,
-    bool cancelled = false)
+    bool cancelled = false,
+    string? cancelReason = null)
 {
     public readonly ICommonSession Player = player;
     public readonly List<ProtoId<JobPrototype>>? Jobs = jobs;
     public readonly List<ProtoId<AntagPrototype>>? Antags = antags;
     public bool Cancelled = cancelled;
+
+    /// <summary>
+    ///     Optional player-facing explanation for a cancelled role assignment.
+    /// </summary>
+    // Pirate: role restrictions can provide a player-facing explanation.
+    public string? CancelReason = cancelReason;
 }

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -98,6 +98,7 @@ namespace Content.Server.GameTicking
 
             // Pirate: round-start assignment bypasses SpawnPlayer's role check. Revalidate
             // assigned roles before spawning so restricted roles remain in the lobby.
+            var assignmentCancelReasons = new Dictionary<NetUserId, string>(); // Pirate
             foreach (var (player, (job, _)) in assignedJobs.ToArray())
             {
                 if (job is null)
@@ -111,7 +112,12 @@ namespace Content.Server.GameTicking
                 RaiseLocalEvent(ref ev);
 
                 if (ev.Cancelled)
+                {
                     assignedJobs[player] = (null, EntityUid.Invalid);
+
+                    if (ev.CancelReason is { } reason)
+                        assignmentCancelReasons[player] = reason;
+                }
             }
 
             // Calculate extended access for stations.
@@ -124,7 +130,10 @@ namespace Content.Server.GameTicking
                     var evNoJobs = new NoJobsAvailableSpawningEvent(playerSession); // Used by gamerules to wipe their antag slot, if they got one
                     RaiseLocalEvent(evNoJobs);
 
-                    _chatManager.DispatchServerMessage(playerSession, Loc.GetString("job-not-available-wait-in-lobby"));
+                    _chatManager.DispatchServerMessage(playerSession,
+                        assignmentCancelReasons.TryGetValue(netUser, out var reason)
+                            ? reason
+                            : Loc.GetString("job-not-available-wait-in-lobby"));
                 }
                 else
                 {
@@ -170,7 +179,13 @@ namespace Content.Server.GameTicking
                 var ev = new IsRoleAllowedEvent(player, jobs, null);
                 RaiseLocalEvent(ref ev);
                 if (ev.Cancelled)
+                {
+                    // Pirate: surface server-side role restrictions to the player.
+                    if (ev.CancelReason is { } reason)
+                        _chatManager.DispatchServerMessage(player, reason);
+
                     return;
+                }
             }
 
             SpawnPlayer(player, character, station, jobId, lateJoin, silent);

--- a/Content.Server/_Pirate/Roles/BlueshieldOfficerRestrictionSystem.cs
+++ b/Content.Server/_Pirate/Roles/BlueshieldOfficerRestrictionSystem.cs
@@ -35,7 +35,10 @@ public sealed class BlueshieldOfficerRestrictionSystem : EntitySystem
     private void OnIsRoleAllowed(ref IsRoleAllowedEvent ev)
     {
         if (ev.Jobs?.Contains(BlueshieldOfficerJob) == true && !HasEnoughCommandStaff())
+        {
             ev.Cancelled = true;
+            ev.CancelReason = Loc.GetString("blueshield-officer-restriction");
+        }
     }
 
     private bool HasEnoughCommandStaff()

--- a/Resources/Locale/en-US/job/job.ftl
+++ b/Resources/Locale/en-US/job/job.ftl
@@ -13,3 +13,5 @@ job-greet-important-disconnect-admin-notify = You are playing a job that is impo
 job-greet-supervisors-warning = As the {$jobName} you answer directly to {$supervisors}. Special circumstances may change this.
 job-greet-crew-shortages = As this station was initially staffed with a skeleton crew, additional access has been added to your ID card.
 job-not-available-wait-in-lobby = The round has started, but you did not receive any of your preferred job roles (or have no preferred job roles selected) and chose to remain in the lobby. You can change this behavior on the customization screen.
+# Pirate: Blueshield Officer joins are gated by the number of command staff.
+blueshield-officer-restriction = You can join as a Blueshield Officer only after at least three command staff members are present on the station.

--- a/Resources/Locale/uk-UA/job/job.ftl
+++ b/Resources/Locale/uk-UA/job/job.ftl
@@ -13,3 +13,5 @@ job-greet-important-disconnect-admin-notify = Ви граєте за профе�
 job-greet-supervisors-warning = Як {$jobName}, ви підпорядковуєтесь безпосередньо {$supervisors}. Особливі обставини можуть це змінити.
 job-greet-crew-shortages = Оскільки ця станція спочатку була укомплектована мінімальним складом, на вашу ID-карту було додано додатковий доступ.
 job-not-available-wait-in-lobby = Раунд розпочався, але ви не отримали жодної з бажаних ролей (або не вибрали жодної бажаної ролі) і вирішили залишитися в лобі. Ви можете змінити цю поведінку на екрані налаштувань персонажа.
+# Pirate: Blueshield Officer joins are gated by the number of command staff.
+blueshield-officer-restriction = Приєднатися офіцером Блакитного Щита можна лише після появи щонайменше трьох членів командування на станції.


### PR DESCRIPTION
Додано пояснення обмеження входу за офіцера Блакитного Щита в тултіпі ролі та повідомленні після відмови.

:cl:
- fix: Пояснено, чому роль офіцера Блакитного Щита недоступна до появи трьох членів командування.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові функції**
  * Додано зрозумілі пояснення причин, через які роль може бути недоступною.
  * Для офіцера Блакитного Щита відображається обмеження: необхідна присутність щонайменше трьох членів командування.
  * Причина відмови тепер показується під час вибору або прямого призначення ролі.

* **Локалізація**
  * Додано повідомлення українською та англійською мовами.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->