### PR TITLE
Зрівняти ліміт очок навичок для видів

### DIFF
--- a/Content.IntegrationTests/Tests/_Pirate/Knowledge/KnowledgeGameplayIntegrationTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Knowledge/KnowledgeGameplayIntegrationTest.cs
@@ -56,17 +56,37 @@ public sealed class KnowledgeGameplayIntegrationTest
             var store = knowledge.EnsureKnowledgeContainer(holder);
             var gun = entMan.SpawnEntity("PirateKnowledgeDummyItem", MapCoordinates.Nullspace);
 
-            var shooting = Ensure("ShootingKnowledge", 100);
+            var shooting = Ensure("ShootingKnowledge", 0);
             var firstAid = Ensure("FirstAidKnowledge", 100);
             var shield = Ensure("KnowledgeWeaponsShield", 100);
             var throwing = Ensure("ThrowingKnowledge", 100);
             var janitor = Ensure("JanitorKnowledge", 100);
             var cooking = Ensure("CookingKnowledge", 0);
 
-            var recoilCurve = entMan.GetComponent<AimSpeedKnowledgeComponent>(shooting.Owner).Curve;
-            var recoil = new GetRecoilModifiersEvent { Gun = gun, User = holder };
-            entMan.EventBus.RaiseLocalEvent(holder, recoil);
-            Assert.That(recoil.Modifier, Is.EqualTo(1f / recoilCurve.GetCurve(100)).Within(0.0001f));
+            var spreadCurve = entMan.GetComponent<AimSpeedKnowledgeComponent>(shooting.Owner).Curve;
+            var expectedSpreadByLevel = new (int Level, float Spread)[]
+            {
+                (0, 3f),
+                (25, 1.9759616f),
+                (26, 1f),
+                (50, 1f),
+                (75, 0.75f),
+                (100, 0.05f),
+            };
+
+            foreach (var (level, expectedSpread) in expectedSpreadByLevel)
+            {
+                shooting.Comp.LearnedLevel = level;
+                var spread = new GetRecoilModifiersEvent { Gun = gun, User = holder };
+                entMan.EventBus.RaiseLocalEvent(holder, spread);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(spread.Modifier,
+                        Is.EqualTo(1f / spreadCurve.GetCurve(level)).Within(0.0001f));
+                    Assert.That(spread.Modifier, Is.EqualTo(expectedSpread).Within(0.0001f),
+                        $"Marksmanship level {level} must reproduce the pre-rework random shot-angle spread.");
+                });
+            }
 
             var selfRecoil = new GetRecoilModifiersEvent { Gun = holder, User = holder };
             entMan.EventBus.RaiseLocalEvent(holder, selfRecoil);
@@ -228,24 +248,32 @@ public sealed class KnowledgeGameplayIntegrationTest
             var rifleComponent = entMan.GetComponent<WeaponClassComponent>(rifle);
             var riflePrototype = prototypes.Index<WeaponClassPrototype>(rifleComponent.Class);
 
-            // GunSystem.GetRecoilAngle raises the same event on the user and then on the gun.
+            // GunSystem's shot-angle calculation raises the same event on the user and then on the gun.
             // Keep both dispatches here so a broken one cannot make an AKM's skill appear inert.
             var lowRecoil = new GetRecoilModifiersEvent { Gun = rifle, User = holder };
             entMan.EventBus.RaiseLocalEvent(holder, lowRecoil);
             entMan.EventBus.RaiseLocalEvent(rifle, lowRecoil);
             var shootingCurve = entMan.GetComponent<AimSpeedKnowledgeComponent>(shooting!.Value.Owner).Curve;
-            Assert.That(lowRecoil.Modifier,
-                Is.EqualTo(1f / shootingCurve.GetCurve(0) / riflePrototype.AimSpeed.GetCurve(0)).Within(0.0001f));
+            Assert.Multiple(() =>
+            {
+                Assert.That(1f / shootingCurve.GetCurve(0), Is.EqualTo(3f).Within(0.0001f));
+                Assert.That(lowRecoil.Modifier,
+                    Is.EqualTo(1f / shootingCurve.GetCurve(0) / riflePrototype.AimSpeed.GetCurve(0)).Within(0.0001f));
+            });
 
             shooting.Value.Comp.LearnedLevel = 100;
             rifleSkill!.Value.Comp.LearnedLevel = 100;
             var highRecoil = new GetRecoilModifiersEvent { Gun = rifle, User = holder };
             entMan.EventBus.RaiseLocalEvent(holder, highRecoil);
             entMan.EventBus.RaiseLocalEvent(rifle, highRecoil);
-            Assert.That(highRecoil.Modifier,
-                Is.EqualTo(1f / shootingCurve.GetCurve(100) / riflePrototype.AimSpeed.GetCurve(100)).Within(0.0001f));
-            Assert.That(highRecoil.Modifier, Is.LessThan(lowRecoil.Modifier),
-                "Higher general and rifle skills must reduce the recoil spread modifier.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(1f / shootingCurve.GetCurve(100), Is.EqualTo(0.05f).Within(0.0001f));
+                Assert.That(highRecoil.Modifier,
+                    Is.EqualTo(1f / shootingCurve.GetCurve(100) / riflePrototype.AimSpeed.GetCurve(100)).Within(0.0001f));
+                Assert.That(highRecoil.Modifier, Is.LessThan(lowRecoil.Modifier),
+                    "Higher general and rifle skills must reduce the shot-spread modifier.");
+            });
 
             entMan.DeleteEntity(rifle);
             entMan.DeleteEntity(weapon);

--- a/Content.IntegrationTests/Tests/_Pirate/Knowledge/KnowledgeLifecycleIntegrationTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Knowledge/KnowledgeLifecycleIntegrationTest.cs
@@ -193,6 +193,8 @@ public sealed class KnowledgeLifecycleIntegrationTest
             {
                 ["MeleeKnowledge"] = 2,
                 ["FirstAidKnowledge"] = 3,
+                ["ChemistryKnowledge"] = 2,
+                ["FabricationKnowledge"] = 1,
                 ["KnowledgeWeaponsEnergy"] = 1,
                 ["DoorsKnowledge"] = 3,
                 ["CookingKnowledge"] = -1,
@@ -202,13 +204,19 @@ public sealed class KnowledgeLifecycleIntegrationTest
             Assert.That(invalid.Mastery, Is.EquivalentTo(new Dictionary<EntProtoId, int>
             {
                 ["FirstAidKnowledge"] = 3,
+                ["ChemistryKnowledge"] = 2,
+                ["FabricationKnowledge"] = 1,
             }), "Invalid, unavailable, over-racial, and over-budget profile entries must be removed deterministically.");
-            Assert.That(knowledge.ProfileCost(invalid), Is.EqualTo(6));
+            Assert.That(knowledge.ProfileCost(invalid), Is.EqualTo(10));
 
             var holder = entMan.SpawnEntity("PirateKnowledgeLifecycleHolder", MapCoordinates.Nullspace);
             knowledge.ApplyProfile(holder, "Human", invalid);
             Assert.That(SharedKnowledgeSystem.GetMastery(
                 knowledge.GetKnowledge(holder, "FirstAidKnowledge")!.Value.Comp.NetLevel), Is.EqualTo(3));
+            Assert.That(SharedKnowledgeSystem.GetMastery(
+                knowledge.GetKnowledge(holder, "ChemistryKnowledge")!.Value.Comp.NetLevel), Is.EqualTo(2));
+            Assert.That(SharedKnowledgeSystem.GetMastery(
+                knowledge.GetKnowledge(holder, "FabricationKnowledge")!.Value.Comp.NetLevel), Is.EqualTo(1));
             Assert.That(SharedKnowledgeSystem.GetMastery(
                 knowledge.GetKnowledge(holder, "DoorsKnowledge")!.Value.Comp.NetLevel), Is.EqualTo(1));
 

--- a/Content.IntegrationTests/Tests/_Pirate/Knowledge/KnowledgePrototypeIntegrityTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Knowledge/KnowledgePrototypeIntegrityTest.cs
@@ -235,8 +235,11 @@ public sealed class KnowledgePrototypeIntegrityTest
                     continue;
                 }
 
-                if (profile!.PointsLimit < 0)
-                    failures.Add($"{speciesId}: profile {profile.ID} has a negative points limit");
+                if (profile!.PointsLimit != 10)
+                    failures.Add($"{speciesId}: profile {profile.ID} must have the shared 10-point limit");
+
+                if (!profile.Profile.Mastery.ContainsKey(KnowledgeGameplaySystem.ShootingKnowledge))
+                    failures.Add($"{speciesId}: profile {profile.ID} must expose Marksmanship at level zero or higher");
 
                 foreach (var (skillId, mastery) in profile.Profile.Mastery)
                 {

--- a/Content.IntegrationTests/Tests/_Pirate/Knowledge/KnowledgeUiIntegrationTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Knowledge/KnowledgeUiIntegrationTest.cs
@@ -74,7 +74,7 @@ public sealed class KnowledgeUiIntegrationTest
             {
                 Assert.That(saveButton.Disabled, Is.False);
                 Assert.That(resetButton.Disabled, Is.False);
-                Assert.That(pointsLabel.Text, Does.Contain("5"));
+                Assert.That(pointsLabel.Text, Does.Contain("9"));
                 Assert.That(firstAidDecrease.Disabled, Is.False);
             });
         });
@@ -110,7 +110,7 @@ public sealed class KnowledgeUiIntegrationTest
             Assert.Multiple(() =>
             {
                 Assert.That(saveButton.Disabled, Is.False);
-                Assert.That(pointsLabel.Text, Does.Contain("6"));
+                Assert.That(pointsLabel.Text, Does.Contain("10"));
             });
             (firstAidDecrease, firstAidIncrease) = GetSkillButtons(client.ProtoMan, skills, "FirstAidKnowledge");
             (chemistryDecrease, chemistryIncrease) = GetSkillButtons(client.ProtoMan, skills, "ChemistryKnowledge");
@@ -129,11 +129,13 @@ public sealed class KnowledgeUiIntegrationTest
             "The editor must stop at the skill's maximum selectable mastery."));
 
         await Click(pair, chemistryIncrease);
+        await Click(pair, chemistryIncrease);
+        await Click(pair, chemistryIncrease);
         await client.WaitAssertion(() =>
         {
             Assert.Multiple(() =>
             {
-                Assert.That(pointsLabel.Text, Does.Contain("-1"));
+                Assert.That(pointsLabel.Text, Does.Contain("-2"));
                 Assert.That(pointsLabel.FontColorOverride, Is.EqualTo(Color.Red));
                 Assert.That(saveButton.Disabled, Is.True,
                     "An over-budget profile must never be applicable.");
@@ -141,7 +143,11 @@ public sealed class KnowledgeUiIntegrationTest
         });
 
         await Click(pair, chemistryDecrease);
-        await client.WaitAssertion(() => Assert.That(saveButton.Disabled, Is.False));
+        await client.WaitAssertion(() =>
+        {
+            Assert.That(pointsLabel.Text, Does.Contain("1"));
+            Assert.That(saveButton.Disabled, Is.False);
+        });
         await Click(pair, saveButton);
 
         await client.WaitAssertion(() =>

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -359,7 +359,9 @@ public sealed partial class GunSystem : SharedGunSystem
 
         var spread = component.CurrentAngle.Theta * random;
         var angle = new Angle(direction.Theta + component.CurrentAngle.Theta * random);
-        DebugTools.Assert(Math.Abs(spread) <= maxTheta); // goob edit
+        // Pirate: skill modifiers scale the random shot angle beyond the gun's unmodified bounds.
+        var spreadBound = Math.Max(Math.Abs(minTheta), Math.Abs(maxTheta)) * Math.Abs(angleEv.Modifier);
+        DebugTools.Assert(Math.Abs(spread) <= spreadBound); // goob edit
         return angle;
     }
 

--- a/Content.Shared/_Pirate/Knowledge/SkillCurve.cs
+++ b/Content.Shared/_Pirate/Knowledge/SkillCurve.cs
@@ -52,6 +52,50 @@ public sealed partial class CubicSkillCurve : SkillCurve
     internal override float GetValue(float value) => value * value * value;
 }
 
+/// <summary>
+/// Reproduces the pre-rework Trauma marksmanship spread profile.
+/// The returned value is inverse spread because aim-speed consumers divide by skill curves.
+/// </summary>
+public sealed partial class MarksmanshipSpreadSkillCurve : SkillCurve
+{
+    [DataField]
+    public float UntrainedSpread = 3f;
+
+    [DataField]
+    public float BasicTrainingLevel = 26f;
+
+    [DataField]
+    public float ExpertLevel = 50f;
+
+    [DataField]
+    public float MinimumSpread = 0.05f;
+
+    internal override float GetValue(float value)
+    {
+        var normalizedLevel = Math.Clamp(value, 0f, 1f);
+        var level = normalizedLevel * 100f;
+        float spread;
+
+        if (level < BasicTrainingLevel)
+        {
+            spread = UntrainedSpread
+                - level / BasicTrainingLevel
+                - normalizedLevel * normalizedLevel;
+        }
+        else if (level <= ExpertLevel)
+        {
+            spread = 1f;
+        }
+        else
+        {
+            var expertProgress = (level - ExpertLevel) / (100f - ExpertLevel);
+            spread = 1f - expertProgress * expertProgress;
+        }
+
+        return 1f / MathF.Max(spread, MinimumSpread);
+    }
+}
+
 public sealed partial class SumSkillCurve : SkillCurve
 {
     [DataField(required: true)]

--- a/Resources/Prototypes/_Pirate/Knowledge/profiles.yml
+++ b/Resources/Prototypes/_Pirate/Knowledge/profiles.yml
@@ -2,7 +2,7 @@
 
 - type: knowledgeProfile
   id: Human
-  pointsLimit: 6
+  pointsLimit: 10
   mastery:
     CookingKnowledge: 0
     DoorsKnowledge: 1
@@ -36,7 +36,7 @@
 
 - type: knowledgeProfile
   id: Dwarf
-  pointsLimit: 3
+  pointsLimit: 10
   mastery:
     MeleeKnowledge: 1
     KnowledgeWeaponsBludgeon: 1
@@ -47,7 +47,7 @@
 
 - type: knowledgeProfile
   id: Reptilian
-  pointsLimit: 3
+  pointsLimit: 10
   mastery:
     ThrowingKnowledge: 1
     MeleeKnowledge: 1
@@ -57,7 +57,7 @@
 
 - type: knowledgeProfile
   id: Diona
-  pointsLimit: 3
+  pointsLimit: 10
   mastery:
     MagicalLiteracyKnowledge: 1
     FirstAidKnowledge: 1
@@ -69,7 +69,7 @@
 
 - type: knowledgeProfile
   id: Moth
-  pointsLimit: 3
+  pointsLimit: 10
   mastery:
     MechanicsKnowledge: 1
     TailoringKnowledge: 1
@@ -83,13 +83,13 @@
 
 - type: knowledgeProfile
   id: Vox
-  pointsLimit: 3
+  pointsLimit: 10
   mastery:
     JanitorKnowledge: 4
 
 - type: knowledgeProfile
   id: IPC
-  pointsLimit: 3
+  pointsLimit: 10
   mastery:
     DoorsKnowledge: 1
     AirlocksKnowledge: 1
@@ -102,7 +102,7 @@
 
 - type: knowledgeProfile
   id: Plasmaman
-  pointsLimit: 3
+  pointsLimit: 10
   mastery:
     DoorsKnowledge: 1
     AirlocksKnowledge: 1
@@ -114,7 +114,7 @@
 
 - type: knowledgeProfile
   id: Slimeperson
-  pointsLimit: 3
+  pointsLimit: 10
   mastery:
     ChemistryKnowledge: 2
     DoorsKnowledge: 1
@@ -127,7 +127,7 @@
 
 - type: knowledgeProfile
   id: Arachnid
-  pointsLimit: 3
+  pointsLimit: 10
   mastery:
     SpiderCraftKnowledge: 4
     DoorsKnowledge: 1
@@ -140,7 +140,7 @@
 
 - type: knowledgeProfile
   id: Abductor
-  pointsLimit: 12
+  pointsLimit: 10
   mastery:
     SurgeryKnowledge: 3
     FirstAidKnowledge: 1

--- a/Resources/Prototypes/_Pirate/Knowledge/profiles.yml
+++ b/Resources/Prototypes/_Pirate/Knowledge/profiles.yml
@@ -38,6 +38,7 @@
   id: Dwarf
   pointsLimit: 10
   mastery:
+    ShootingKnowledge: 0
     MeleeKnowledge: 1
     KnowledgeWeaponsBludgeon: 1
     KnowledgeWeaponsMining: 2
@@ -49,6 +50,7 @@
   id: Reptilian
   pointsLimit: 10
   mastery:
+    ShootingKnowledge: 0
     ThrowingKnowledge: 1
     MeleeKnowledge: 1
     CarvingKnowledge: 1
@@ -59,6 +61,7 @@
   id: Diona
   pointsLimit: 10
   mastery:
+    ShootingKnowledge: 0
     MagicalLiteracyKnowledge: 1
     FirstAidKnowledge: 1
     ChemistryKnowledge: 1
@@ -71,6 +74,7 @@
   id: Moth
   pointsLimit: 10
   mastery:
+    ShootingKnowledge: 0
     MechanicsKnowledge: 1
     TailoringKnowledge: 1
     DoorsKnowledge: 1
@@ -85,12 +89,14 @@
   id: Vox
   pointsLimit: 10
   mastery:
+    ShootingKnowledge: 0
     JanitorKnowledge: 4
 
 - type: knowledgeProfile
   id: IPC
   pointsLimit: 10
   mastery:
+    ShootingKnowledge: 0
     DoorsKnowledge: 1
     AirlocksKnowledge: 1
     BotsKnowledge: 2
@@ -104,6 +110,7 @@
   id: Plasmaman
   pointsLimit: 10
   mastery:
+    ShootingKnowledge: 0
     DoorsKnowledge: 1
     AirlocksKnowledge: 1
     FurnitureKnowledge: 1
@@ -116,6 +123,7 @@
   id: Slimeperson
   pointsLimit: 10
   mastery:
+    ShootingKnowledge: 0
     ChemistryKnowledge: 2
     DoorsKnowledge: 1
     AirlocksKnowledge: 1
@@ -129,6 +137,7 @@
   id: Arachnid
   pointsLimit: 10
   mastery:
+    ShootingKnowledge: 0
     SpiderCraftKnowledge: 4
     DoorsKnowledge: 1
     AirlocksKnowledge: 1

--- a/Resources/Prototypes/_Pirate/Knowledge/skills.yml
+++ b/Resources/Prototypes/_Pirate/Knowledge/skills.yml
@@ -214,9 +214,12 @@
   - type: Knowledge
     unremoveable: true
   - type: AimSpeedKnowledge
-    curve: !type:RootSkillCurve
-      skillOffset: 2.5
-      curveScale: 0.6
+    # Pirate: Restore the pre-rework Trauma random shot-angle spread.
+    curve: !type:MarksmanshipSpreadSkillCurve
+      untrainedSpread: 3
+      basicTrainingLevel: 26
+      expertLevel: 50
+      minimumSpread: 0.05
 
 - type: entity
   parent: BasePirateRangedKnowledge


### PR DESCRIPTION
Збільшує ліміт очок навичок до 10 та повертає старий траєкторний розкид Marksman.

Базовий стан Trauma для порівняння майбутніх змін навичок: 505161665b7032bf6340c85ee4c70f52dadd915b.

:cl:
- tweak: Збільшено ліміт очок навичок до 10 для всіх видів.
- fix: Відновлено помітний розкид стрільби без Marksman і майже точну стрільбу на майстерному рівні.