### PR TITLE
BR-40c "Черепаха" tweak

### DIFF
--- a/Resources/Prototypes/_Pirate/Security/security_utility.yml
+++ b/Resources/Prototypes/_Pirate/Security/security_utility.yml
@@ -24,7 +24,7 @@
         restitution: 0.3
         friction: 0.2
   - type: Item
-    size: Small
+    size: Ginormous
   - type: HeldSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7


### PR DESCRIPTION

**Журнал змін**
:cl:
- tweak: BR-40c "Черепаха" (енергетичний щит) більше не можна запхати в рюкзак