### PR TITLE
Виправлення шарів довгих суконь

### DIFF
--- a/Resources/Prototypes/_Pirate/Entities/Clothing/PlayerCosmetics/expansion.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Clothing/PlayerCosmetics/expansion.yml
@@ -796,9 +796,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Arcane/Uniforms/dresseswithflowers.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Arcane/Uniforms/dresseswithflowers.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformBase
@@ -810,9 +808,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Arcane/Uniforms/flower_princess.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Arcane/Uniforms/flower_princess.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformBase
@@ -824,9 +820,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Arcane/Uniforms/fly_agaric.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Arcane/Uniforms/fly_agaric.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformBase
@@ -838,9 +832,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Arcane/Uniforms/gentle_yellow.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Arcane/Uniforms/gentle_yellow.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformBase
@@ -852,9 +844,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Arcane/Uniforms/spider.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Arcane/Uniforms/spider.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformBase
@@ -866,9 +856,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Arcane/Uniforms/tango_dress.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Arcane/Uniforms/tango_dress.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformBase
@@ -891,9 +879,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Starlight/Uniforms/dress_red.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Starlight/Uniforms/dress_red.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformBase
@@ -905,9 +891,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Starlight/Uniforms/dress_victorian_black.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Starlight/Uniforms/dress_victorian_black.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformBase
@@ -919,9 +903,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Starlight/Uniforms/dress_victorian_red.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Starlight/Uniforms/dress_victorian_red.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformBase
@@ -933,9 +915,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Starlight/Uniforms/lady.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Expansion/Starlight/Uniforms/lady.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformBase

--- a/Resources/Prototypes/_Pirate/Entities/Clothing/PlayerCosmetics/fresh_ports.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Clothing/PlayerCosmetics/fresh_ports.yml
@@ -52,9 +52,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Fresh/Starlight/Uniforms/druid_robes.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Fresh/Starlight/Uniforms/druid_robes.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformBase
@@ -77,9 +75,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Fresh/Starlight/Uniforms/flamenco.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Fresh/Starlight/Uniforms/flamenco.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformBase
@@ -113,9 +109,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Fresh/Starlight/Uniforms/lilac_dress.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Fresh/Starlight/Uniforms/lilac_dress.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformBase

--- a/Resources/Prototypes/_Pirate/Entities/Clothing/PlayerCosmetics/ported.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Clothing/PlayerCosmetics/ported.yml
@@ -517,9 +517,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Uniforms/Jumpskirt/mus_singerdress.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Uniforms/Jumpskirt/mus_singerdress.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   name: Pink Princess Dress
@@ -532,9 +530,7 @@
   - type: Item
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Uniforms/Jumpskirt/pinkprincessdress.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   name: Green Princess Dress
@@ -547,9 +543,7 @@
   - type: Item
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Uniforms/Jumpskirt/greenprincessdress.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformSkirtBase
@@ -561,9 +555,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Uniforms/Other/clayshaperdress.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Uniforms/Other/clayshaperdress.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformSkirtBase
@@ -575,9 +567,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Uniforms/Other/druidrobe.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Uniforms/Other/druidrobe.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformSkirtBase
@@ -589,9 +579,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Uniforms/Other/moondress.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Uniforms/Other/moondress.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformSkirtBase
@@ -603,9 +591,7 @@
     sprite: _Pirate/Clothing/PlayerCosmetics/Uniforms/Other/tidalrobe.rsi
   - type: Clothing
     sprite: _Pirate/Clothing/PlayerCosmetics/Uniforms/Other/tidalrobe.rsi
-  - type: HideClothingLayerClothing
-    hiddenSlots:
-    - shoes
+  - type: ClothingLayerRemap
 
 - type: entity
   parent: ClothingUniformBase


### PR DESCRIPTION
Виправляє порядок відмальовування довгих суконь і шат: тканина тепер перекриває ноги та взуття, як у вечірньої сукні.

:cl:
- fix: Довгі сукні та шати більше не відображають ноги поверх тканини.