### PR TITLE
secret doors

### DIFF
--- a/Content.Pirate.Server/Construction/AlignToAdjacentWallsSystem.cs
+++ b/Content.Pirate.Server/Construction/AlignToAdjacentWallsSystem.cs
@@ -1,0 +1,69 @@
+using Content.Pirate.Shared.Construction;
+using Content.Server.Construction;
+using Content.Shared.Tag;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Pirate.Server.Construction;
+
+/// <summary>
+/// Turns a freshly built entity to match the wall run around it.
+/// </summary>
+public sealed class AlignToAdjacentWallsSystem : EntitySystem
+{
+    [Dependency] private readonly SharedMapSystem _maps = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly TagSystem _tags = default!;
+
+    private static readonly ProtoId<TagPrototype> WallTag = "Wall";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<AlignToAdjacentWallsComponent, AfterConstructionChangeEntityEvent>(OnConstructed);
+    }
+
+    private void OnConstructed(Entity<AlignToAdjacentWallsComponent> ent, ref AfterConstructionChangeEntityEvent args)
+    {
+        Align(ent);
+    }
+
+    /// <summary>
+    /// Rotates the entity onto whichever axis has more adjacent walls. Leaves it alone on a tie, so a
+    /// free-standing door keeps whatever the construction step gave it.
+    /// </summary>
+    public void Align(Entity<AlignToAdjacentWallsComponent> ent)
+    {
+        var xform = Transform(ent);
+
+        if (xform.GridUid is not { } gridUid || !TryComp<MapGridComponent>(gridUid, out var grid))
+            return;
+
+        var origin = _maps.TileIndicesFor(gridUid, grid, xform.Coordinates);
+
+        var northSouth = HasWall(gridUid, grid, origin + new Vector2i(0, 1))
+                       + HasWall(gridUid, grid, origin + new Vector2i(0, -1));
+        var eastWest = HasWall(gridUid, grid, origin + new Vector2i(1, 0))
+                     + HasWall(gridUid, grid, origin + new Vector2i(-1, 0));
+
+        if (northSouth == eastWest)
+            return;
+
+        var degrees = northSouth > eastWest ? ent.Comp.AlongNorthSouth : ent.Comp.AlongEastWest;
+        _transform.SetLocalRotation(ent, Angle.FromDegrees(degrees));
+    }
+
+    private int HasWall(EntityUid gridUid, MapGridComponent grid, Vector2i tile)
+    {
+        var anchored = _maps.GetAnchoredEntitiesEnumerator(gridUid, grid, tile);
+
+        while (anchored.MoveNext(out var uid))
+        {
+            if (_tags.HasTag(uid.Value, WallTag))
+                return 1;
+        }
+
+        return 0;
+    }
+}

--- a/Content.Pirate.Server/Construction/AlignToAdjacentWallsSystem.cs
+++ b/Content.Pirate.Server/Construction/AlignToAdjacentWallsSystem.cs
@@ -7,9 +7,6 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Pirate.Server.Construction;
 
-/// <summary>
-/// Turns a freshly built entity to match the wall run around it.
-/// </summary>
 public sealed class AlignToAdjacentWallsSystem : EntitySystem
 {
     [Dependency] private readonly SharedMapSystem _maps = default!;
@@ -29,10 +26,7 @@ public sealed class AlignToAdjacentWallsSystem : EntitySystem
         Align(ent);
     }
 
-    /// <summary>
-    /// Rotates the entity onto whichever axis has more adjacent walls. Leaves it alone on a tie, so a
-    /// free-standing door keeps whatever the construction step gave it.
-    /// </summary>
+    /// <summary>Aligns a constructed entity with the dominant adjacent-wall axis.</summary>
     public void Align(Entity<AlignToAdjacentWallsComponent> ent)
     {
         var xform = Transform(ent);

--- a/Content.Pirate.Server/Construction/DoorClosed.cs
+++ b/Content.Pirate.Server/Construction/DoorClosed.cs
@@ -5,10 +5,7 @@ using JetBrains.Annotations;
 
 namespace Content.Pirate.Server.Construction;
 
-/// <summary>
-/// Requires a door to be shut before the edge can be taken. Secret doors use this so they can only
-/// be bolted into a solid wall while closed, mirroring the /tg/station falsewall screwdriver check.
-/// </summary>
+/// <summary>Requires a door to match the configured closed state.</summary>
 [UsedImplicitly]
 [DataDefinition]
 public sealed partial class DoorClosed : IGraphCondition
@@ -24,7 +21,8 @@ public sealed partial class DoorClosed : IGraphCondition
 
     public bool Condition(EntityUid uid, IEntityManager entityManager)
     {
-        return IsClosed(uid, entityManager) == Closed;
+        return entityManager.TryGetComponent<DoorComponent>(uid, out var door)
+               && (door.State == DoorState.Closed) == Closed;
     }
 
     public bool DoExamine(ExaminedEvent args)

--- a/Content.Pirate.Server/Construction/DoorClosed.cs
+++ b/Content.Pirate.Server/Construction/DoorClosed.cs
@@ -1,0 +1,52 @@
+using Content.Shared.Construction;
+using Content.Shared.Doors.Components;
+using Content.Shared.Examine;
+using JetBrains.Annotations;
+
+namespace Content.Pirate.Server.Construction;
+
+/// <summary>
+/// Requires a door to be shut before the edge can be taken. Secret doors use this so they can only
+/// be bolted into a solid wall while closed, mirroring the /tg/station falsewall screwdriver check.
+/// </summary>
+[UsedImplicitly]
+[DataDefinition]
+public sealed partial class DoorClosed : IGraphCondition
+{
+    [DataField]
+    public bool Closed { get; private set; } = true;
+
+    private static bool IsClosed(EntityUid uid, IEntityManager entityManager)
+    {
+        return entityManager.TryGetComponent<DoorComponent>(uid, out var door)
+               && door.State == DoorState.Closed;
+    }
+
+    public bool Condition(EntityUid uid, IEntityManager entityManager)
+    {
+        return IsClosed(uid, entityManager) == Closed;
+    }
+
+    public bool DoExamine(ExaminedEvent args)
+    {
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+
+        if (IsClosed(args.Examined, entityManager) == Closed)
+            return false;
+
+        args.PushMarkup(Loc.GetString(Closed
+            ? "construction-examine-condition-door-closed"
+            : "construction-examine-condition-door-open"));
+        return true;
+    }
+
+    public IEnumerable<ConstructionGuideEntry> GenerateGuideEntry()
+    {
+        yield return new ConstructionGuideEntry
+        {
+            Localization = Closed
+                ? "construction-step-condition-door-closed"
+                : "construction-step-condition-door-open",
+        };
+    }
+}

--- a/Content.Pirate.Shared/AtmosLinks/AtmosLinkOverlayEvents.cs
+++ b/Content.Pirate.Shared/AtmosLinks/AtmosLinkOverlayEvents.cs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+
+namespace Content.Pirate.Shared.AtmosLinks;
+
+/// <summary>
+///     What kind of atmos device a marker belongs to. Only used to pick a color and a short label client side.
+/// </summary>
+[Serializable, NetSerializable]
+public enum AtmosLinkDeviceKind : byte
+{
+    Other,
+    AirAlarm,
+    FireAlarm,
+    Sensor,
+    Vent,
+    Scrubber,
+    Firelock,
+}
+
+/// <summary>
+///     One device list (air alarm, fire alarm, ...) together with everything it links to.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class AtmosLinkGroup
+{
+    public NetCoordinates Source;
+    public AtmosLinkDeviceKind Kind;
+    public List<NetCoordinates> Targets;
+
+    public AtmosLinkGroup(NetCoordinates source, AtmosLinkDeviceKind kind, List<NetCoordinates> targets)
+    {
+        Source = source;
+        Kind = kind;
+        Targets = targets;
+    }
+}
+
+/// <summary>
+///     An atmos device that no device list references, or a device list that links to nothing.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class AtmosLinkOrphan
+{
+    public NetCoordinates Position;
+    public AtmosLinkDeviceKind Kind;
+
+    public AtmosLinkOrphan(NetCoordinates position, AtmosLinkDeviceKind kind)
+    {
+        Position = position;
+        Kind = kind;
+    }
+}
+
+/// <summary>
+///     Snapshot of every atmos device link and every unlinked atmos device, sent to a mapper that
+///     enabled the overlay with the "atmoslinks" command.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class AtmosLinkOverlayDataEvent : EntityEventArgs
+{
+    public List<AtmosLinkGroup> Groups;
+    public List<AtmosLinkOrphan> Orphans;
+
+    public AtmosLinkOverlayDataEvent(List<AtmosLinkGroup> groups, List<AtmosLinkOrphan> orphans)
+    {
+        Groups = groups;
+        Orphans = orphans;
+    }
+}
+
+/// <summary>
+///     Tells the client to drop the overlay.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class AtmosLinkOverlayDisableEvent : EntityEventArgs
+{
+}

--- a/Content.Pirate.Shared/AtmosLinks/AtmosLinkOverlayEvents.cs
+++ b/Content.Pirate.Shared/AtmosLinks/AtmosLinkOverlayEvents.cs
@@ -5,9 +5,6 @@ using Robust.Shared.Serialization;
 
 namespace Content.Pirate.Shared.AtmosLinks;
 
-/// <summary>
-///     What kind of atmos device a marker belongs to. Only used to pick a color and a short label client side.
-/// </summary>
 [Serializable, NetSerializable]
 public enum AtmosLinkDeviceKind : byte
 {
@@ -20,9 +17,6 @@ public enum AtmosLinkDeviceKind : byte
     Firelock,
 }
 
-/// <summary>
-///     One device list (air alarm, fire alarm, ...) together with everything it links to.
-/// </summary>
 [Serializable, NetSerializable]
 public sealed class AtmosLinkGroup
 {
@@ -38,9 +32,6 @@ public sealed class AtmosLinkGroup
     }
 }
 
-/// <summary>
-///     An atmos device that no device list references, or a device list that links to nothing.
-/// </summary>
 [Serializable, NetSerializable]
 public sealed class AtmosLinkOrphan
 {
@@ -54,10 +45,6 @@ public sealed class AtmosLinkOrphan
     }
 }
 
-/// <summary>
-///     Snapshot of every atmos device link and every unlinked atmos device, sent to a mapper that
-///     enabled the overlay with the "atmoslinks" command.
-/// </summary>
 [Serializable, NetSerializable]
 public sealed class AtmosLinkOverlayDataEvent : EntityEventArgs
 {
@@ -71,9 +58,6 @@ public sealed class AtmosLinkOverlayDataEvent : EntityEventArgs
     }
 }
 
-/// <summary>
-///     Tells the client to drop the overlay.
-/// </summary>
 [Serializable, NetSerializable]
 public sealed class AtmosLinkOverlayDisableEvent : EntityEventArgs
 {

--- a/Content.Pirate.Shared/Construction/AlignToAdjacentWallsComponent.cs
+++ b/Content.Pirate.Shared/Construction/AlignToAdjacentWallsComponent.cs
@@ -1,0 +1,24 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Pirate.Shared.Construction;
+
+/// <summary>
+/// Orients an entity to match the wall run it was built into. Secret doors use this because they can't be
+/// rotated after placement, so a manually built one would otherwise always face the construction default.
+/// Only applies when the entity is built - mapped instances keep whatever rotation the mapper set.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class AlignToAdjacentWallsComponent : Component
+{
+    /// <summary>
+    /// Rotation (degrees) to use when the neighbouring walls run east-west.
+    /// </summary>
+    [DataField]
+    public float AlongEastWest;
+
+    /// <summary>
+    /// Rotation (degrees) to use when the neighbouring walls run north-south.
+    /// </summary>
+    [DataField]
+    public float AlongNorthSouth = 90f;
+}

--- a/Content.Pirate.Shared/Construction/AlignToAdjacentWallsComponent.cs
+++ b/Content.Pirate.Shared/Construction/AlignToAdjacentWallsComponent.cs
@@ -2,23 +2,12 @@ using Robust.Shared.GameStates;
 
 namespace Content.Pirate.Shared.Construction;
 
-/// <summary>
-/// Orients an entity to match the wall run it was built into. Secret doors use this because they can't be
-/// rotated after placement, so a manually built one would otherwise always face the construction default.
-/// Only applies when the entity is built - mapped instances keep whatever rotation the mapper set.
-/// </summary>
 [RegisterComponent, NetworkedComponent]
 public sealed partial class AlignToAdjacentWallsComponent : Component
 {
-    /// <summary>
-    /// Rotation (degrees) to use when the neighbouring walls run east-west.
-    /// </summary>
     [DataField]
     public float AlongEastWest;
 
-    /// <summary>
-    /// Rotation (degrees) to use when the neighbouring walls run north-south.
-    /// </summary>
     [DataField]
     public float AlongNorthSouth = 90f;
 }

--- a/Content.Pirate.Shared/Tools/StackRefinableComponent.cs
+++ b/Content.Pirate.Shared/Tools/StackRefinableComponent.cs
@@ -1,0 +1,48 @@
+using Content.Shared.DoAfter;
+using Content.Shared.Tools;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Pirate.Shared.Tools;
+
+/// <summary>
+/// Refines part of a stack with a tool, leaving the remainder alone. The vanilla ToolRefinableComponent
+/// deletes the whole entity, which would eat an entire stack of rods to produce a single sheet.
+/// Mirrors SS13's rods.dm welder_act: 2 rods -> 1 steel sheet, repeatable down the stack.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class StackRefinableComponent : Component
+{
+    /// <summary>
+    /// What a single refine produces.
+    /// </summary>
+    [DataField(required: true)]
+    public EntProtoId RefineResult;
+
+    /// <summary>
+    /// How many units of this stack one refine consumes.
+    /// </summary>
+    [DataField]
+    public int Cost = 2;
+
+    /// <summary>
+    /// How many <see cref="RefineResult"/> a single refine spawns.
+    /// </summary>
+    [DataField]
+    public int ResultAmount = 1;
+
+    [DataField]
+    public float RefineTime = 1f;
+
+    [DataField]
+    public float RefineFuel = 1f;
+
+    [DataField]
+    public ProtoId<ToolQualityPrototype> QualityNeeded = "Welding";
+}
+
+[Serializable, NetSerializable]
+public sealed partial class StackRefineDoAfterEvent : SimpleDoAfterEvent
+{
+}

--- a/Content.Pirate.Shared/Tools/StackRefinableComponent.cs
+++ b/Content.Pirate.Shared/Tools/StackRefinableComponent.cs
@@ -6,29 +6,16 @@ using Robust.Shared.Serialization;
 
 namespace Content.Pirate.Shared.Tools;
 
-/// <summary>
-/// Refines part of a stack with a tool, leaving the remainder alone. The vanilla ToolRefinableComponent
-/// deletes the whole entity, which would eat an entire stack of rods to produce a single sheet.
-/// Mirrors SS13's rods.dm welder_act: 2 rods -> 1 steel sheet, repeatable down the stack.
-/// </summary>
+/// <summary>Refines part of a stack without consuming its remainder.</summary>
 [RegisterComponent, NetworkedComponent]
 public sealed partial class StackRefinableComponent : Component
 {
-    /// <summary>
-    /// What a single refine produces.
-    /// </summary>
     [DataField(required: true)]
     public EntProtoId RefineResult;
 
-    /// <summary>
-    /// How many units of this stack one refine consumes.
-    /// </summary>
     [DataField]
     public int Cost = 2;
 
-    /// <summary>
-    /// How many <see cref="RefineResult"/> a single refine spawns.
-    /// </summary>
     [DataField]
     public int ResultAmount = 1;
 

--- a/Content.Pirate.Shared/Tools/StackRefinableSystem.cs
+++ b/Content.Pirate.Shared/Tools/StackRefinableSystem.cs
@@ -6,9 +6,6 @@ using Robust.Shared.Network;
 
 namespace Content.Pirate.Shared.Tools;
 
-/// <summary>
-/// Lets a tool refine part of a stack into something else without destroying the rest of it.
-/// </summary>
 public sealed class StackRefinableSystem : EntitySystem
 {
     [Dependency] private readonly INetManager _net = default!;
@@ -28,8 +25,7 @@ public sealed class StackRefinableSystem : EntitySystem
         if (args.Handled)
             return;
 
-        // Only complain about the count if they're actually holding the right tool, otherwise every
-        // interaction with a short stack would nag.
+        // Avoid a shortage popup for unrelated tools.
         if (!_tool.HasQuality(args.Used, ent.Comp.QualityNeeded))
             return;
 
@@ -58,7 +54,7 @@ public sealed class StackRefinableSystem : EntitySystem
         if (_net.IsClient)
             return;
 
-        // The stack can shrink while the do-after runs, so re-check before consuming.
+        // The stack can shrink during the do-after.
         if (!_stack.TryUse(ent.Owner, ent.Comp.Cost))
             return;
 
@@ -69,8 +65,7 @@ public sealed class StackRefinableSystem : EntitySystem
             SpawnNextToOrDrop(ent.Comp.RefineResult, ent);
         }
 
-        // Keep going while there's enough left, so a big stack doesn't need a click per pair.
-        // TryUse deletes the stack when it empties, so re-check existence before repeating.
+        // Repeat while another refinement can be paid for.
         if (Exists(ent) && !TerminatingOrDeleted(ent) && _stack.GetCount(ent.Owner) >= ent.Comp.Cost)
             args.Repeat = true;
     }

--- a/Content.Pirate.Shared/Tools/StackRefinableSystem.cs
+++ b/Content.Pirate.Shared/Tools/StackRefinableSystem.cs
@@ -1,0 +1,77 @@
+using Content.Shared.Interaction;
+using Content.Shared.Popups;
+using Content.Shared.Stacks;
+using Content.Shared.Tools.Systems;
+using Robust.Shared.Network;
+
+namespace Content.Pirate.Shared.Tools;
+
+/// <summary>
+/// Lets a tool refine part of a stack into something else without destroying the rest of it.
+/// </summary>
+public sealed class StackRefinableSystem : EntitySystem
+{
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedStackSystem _stack = default!;
+    [Dependency] private readonly SharedToolSystem _tool = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<StackRefinableComponent, InteractUsingEvent>(OnInteractUsing);
+        SubscribeLocalEvent<StackRefinableComponent, StackRefineDoAfterEvent>(OnDoAfter);
+    }
+
+    private void OnInteractUsing(Entity<StackRefinableComponent> ent, ref InteractUsingEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        // Only complain about the count if they're actually holding the right tool, otherwise every
+        // interaction with a short stack would nag.
+        if (!_tool.HasQuality(args.Used, ent.Comp.QualityNeeded))
+            return;
+
+        if (_stack.GetCount(ent.Owner) < ent.Comp.Cost)
+        {
+            _popup.PopupClient(Loc.GetString("stack-refinable-not-enough",
+                ("count", ent.Comp.Cost), ("item", ent.Owner)), ent, args.User);
+            return;
+        }
+
+        args.Handled = _tool.UseTool(
+            args.Used,
+            args.User,
+            ent,
+            ent.Comp.RefineTime,
+            ent.Comp.QualityNeeded,
+            new StackRefineDoAfterEvent(),
+            fuel: ent.Comp.RefineFuel);
+    }
+
+    private void OnDoAfter(Entity<StackRefinableComponent> ent, ref StackRefineDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled)
+            return;
+
+        if (_net.IsClient)
+            return;
+
+        // The stack can shrink while the do-after runs, so re-check before consuming.
+        if (!_stack.TryUse(ent.Owner, ent.Comp.Cost))
+            return;
+
+        args.Handled = true;
+
+        for (var i = 0; i < ent.Comp.ResultAmount; i++)
+        {
+            SpawnNextToOrDrop(ent.Comp.RefineResult, ent);
+        }
+
+        // Keep going while there's enough left, so a big stack doesn't need a click per pair.
+        // TryUse deletes the stack when it empties, so re-check existence before repeating.
+        if (Exists(ent) && !TerminatingOrDeleted(ent) && _stack.GetCount(ent.Owner) >= ent.Comp.Cost)
+            args.Repeat = true;
+    }
+}

--- a/Content.Server/Construction/ConstructionSystem.Graph.cs
+++ b/Content.Server/Construction/ConstructionSystem.Graph.cs
@@ -368,7 +368,13 @@ namespace Content.Server.Construction
             var newTransform = Transform(newUid);
             TransformSystem.AttachToGridOrMap(newUid, newTransform); // in case in hands or a container
             newTransform.LocalRotation = transform.LocalRotation;
-            newTransform.Anchored = transform.Anchored;
+            // Pirate: secret door - route unanchoring through the system so the physics body drops back to
+            // Dynamic and the snap-grid cell is released. The raw setter leaves an entity whose prototype is
+            // bodyType: Static (e.g. Girder) unanchored but unpullable until it's wrench-cycled by hand.
+            if (!transform.Anchored)
+                TransformSystem.Unanchor(newUid, newTransform);
+            else
+                newTransform.Anchored = transform.Anchored;
 
             // Container transferring.
             if (containerManager != null)

--- a/Content.Shared/Tools/Systems/SharedToolSystem.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.cs
@@ -65,14 +65,18 @@ public abstract partial class SharedToolSystem : EntitySystem
         var ev = args.WrappedEvent;
         ev.DoAfter = args.DoAfter;
 
+#region Pirate: rod refining
+        // SharedDoAfterSystem only resets the outer event.
+        ev.Handled = false;
+        ev.Repeat = false;
+
         if (args.OriginalTarget != null)
             RaiseLocalEvent(GetEntity(args.OriginalTarget.Value), (object) ev);
         else
             RaiseLocalEvent((object) ev);
 
-        // Pirate: rod refining - carry the wrapped event's repeat request back out to the tool do-after.
-        // SharedDoAfterSystem only looks at the outer event, so without this no tool do-after can repeat.
         args.Repeat = ev.Repeat;
+#endregion Pirate: rod refining
 
         if (TryComp(uid, out UseDelayComponent? delay)) // Goobstation
             _delay.TryResetDelay((uid, delay));

--- a/Content.Shared/Tools/Systems/SharedToolSystem.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.cs
@@ -70,6 +70,10 @@ public abstract partial class SharedToolSystem : EntitySystem
         else
             RaiseLocalEvent((object) ev);
 
+        // Pirate: rod refining - carry the wrapped event's repeat request back out to the tool do-after.
+        // SharedDoAfterSystem only looks at the outer event, so without this no tool do-after can repeat.
+        args.Repeat = ev.Repeat;
+
         if (TryComp(uid, out UseDelayComponent? delay)) // Goobstation
             _delay.TryResetDelay((uid, delay));
     }

--- a/Resources/Locale/en-US/_Pirate/construction/conditions/door-closed.ftl
+++ b/Resources/Locale/en-US/_Pirate/construction/conditions/door-closed.ftl
@@ -1,0 +1,5 @@
+construction-examine-condition-door-closed = First, close it.
+construction-examine-condition-door-open = First, open it.
+
+construction-step-condition-door-closed = It must be closed.
+construction-step-condition-door-open = It must be open.

--- a/Resources/Locale/en-US/_Pirate/tools/stack-refinable.ftl
+++ b/Resources/Locale/en-US/_Pirate/tools/stack-refinable.ftl
@@ -1,0 +1,1 @@
+stack-refinable-not-enough = You need at least {$count} to shape {THE($item)} into anything.

--- a/Resources/Prototypes/Entities/Objects/Materials/parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/parts.yml
@@ -36,6 +36,10 @@
   - type: PhysicalComposition
     materialComposition:
       Steel: 50 #Half of a regular steel sheet to reflect the crafting recipe
+  # Pirate: rod refining - weld 2 rods back into a sheet, reversing the 1 steel -> 2 rods recipe (SS13 rods.dm welder_act)
+  - type: StackRefinable
+    refineResult: SheetSteel1
+    cost: 2
   - type: Stack
     stackType: MetalRod
     baseLayer: base

--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/reinforced_secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/reinforced_secret_door.yml
@@ -37,9 +37,7 @@
     openingAnimationTime: 1.2
     closingAnimationTime: 1.2
   - type: Appearance
-  - type: Weldable
-    time: 2
-    weldedExamineMessage: null
+  # Pirate: secret door - no Weldable; WeldableSystem handles InteractUsing before construction does, so the welder has to reach the graph to dismantle (SS13 falsewall)
   - type: Airtight
   - type: Damageable
     damageContainer: StructuralInorganic
@@ -60,17 +58,14 @@
     key: walls
     mode: NoSprite
   - type: Occluder
-  - type: ContainerFill
-    containers:
-      battery-container: [ PowerCellMedium ]
+  # Pirate: secret door - face the wall run we're built into; these can't be rotated once placed
+  - type: AlignToAdjacentWalls
+  # Pirate: secret door - dropped the battery-container; nothing ever read the cell
   - type: Tag
     tags:
     - Structure
     - Wall
     - ForceNoFixRotations # Don't want the fixrotations command to target these
-  - type: ContainerContainer
-    containers:
-      battery-container: !type:Container
   - type: BlockWeather
   - type: ExaminableDamage
     messages: WindowMessages
@@ -130,8 +125,6 @@
   name: reinforced wall
   parent: BaseReinforcedSecretDoor
   components:
-  - type: Construction
-    graph: ReinforcedSecretDoor
-    node: ReinforcedSecretDoor
-    containers:
-    - battery-container
+  - type: Construction # Pirate: secret door - lives in the Girder graph now, built from a displaced girder (SS13 falsewall)
+    graph: Girder
+    node: reinforcedSecretDoor

--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -41,9 +41,7 @@
     openingAnimationTime: 1.2
     closingAnimationTime: 1.2
   - type: Appearance
-  - type: Weldable
-    time: 2
-    weldedExamineMessage: null
+  # Pirate: secret door - no Weldable; WeldableSystem handles InteractUsing before construction does, so the welder has to reach the graph to dismantle (SS13 falsewall)
   - type: Airtight
   - type: Damageable
     damageContainer: StructuralInorganic
@@ -64,17 +62,14 @@
     key: walls
     mode: NoSprite
   - type: Occluder
-  - type: ContainerFill
-    containers:
-      battery-container: [ PowerCellMedium ]
+  # Pirate: secret door - face the wall run we're built into; these can't be rotated once placed
+  - type: AlignToAdjacentWalls
+  # Pirate: secret door - dropped the battery-container; nothing ever read the cell
   - type: Tag
     tags:
     - Structure
     - Wall
     - ForceNoFixRotations # Don't want the fixrotations command to target these
-  - type: ContainerContainer
-    containers:
-      battery-container: !type:Container
   - type: BlockWeather
   - type: ExaminableDamage
     messages: WindowMessages
@@ -135,10 +130,8 @@
   name: solid wall
   parent: BaseSecretDoor
   components:
-  - type: Construction
-    graph: SecretDoor
+  - type: Construction # Pirate: secret door - lives in the Girder graph now, built from a displaced girder (SS13 falsewall)
+    graph: Girder
     node: solidSecretDoor
-    containers:
-    - battery-container
   - type: CosmicCorruptible # DeltaV - Cosmic Cult
     convertTo: DoorCosmicCult

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -31,6 +31,22 @@
             - tool: Screwing
               doAfter: 2
 
+    # Pirate: secret door start - unanchored ("displaced") girder conceals into a secret door, as in SS13
+        - to: solidSecretDoor
+          completed:
+            - !type:SnapToGrid
+              southRotation: true
+            - !type:SetAnchor
+              value: true
+          conditions:
+            - !type:EntityAnchored
+              anchored: false
+          steps:
+            - material: Steel
+              amount: 2
+              doAfter: 2
+    # Pirate: secret door end
+
         - to: wall
           completed:
             - !type:SnapToGrid
@@ -148,6 +164,70 @@
             - tool: Welding
               doAfter: 10
 
+    # Pirate: secret door start - welder dismantles back to a displaced girder, screwdriver bolts it into a real wall (SS13 falsewall)
+    - node: solidSecretDoor
+      entity: SolidSecretDoor
+      edges:
+        - to: girder
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 2
+            - !type:SetAnchor
+              value: false
+          steps:
+            - tool: Welding
+              doAfter: 2
+
+        - to: wall
+          completed:
+            - !type:SnapToGrid
+              southRotation: true
+          conditions:
+            - !type:EntityAnchored {}
+            - !type:DoorClosed {}
+          steps:
+            - tool: Screwing
+              doAfter: 2
+
+    - node: reinforcedSecretDoor
+      entity: ReinforcedSecretDoor
+      edges:
+        - to: reinforcedGirder
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetPlasteel1
+              amount: 2
+            - !type:SetAnchor
+              value: false
+          steps:
+            - tool: Welding
+              doAfter: 2
+
+        # Reinforced falsewalls can also be cut apart with wirecutters in SS13
+        - to: reinforcedGirder
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetPlasteel1
+              amount: 2
+            - !type:SetAnchor
+              value: false
+          steps:
+            - tool: Cutting
+              doAfter: 2
+
+        - to: reinforcedWall
+          completed:
+            - !type:SnapToGrid
+              southRotation: true
+          conditions:
+            - !type:EntityAnchored {}
+            - !type:DoorClosed {}
+          steps:
+            - tool: Screwing
+              doAfter: 2
+    # Pirate: secret door end
+
     - node: wallChitin
       entity: WallSolidChitin
       edges:
@@ -257,6 +337,24 @@
     - node: reinforcedGirder
       entity: ReinforcedGirder
       edges:
+    # Pirate: secret door start - mirrors the reinforced wall pipeline: a displaced *reinforced* girder takes
+    # plasteel to conceal. SS13 builds every falsewall off a plain displaced girder, but its real r-wall is far
+    # cheaper than SS14's, so copying that here made the fake cost half of the wall it imitates.
+        - to: reinforcedSecretDoor
+          completed:
+            - !type:SnapToGrid
+              southRotation: true
+            - !type:SetAnchor
+              value: true
+          conditions:
+            - !type:EntityAnchored
+              anchored: false
+          steps:
+            - material: Plasteel
+              amount: 2
+              doAfter: 2
+    # Pirate: secret door end
+
         - to: reinforcedWall
           completed:
             - !type:SnapToGrid

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/reinforcedsecretdoor.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/reinforcedsecretdoor.yml
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+# Pirate: secret door - legacy assembly graph, kept for any mapped ReinforcedSecretDoorAssembly.
+# Reinforced secret doors are built from a displaced girder in the Girder graph now (SS13 falsewall);
+# the old cable + power cell steps are gone. Finishing here hands the entity to the Girder graph.
 - type: constructionGraph
   id: ReinforcedSecretDoor
   start: start
@@ -24,13 +27,15 @@
     - !type:SnapToGrid {}
     - !type:SetAnchor {}
     edges:
-    - to: wired
+    - to: ReinforcedSecretDoor
       conditions:
       - !type:EntityAnchored {}
       steps:
-      - material: Cable
+      - material: Plasteel
         amount: 4
-        doAfter: 2.5
+        doAfter: 2
+      - tool: Screwing
+        doAfter: 2
     - to: start
       conditions:
       - !type:EntityAnchored
@@ -39,65 +44,13 @@
       - !type:SpawnPrototype
         prototype: SheetSteel1
         amount: 4
+      - !type:SpawnPrototype
+        prototype: PartRodMetal1
+        amount: 4
       - !type:DeleteEntity {}
       steps:
       - tool: Welding
         doAfter: 3
 
-  - node: wired
-    entity: ReinforcedSecretDoorAssembly
-    edges:
-    - to: electronics
-      steps:
-      - component: PowerCell
-        name: construction-graph-component-power-cell
-        store: battery-container
-        icon:
-          sprite: Objects/Power/power_cells.rsi
-          state: small
-        doAfter: 1
-    - to: assembly
-      completed:
-      - !type:GivePrototype
-        prototype: CableApcStack1
-        amount: 4
-      steps:
-      - tool: Cutting
-        doAfter: 2
-
-  - node: electronics
-    entity: ReinforcedSecretDoorAssembly
-    edges:
-    - to: screwdrivering
-      steps:
-      - material: Plasteel
-        amount: 4
-        doAfter: 2
-      - tool: Welding
-        doAfter: 2
-
-  - node: screwdrivering
-    entity: ReinforcedSecretDoorAssembly
-    edges:
-    - to: ReinforcedSecretDoor
-      steps:
-      - tool: Screwing
-        doAfter: 2
-
   - node: ReinforcedSecretDoor
     entity: ReinforcedSecretDoor
-    edges:
-    - to: wired
-      conditions:
-      - !type:EntityAnchored {}
-      - !type:DoorWelded {}
-      completed:
-      - !type:EmptyAllContainers
-        pickup: true
-        emptyAtUser: true
-      - !type:SpawnPrototype
-        prototype: SheetPlasteel1
-        amount: 4
-      steps:
-      - tool: Prying
-        doAfter: 5

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/secretdoor.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/secretdoor.yml
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: MIT
 
+# Pirate: secret door - legacy assembly graph. Secret doors are built from a displaced girder in the
+# Girder graph now (SS13 falsewall), but BaseSecretDoorAssembly is still placed on some maps, so this
+# keeps those instances finishable and removable. The old cable + power cell steps are gone; nothing
+# ever read the cell. Finishing here hands the entity over to the Girder graph.
 - type: constructionGraph
   id: SecretDoor
   start: start
@@ -24,13 +28,12 @@
     - !type:SnapToGrid {}
     - !type:SetAnchor {}
     edges:
-    - to: wired
+    - to: solidSecretDoor
       conditions:
       - !type:EntityAnchored {}
       steps:
-      - material: Cable
-        amount: 4
-        doAfter: 2.5
+      - tool: Screwing
+        doAfter: 2
     - to: start
       conditions:
       - !type:EntityAnchored
@@ -39,51 +42,13 @@
       - !type:SpawnPrototype
         prototype: SheetSteel1
         amount: 4
+      - !type:SpawnPrototype
+        prototype: PartRodMetal1
+        amount: 4
       - !type:DeleteEntity {}
       steps:
       - tool: Welding
         doAfter: 3
 
-  - node: wired
-    entity: BaseSecretDoorAssembly
-    edges:
-    - to: electronics
-      steps:
-      - component: PowerCell
-        name: construction-graph-component-power-cell
-        store: battery-container
-        icon:
-          sprite: Objects/Power/power_cells.rsi
-          state: small
-        doAfter: 1
-    - to: assembly
-      completed:
-      - !type:GivePrototype
-        prototype: CableApcStack1
-        amount: 4
-      steps:
-      - tool: Cutting
-        doAfter: 2
-
-  - node: electronics
-    entity: BaseSecretDoorAssembly
-    edges:
-    - to: solidSecretDoor
-      steps:
-      - tool: Screwing
-        doAfter: 2
-
   - node: solidSecretDoor
     entity: SolidSecretDoor
-    edges:
-    - to: wired
-      conditions:
-      - !type:EntityAnchored {}
-      - !type:DoorWelded {}
-      completed:
-      - !type:EmptyAllContainers
-        pickup: true
-        emptyAtUser: true
-      steps:
-      - tool: Prying
-        doAfter: 5

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -1817,43 +1817,8 @@
   practical:
     MetalworkingKnowledge: 2
 
-- type: construction
-  name: recipes-secret-door-name
-  id: SolidSecretDoor
-  graph: SecretDoor
-  startNode: start
-  targetNode: solidSecretDoor
-  category: construction-category-structures
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-  # Pirate: effective Trauma skill requirements and quality.
-  theory:
-    WallsKnowledge: 0
-    DoorsKnowledge: 0
-    ElectronicsKnowledge: 0
-  useQuality: false
-
-- type: construction
-  name: recipes-secret-door-reinforced-name
-  id: ReinforcedSecretDoor
-  graph: ReinforcedSecretDoor
-  startNode: start
-  targetNode: ReinforcedSecretDoor
-  category: construction-category-structures
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-  # Pirate: effective Trauma skill requirements and quality.
-  theory:
-    WallsKnowledge: 0
-    DoorsKnowledge: 0
-    ElectronicsKnowledge: 0
-  useQuality: false
+# Pirate: secret door - no crafting-menu entry, matching SS13. Both variants are built by unwrenching a
+# girder into its displaced state and applying steel (normal) or plasteel (reinforced); see the Girder graph.
 
 - type: construction
   id: FungalSoil


### PR DESCRIPTION
## Чому / Баланс
рецепт прихованих дверей це сором


## Зміни, що порушують сумісність

**Журнал змін**
:cl:
- remove: для прихованих дверей більше не треба батарейка і проводка, їх рецепт тепер не видно в меню будівництва
- tweak: приховані двері будуються якщо на незакріплений каркас (girder) додати сталь або на укріплений варіант пласталь. розбираються зваркою, можна перетворити на звичайні стіни викруткою
- add: сталеві стрижні можна переробити назад у сталь зваркою



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Нові можливості**
  * Секретні двері можна будувати зі зміщених гірдерів і закріплювати у справжніх стінах.
  * Двері автоматично вирівнюються за напрямком сусідніх стін.
  * Додано перевірки відкритого або закритого стану дверей у будівельних умовах.
  * Два металеві стрижні можна переробити на сталевий лист.
  * Додано візуалізацію атмосферних зв’язків і пристроїв.

* **Зміни**
  * Спрощено складання та розбирання секретних дверей.
  * Секретні двері більше не потребують живлення та не зварюються.
  * Секретні двері більше не доступні як окремі рецепти крафту.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->