### PR TITLE
EdjeConnection - fix arcades

### DIFF
--- a/Content.Pirate.Server/_Pirate/Sprite/EdgeConnections/EdgeConnectionSystem.cs
+++ b/Content.Pirate.Server/_Pirate/Sprite/EdgeConnections/EdgeConnectionSystem.cs
@@ -123,7 +123,7 @@ public sealed class EdgeConnectionSystem : EntitySystem
                 continue;
 
             var otherQuarterTurns = GetQuarterTurns(otherXform.LocalRotation);
-            if (selfQuarterTurns % 2 != otherQuarterTurns % 2)
+            if (selfQuarterTurns != otherQuarterTurns)
                 continue;
 
             var otherAllowed = RotateDirections(edge.AllowedDirections, otherXform.LocalRotation, clockwise: true);

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
@@ -25,6 +25,26 @@
     - map: ["enum.WiresVisualLayers.MaintenancePanel"]
       state: panel
       visible: false
+  # Pirate edit start
+  - type: EdgeConnection
+    allowedDirections: None
+  - type: GenericVisualizer
+    visuals:
+      enum.ComputerVisuals.Powered:
+        computerLayerScreen:
+          True: { visible: true, shader: unshaded }
+          False: { visible: false }
+        computerLayerKeys:
+          True: { visible: true, shader: unshaded }
+          False: { visible: true, shader: shaded }
+      enum.WiresVisuals.MaintenancePanelState:
+        enum.WiresVisualLayers.MaintenancePanel:
+          True: { visible: false }
+          False: { visible: true }
+      enum.EdgeConnectionVisuals.ConnectionMask:
+        computerLayerBody:
+          None: { state: arcade, sprite: Structures/Machines/arcade.rsi }
+  # Pirate edit end
   - type: Icon
     sprite: Structures/Machines/arcade.rsi
     state: arcade

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1780,6 +1780,14 @@
         enum.WiresVisualLayers.MaintenancePanel:
           True: { visible: false }
           False: { visible: true }
+      # Pirate edit start
+      enum.EdgeConnectionVisuals.ConnectionMask:
+        computerLayerBody:
+          None: { state: computer, sprite: Structures/Machines/computers.rsi }
+          East: { state: computer, sprite: Structures/Machines/computers.rsi }
+          West: { state: computer, sprite: Structures/Machines/computers.rsi }
+          East, West: { state: computer, sprite: Structures/Machines/computers.rsi }
+      # Pirate edit end
   - type: ApcPowerReceiver
     powerLoad: 1000
   - type: Computer

--- a/Resources/Prototypes/_DEN/Entities/Structures/Machines/somber_machines.yml
+++ b/Resources/Prototypes/_DEN/Entities/Structures/Machines/somber_machines.yml
@@ -72,7 +72,17 @@
     - map: ["computerLayerBody"]
       state: sombertelevision
     - map: ["computerLayerScreen"]
-      state: sombertelevision-on
+      state: sombertelevision-on'
+  # Pirate edit start
+  - type: GenericVisualizer
+    visuals:
+      enum.EdgeConnectionVisuals.ConnectionMask:
+        computerLayerBody:
+          None: { state: sombertelevision, sprite: _DEN/Structures/Machines/computers.rsi }
+          East: { state: sombertelevision, sprite: _DEN/Structures/Machines/computers.rsi }
+          West: { state: sombertelevision, sprite: _DEN/Structures/Machines/computers.rsi }
+          East, West: { state: sombertelevision, sprite: _DEN/Structures/Machines/computers.rsi }
+  # Pirate edit end
   - type: EtherealLight
   - type: PointLight
     radius: 2

--- a/Resources/Prototypes/_DEN/Entities/Structures/Machines/somber_machines.yml
+++ b/Resources/Prototypes/_DEN/Entities/Structures/Machines/somber_machines.yml
@@ -72,7 +72,7 @@
     - map: ["computerLayerBody"]
       state: sombertelevision
     - map: ["computerLayerScreen"]
-      state: sombertelevision-on'
+      state: sombertelevision-on
   # Pirate edit start
   - type: GenericVisualizer
     visuals:


### PR DESCRIPTION
## Медіа
До:
<img width="426" height="117" alt="Знімок екрана 2026-08-29 195722" src="https://github.com/user-attachments/assets/e7b8d189-1996-44ce-b4a0-b65d2fb6b78d" />


Після:
<img width="354" height="161" alt="Знімок екрана 2026-08-29 200848" src="https://github.com/user-attachments/assets/7066561a-1410-4737-8468-3ef97b061692" />


**Журнал змін**
:cl:
- fix: Аркадні автомати тепер мають свою текстурку, а не консольку рами компутєра.
- fix: Аркадні автомати більше не об'єднуються з консолями
- fix: Консоль перезавантаження ШІ тепер об'єднується з іншими консолями
- fix: Телевізор мантіса тепер має свою текстурку, а не текстурку звичайного телевізора


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Нові можливості**
  - Покращено відображення підключень, станів живлення та сервісних індикаторів для аркадних автоматів.
  - Додано коректні візуальні стани підключень для комп’ютера ремонту станційного ШІ.
  - Оновлено відображення корпусу й екрана похмурого телевізора.

- **Виправлення**
  - Сусідні з’єднання тепер вважаються сумісними лише за повного збігу орієнтації.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->