### PR TITLE
Fix temperature events and replay PVS state

### DIFF
--- a/Content.IntegrationTests/Tests/_Pirate/Temperature/TemperatureSystemTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Temperature/TemperatureSystemTest.cs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server.Temperature.Systems;
+using Content.Shared.Temperature;
+using Content.Shared.Temperature.Components;
+using Robust.Server;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Reflection;
+using Robust.UnitTesting;
+
+namespace Content.IntegrationTests.Tests._Pirate.Temperature;
+
+[TestFixture]
+[TestOf(typeof(TemperatureSystem))]
+public sealed class TemperatureSystemTest : RobustIntegrationTest
+{
+    [Test]
+    public async Task ForceChangeTemperatureRaisesOneEvent()
+    {
+        var options = new RobustIntegrationTest.ServerIntegrationOptions
+        {
+            ContentStart = true,
+            ContentAssemblies = PoolManager.GetAssemblies(client: false, includePoolAssembly: false),
+            Pool = false,
+            Options = new ServerOptions
+            {
+                LoadConfigAndUserData = false,
+                LoadContentResources = false,
+            },
+        };
+
+        foreach (var (cvar, value) in PoolManager.TestCvars)
+        {
+            options.CVarOverrides[cvar] = value;
+        }
+
+        options.BeforeStart += () =>
+        {
+            IoCManager.Resolve<IEntitySystemManager>()
+                .LoadExtraSystemType<TemperatureEventCounterSystem>();
+        };
+
+        using var server = StartServer(options);
+        await server.WaitIdleAsync();
+
+        await server.WaitAssertion(() =>
+        {
+            var entityManager = server.ResolveDependency<IEntityManager>();
+            var temperatureSystem = entityManager.System<TemperatureSystem>();
+            var counter = entityManager.System<TemperatureEventCounterSystem>();
+            var entity = entityManager.SpawnEntity(null, MapCoordinates.Nullspace);
+            var temperature = entityManager.AddComponent<TemperatureComponent>(entity);
+
+            temperatureSystem.ForceChangeTemperature(entity, temperature.CurrentTemperature + 1f, temperature);
+
+            Assert.That(counter.EventCount, Is.EqualTo(1));
+        });
+    }
+
+    [Reflect(false)]
+    private sealed class TemperatureEventCounterSystem : EntitySystem
+    {
+        public int EventCount { get; private set; }
+
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<TemperatureComponent, OnTemperatureChangeEvent>(OnTemperatureChange);
+        }
+
+        private void OnTemperatureChange(Entity<TemperatureComponent> _, ref OnTemperatureChangeEvent args)
+        {
+            EventCount++;
+        }
+    }
+}

--- a/Content.IntegrationTests/Tests/_Pirate/Temperature/TemperatureSystemTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Temperature/TemperatureSystemTest.cs
@@ -26,9 +26,13 @@ public sealed class TemperatureSystemTest : RobustIntegrationTest
             ContentStart = true,
             ContentAssemblies = PoolManager.GetAssemblies(client: false, includePoolAssembly: false),
             Pool = false,
-            // The standalone harness does not mount Pirate prototype resources, but BankCardSystem
-            // indexes this prototype during content startup.
+            // The standalone harness does not mount content prototype resources required during
+            // content startup.
             ExtraPrototypes = """
+                - type: language
+                  id: Universal
+                - type: language
+                  id: Psychomantic
                 - type: salary
                   id: Salaries
                   salaries: {}
@@ -78,6 +82,16 @@ public sealed class TemperatureSystemTest : RobustIntegrationTest
                 Assert.That(counter.TemperatureDelta, Is.EqualTo(expectedTemperature - lastTemperature).Within(0.001f));
                 Assert.That(temperature.CurrentTemperature, Is.EqualTo(expectedTemperature).Within(0.001f));
             });
+
+            counter.CancelNextAttempt = true;
+            var temperatureBeforeCancellation = temperature.CurrentTemperature;
+            temperatureSystem.ForceChangeTemperature(entity, temperatureBeforeCancellation + 2f, temperature);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(temperature.CurrentTemperature, Is.EqualTo(temperatureBeforeCancellation).Within(0.001f));
+                Assert.That(counter.EventCount, Is.EqualTo(1));
+            });
         });
     }
 
@@ -90,17 +104,28 @@ public sealed class TemperatureSystemTest : RobustIntegrationTest
         public float CurrentTemperature { get; private set; }
         public float LastTemperature { get; private set; }
         public float TemperatureDelta { get; private set; }
+        public bool CancelNextAttempt { get; set; }
 
         public override void Initialize()
         {
             base.Initialize();
             SubscribeLocalEvent<TemperatureComponent, TemperatureImmunityEvent>(OnTemperatureImmunity);
+            SubscribeLocalEvent<TemperatureComponent, TemperatureChangeAttemptEvent>(OnTemperatureChangeAttempt);
             SubscribeLocalEvent<TemperatureComponent, OnTemperatureChangeEvent>(OnTemperatureChange);
         }
 
         private void OnTemperatureImmunity(Entity<TemperatureComponent> _, ref TemperatureImmunityEvent args)
         {
             args.CurrentTemperature += ImmunityAdjustment;
+        }
+
+        private void OnTemperatureChangeAttempt(Entity<TemperatureComponent> _, ref TemperatureChangeAttemptEvent args)
+        {
+            if (!CancelNextAttempt)
+                return;
+
+            CancelNextAttempt = false;
+            args.Cancel();
         }
 
         private void OnTemperatureChange(Entity<TemperatureComponent> _, ref OnTemperatureChangeEvent args)

--- a/Content.IntegrationTests/Tests/_Pirate/Temperature/TemperatureSystemTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Temperature/TemperatureSystemTest.cs
@@ -26,6 +26,13 @@ public sealed class TemperatureSystemTest : RobustIntegrationTest
             ContentStart = true,
             ContentAssemblies = PoolManager.GetAssemblies(client: false, includePoolAssembly: false),
             Pool = false,
+            // The standalone harness does not mount Pirate prototype resources, but BankCardSystem
+            // indexes this prototype during content startup.
+            ExtraPrototypes = """
+                - type: salary
+                  id: Salaries
+                  salaries: {}
+                """,
             // Content startup currently reports a known invalid prototype at Error level.
             FailureLogLevel = LogLevel.Fatal,
             Options = new ServerOptions

--- a/Content.IntegrationTests/Tests/_Pirate/Temperature/TemperatureSystemTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Temperature/TemperatureSystemTest.cs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Server.Temperature.Systems;
+using Content.Goobstation.Shared.Temperature;
 using Content.Shared.Temperature;
 using Content.Shared.Temperature.Components;
 using Robust.Server;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Reflection;
 using Robust.UnitTesting;
@@ -24,6 +26,8 @@ public sealed class TemperatureSystemTest : RobustIntegrationTest
             ContentStart = true,
             ContentAssemblies = PoolManager.GetAssemblies(client: false, includePoolAssembly: false),
             Pool = false,
+            // Content startup currently reports a known invalid prototype at Error level.
+            FailureLogLevel = LogLevel.Fatal,
             Options = new ServerOptions
             {
                 LoadConfigAndUserData = false,
@@ -44,6 +48,7 @@ public sealed class TemperatureSystemTest : RobustIntegrationTest
 
         using var server = StartServer(options);
         await server.WaitIdleAsync();
+        await server.WaitPost(() => server.CfgMan.SetCVar(RTCVars.FailureLogLevel, LogLevel.Error));
 
         await server.WaitAssertion(() =>
         {
@@ -52,27 +57,51 @@ public sealed class TemperatureSystemTest : RobustIntegrationTest
             var counter = entityManager.System<TemperatureEventCounterSystem>();
             var entity = entityManager.SpawnEntity(null, MapCoordinates.Nullspace);
             var temperature = entityManager.AddComponent<TemperatureComponent>(entity);
+            var lastTemperature = temperature.CurrentTemperature;
+            var requestedTemperature = lastTemperature + 1f;
+            var expectedTemperature = requestedTemperature + TemperatureEventCounterSystem.ImmunityAdjustment;
 
-            temperatureSystem.ForceChangeTemperature(entity, temperature.CurrentTemperature + 1f, temperature);
+            temperatureSystem.ForceChangeTemperature(entity, requestedTemperature, temperature);
 
-            Assert.That(counter.EventCount, Is.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(counter.EventCount, Is.EqualTo(1));
+                Assert.That(counter.CurrentTemperature, Is.EqualTo(expectedTemperature).Within(0.001f));
+                Assert.That(counter.LastTemperature, Is.EqualTo(lastTemperature).Within(0.001f));
+                Assert.That(counter.TemperatureDelta, Is.EqualTo(expectedTemperature - lastTemperature).Within(0.001f));
+                Assert.That(temperature.CurrentTemperature, Is.EqualTo(expectedTemperature).Within(0.001f));
+            });
         });
     }
 
     [Reflect(false)]
     private sealed class TemperatureEventCounterSystem : EntitySystem
     {
+        public const float ImmunityAdjustment = 1f;
+
         public int EventCount { get; private set; }
+        public float CurrentTemperature { get; private set; }
+        public float LastTemperature { get; private set; }
+        public float TemperatureDelta { get; private set; }
 
         public override void Initialize()
         {
             base.Initialize();
+            SubscribeLocalEvent<TemperatureComponent, TemperatureImmunityEvent>(OnTemperatureImmunity);
             SubscribeLocalEvent<TemperatureComponent, OnTemperatureChangeEvent>(OnTemperatureChange);
+        }
+
+        private void OnTemperatureImmunity(Entity<TemperatureComponent> _, ref TemperatureImmunityEvent args)
+        {
+            args.CurrentTemperature += ImmunityAdjustment;
         }
 
         private void OnTemperatureChange(Entity<TemperatureComponent> _, ref OnTemperatureChangeEvent args)
         {
             EventCount++;
+            CurrentTemperature = args.CurrentTemperature;
+            LastTemperature = args.LastTemperature;
+            TemperatureDelta = args.TemperatureDelta;
         }
     }
 }

--- a/Content.IntegrationTests/Tests/_Pirate/Temperature/TemperatureSystemTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Temperature/TemperatureSystemTest.cs
@@ -26,23 +26,11 @@ public sealed class TemperatureSystemTest : RobustIntegrationTest
             ContentStart = true,
             ContentAssemblies = PoolManager.GetAssemblies(client: false, includePoolAssembly: false),
             Pool = false,
-            // The standalone harness does not mount content prototype resources required during
-            // content startup.
-            ExtraPrototypes = """
-                - type: language
-                  id: Universal
-                - type: language
-                  id: Psychomantic
-                - type: salary
-                  id: Salaries
-                  salaries: {}
-                """,
-            // Content startup currently reports a known invalid prototype at Error level.
             FailureLogLevel = LogLevel.Fatal,
             Options = new ServerOptions
             {
                 LoadConfigAndUserData = false,
-                LoadContentResources = false,
+                LoadContentResources = true,
             },
         };
 

--- a/Content.Server/Shuttles/Systems/RadarConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/RadarConsoleSystem.cs
@@ -18,16 +18,31 @@ public sealed class RadarConsoleSystem : SharedRadarConsoleSystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<RadarConsoleComponent, ComponentStartup>(OnRadarStartup);
+        Subs.BuiEvents<RadarConsoleComponent>(RadarConsoleUiKey.Key, subs =>
+        {
+            subs.Event<BoundUIOpenedEvent>(OnRadarUIOpened);
+            subs.Event<BoundUIClosedEvent>(OnRadarUIClosed);
+        });
     }
 
-    private void OnRadarStartup(EntityUid uid, RadarConsoleComponent component, ComponentStartup args)
+    private void OnRadarUIOpened(EntityUid uid, RadarConsoleComponent component, BoundUIOpenedEvent args)
     {
         UpdateState(uid, component);
     }
 
+    private void OnRadarUIClosed(EntityUid uid, RadarConsoleComponent component, BoundUIClosedEvent args)
+    {
+        // Pirate: do not retain a large radar state in replay/PVS after the last viewer closes the UI.
+        if (!_uiSystem.IsUiOpen(uid, RadarConsoleUiKey.Key))
+            _uiSystem.SetUiState(uid, RadarConsoleUiKey.Key, null);
+    }
+
     protected override void UpdateState(EntityUid uid, RadarConsoleComponent component)
     {
+        // Pirate: BUI state is only useful while a console is open; avoid retaining it in replays otherwise.
+        if (!_uiSystem.IsUiOpen(uid, RadarConsoleUiKey.Key))
+            return;
+
         var xform = Transform(uid);
         var onGrid = xform.ParentUid == xform.GridUid;
         EntityCoordinates? coordinates = onGrid ? xform.Coordinates : null;

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -69,6 +69,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
         SubscribeLocalEvent<ShuttleConsoleComponent, AfterActivatableUIOpenEvent>(OnConsoleUIOpenAttempt);
         Subs.BuiEvents<ShuttleConsoleComponent>(ShuttleConsoleUiKey.Key, subs =>
         {
+            subs.Event<BoundUIOpenedEvent>(OnConsoleUIOpened);
             subs.Event<ShuttleConsoleFTLBeaconMessage>(OnBeaconFTLMessage);
             subs.Event<ShuttleConsoleFTLPositionMessage>(OnPositionFTLMessage);
             #region Pirate: multiz
@@ -122,8 +123,6 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
     /// </summary>
     public void RefreshShuttleConsoles(EntityUid gridUid)
     {
-        var exclusions = new List<ShuttleExclusionObject>();
-        GetExclusions(ref exclusions);
         _consoles.Clear();
         DockingInterfaceState? dockState = null;
         DockingPortStates? dockingPortStates = null;
@@ -162,8 +161,6 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
     /// </summary>
     public void RefreshShuttleConsoles()
     {
-        var exclusions = new List<ShuttleExclusionObject>();
-        GetExclusions(ref exclusions);
         var query = AllEntityQuery<ShuttleConsoleComponent>();
         DockingInterfaceState? dockState = null;
         DockingPortStates? dockingPortStates = null;
@@ -180,11 +177,20 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
     private void OnConsoleUIClose(EntityUid uid, ShuttleConsoleComponent component, BoundUIClosedEvent args)
     {
         if ((ShuttleConsoleUiKey)args.UiKey != ShuttleConsoleUiKey.Key)
-        {
             return;
-        }
 
         RemovePilot(args.Actor);
+
+        // Pirate: do not retain a large shuttle state in replay/PVS after the last viewer closes the UI.
+        if (!_ui.IsUiOpen(uid, ShuttleConsoleUiKey.Key))
+            _ui.SetUiState(uid, ShuttleConsoleUiKey.Key, null);
+    }
+
+    private void OnConsoleUIOpened(EntityUid uid, ShuttleConsoleComponent component, BoundUIOpenedEvent args)
+    {
+        DockingInterfaceState? dockState = null;
+        DockingPortStates? dockingPortStates = null;
+        UpdateState(uid, ref dockState, ref dockingPortStates);
     }
 
     private void OnConsoleUIOpenAttempt(EntityUid uid, ShuttleConsoleComponent component,
@@ -296,6 +302,10 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
         ref DockingInterfaceState? dockState,
         ref DockingPortStates? dockingPortStates)
     {
+        // Pirate: BUI state is only useful while a console is open; avoid retaining it in replays otherwise.
+        if (!_ui.IsUiOpen(consoleUid, ShuttleConsoleUiKey.Key))
+            return;
+
         EntityUid? entity = consoleUid;
 
         var getShuttleEv = new ConsoleShuttleEvent

--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -89,7 +89,7 @@ public sealed partial class TemperatureSystem : SharedTemperatureSystem
             return;
 
         var lastTemp = temperature.CurrentTemperature;
-        var delta = temperature.CurrentTemperature - temp;
+        var attemptDelta = temperature.CurrentTemperature - temp;
         temperature.CurrentTemperature = temp;
 
         // Goob start
@@ -104,13 +104,14 @@ public sealed partial class TemperatureSystem : SharedTemperatureSystem
         RaiseLocalEvent(uid, tempEv);
         temperature.CurrentTemperature = tempEv.CurrentTemperature;
 
-        var attemptEv = new TemperatureChangeAttemptEvent(temp, lastTemp, delta);
+        var attemptEv = new TemperatureChangeAttemptEvent(temp, lastTemp, attemptDelta);
         RaiseLocalEvent(uid, attemptEv);
         if (attemptEv.Cancelled)
             return;
         // Goob end
 
         // Pirate: notify listeners once, after all temperature modifiers have been applied.
+        var delta = temperature.CurrentTemperature - lastTemp;
         RaiseLocalEvent(uid, new OnTemperatureChangeEvent(temperature.CurrentTemperature, lastTemp, delta),
             true);
     }

--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -91,7 +91,6 @@ public sealed partial class TemperatureSystem : SharedTemperatureSystem
         var lastTemp = temperature.CurrentTemperature;
         var delta = temperature.CurrentTemperature - temp;
         temperature.CurrentTemperature = temp;
-        RaiseLocalEvent(uid, new OnTemperatureChangeEvent(temperature.CurrentTemperature, lastTemp, delta), broadcast: true);
 
         // Goob start
 
@@ -111,6 +110,7 @@ public sealed partial class TemperatureSystem : SharedTemperatureSystem
             return;
         // Goob end
 
+        // Pirate: notify listeners once, after all temperature modifiers have been applied.
         RaiseLocalEvent(uid, new OnTemperatureChangeEvent(temperature.CurrentTemperature, lastTemp, delta),
             true);
     }

--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -89,30 +89,31 @@ public sealed partial class TemperatureSystem : SharedTemperatureSystem
             return;
 
         var lastTemp = temperature.CurrentTemperature;
-        var attemptDelta = temperature.CurrentTemperature - temp;
-        temperature.CurrentTemperature = temp;
+        var newTemp = temp;
 
         // Goob start
 
         var preEv = new BeforeTemperatureChange(
-            temperature.CurrentTemperature,
+            newTemp,
             lastTemp,
-            temperature.CurrentTemperature - lastTemp);
+            newTemp - lastTemp);
         RaiseLocalEvent(uid, ref preEv);
 
-        var tempEv = new TemperatureImmunityEvent(temperature.CurrentTemperature);
+        var tempEv = new TemperatureImmunityEvent(newTemp);
         RaiseLocalEvent(uid, tempEv);
-        temperature.CurrentTemperature = tempEv.CurrentTemperature;
+        newTemp = tempEv.CurrentTemperature;
 
-        var attemptEv = new TemperatureChangeAttemptEvent(temp, lastTemp, attemptDelta);
+        var attemptEv = new TemperatureChangeAttemptEvent(newTemp, lastTemp, newTemp - lastTemp);
         RaiseLocalEvent(uid, attemptEv);
         if (attemptEv.Cancelled)
             return;
+
+        temperature.CurrentTemperature = newTemp;
         // Goob end
 
         // Pirate: notify listeners once, after all temperature modifiers have been applied.
-        var delta = temperature.CurrentTemperature - lastTemp;
-        RaiseLocalEvent(uid, new OnTemperatureChangeEvent(temperature.CurrentTemperature, lastTemp, delta),
+        var delta = newTemp - lastTemp;
+        RaiseLocalEvent(uid, new OnTemperatureChangeEvent(newTemp, lastTemp, delta),
             true);
     }
 

--- a/Content.Server/_Mono/FireControl/FireControlSystem.Console.cs
+++ b/Content.Server/_Mono/FireControl/FireControlSystem.Console.cs
@@ -32,6 +32,7 @@ public sealed partial class FireControlSystem : EntitySystem
         SubscribeLocalEvent<FireControlConsoleComponent, FireControlConsoleRefreshServerMessage>(OnRefreshServer);
         SubscribeLocalEvent<FireControlConsoleComponent, FireControlConsoleFireMessage>(OnFire);
         SubscribeLocalEvent<FireControlConsoleComponent, BoundUIOpenedEvent>(OnUIOpened);
+        SubscribeLocalEvent<FireControlConsoleComponent, BoundUIClosedEvent>(OnUIClosed);
         SubscribeLocalEvent<FireControlConsoleComponent, FireControlConsoleSelectLayerMessage>(OnSelectLayer); // Pirate: multiz
     }
 
@@ -78,7 +79,19 @@ public sealed partial class FireControlSystem : EntitySystem
 
     public void OnUIOpened(EntityUid uid, FireControlConsoleComponent component, BoundUIOpenedEvent args)
     {
+        if (args.UiKey is not FireControlConsoleUiKey.Key)
+            return;
+
         UpdateUi(uid, component);
+    }
+
+    private void OnUIClosed(EntityUid uid, FireControlConsoleComponent component, BoundUIClosedEvent args)
+    {
+        if (args.UiKey is not FireControlConsoleUiKey.Key || _ui.IsUiOpen(uid, FireControlConsoleUiKey.Key))
+            return;
+
+        // Pirate: do not retain a large gunnery state in replay/PVS after the last viewer closes the UI.
+        _ui.SetUiState(uid, FireControlConsoleUiKey.Key, null);
     }
 
     #region Pirate: multiz
@@ -126,6 +139,10 @@ public sealed partial class FireControlSystem : EntitySystem
     private void UpdateUi(EntityUid uid, FireControlConsoleComponent? component = null)
     {
         if (!Resolve(uid, ref component))
+            return;
+
+        // Pirate: gunnery state is only useful while the console is open; avoid replay/PVS payload for idle consoles.
+        if (!_ui.IsUiOpen(uid, FireControlConsoleUiKey.Key))
             return;
 
         #region Pirate: multiz


### PR DESCRIPTION
:cl:
- fix: Прибрано подвійне сповіщення про зміну температури
- tweak: Не зберігати важкі стани shuttle/radar/gunnery UI у replay після закриття

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Виправлення**
  * Подію зміни температури надсилають після застосування всіх модифікаторів, тож слухачі отримують остаточне значення.
  * Стан радарних, шатлових і вогневих консолей оновлюється лише під час відкриття інтерфейсу та очищується після його закриття.
  * Закриті консолі більше не виконують зайві оновлення та не зберігають великий стан у реплеях і PVS.

* **Тести**
  * Додано інтеграційну перевірку одноразового надсилання події зміни температури.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->