### PR TITLE
СМЕРТЬ І ЧУМА НА ГОЛОВУ СЕКБОРГІВ

### DIFF
--- a/Content.IntegrationTests/Tests/_Pirate/Silicons/SecurityBorgAlertLevelPolicyTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Silicons/SecurityBorgAlertLevelPolicyTest.cs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Pirate.Server.Silicons.Borgs;
+
+namespace Content.IntegrationTests.Tests._Pirate.Silicons;
+
+[TestFixture]
+[TestOf(typeof(SecurityBorgAlertLevelPolicy))]
+public sealed class SecurityBorgAlertLevelPolicyTest
+{
+    [TestCase("green", SecurityBorgAlertLevelTier.Green)]
+    [TestCase("red", SecurityBorgAlertLevelTier.Full)]
+    [TestCase("violet", SecurityBorgAlertLevelTier.Full)]
+    [TestCase("gamma", SecurityBorgAlertLevelTier.Full)]
+    [TestCase("delta", SecurityBorgAlertLevelTier.Full)]
+    [TestCase("epsilon", SecurityBorgAlertLevelTier.Full)]
+    [TestCase("amber", SecurityBorgAlertLevelTier.Full)]
+    [TestCase("octarine", SecurityBorgAlertLevelTier.Full)]
+    [TestCase("blue", SecurityBorgAlertLevelTier.Officer)]
+    [TestCase("yellow", SecurityBorgAlertLevelTier.Officer)]
+    [TestCase("orange", SecurityBorgAlertLevelTier.Officer)]
+    [TestCase("omicron", SecurityBorgAlertLevelTier.Officer)]
+    [TestCase("honk", SecurityBorgAlertLevelTier.Officer)]
+    [TestCase("white", SecurityBorgAlertLevelTier.Officer)]
+    [TestCase("future-alert", SecurityBorgAlertLevelTier.Officer)]
+    [TestCase(null, SecurityBorgAlertLevelTier.Green)]
+    public void GetsExpectedTier(string? alertLevel, SecurityBorgAlertLevelTier expected)
+    {
+        Assert.That(SecurityBorgAlertLevelPolicy.GetTier(alertLevel), Is.EqualTo(expected));
+    }
+}

--- a/Content.Pirate.Server/Silicons/Borgs/SecurityBorgAlertLevelAccessComponent.cs
+++ b/Content.Pirate.Server/Silicons/Borgs/SecurityBorgAlertLevelAccessComponent.cs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Pirate.Server.Silicons.Borgs;
+
+/// <summary>
+/// Marks a security cyborg whose access is determined by its owning station's alert level.
+/// </summary>
+[RegisterComponent]
+public sealed partial class SecurityBorgAlertLevelAccessComponent : Component
+{
+}

--- a/Content.Pirate.Server/Silicons/Borgs/SecurityBorgAlertLevelAccessSystem.cs
+++ b/Content.Pirate.Server/Silicons/Borgs/SecurityBorgAlertLevelAccessSystem.cs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Linq;
+using Content.Server.AlertLevel;
+using Content.Server.Station.Systems;
+using Content.Shared.Access;
+using Content.Shared.Access.Components;
+using Content.Shared.Access.Systems;
+using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
+
+namespace Content.Pirate.Server.Silicons.Borgs;
+
+/// <summary>
+/// Applies the security cyborg alert policy to its mutable access provider.
+/// </summary>
+public sealed class SecurityBorgAlertLevelAccessSystem : EntitySystem
+{
+    private static readonly ProtoId<JobPrototype> SecurityOfficerJob = "SecurityOfficer";
+    private static readonly ProtoId<AccessGroupPrototype> AllAccessGroup = "AllAccess";
+    private static readonly ProtoId<AccessLevelPrototype> BorgAccess = "Borg";
+    private static readonly ProtoId<AccessLevelPrototype> MaintenanceAccess = "Maintenance";
+
+    [Dependency] private readonly AlertLevelSystem _alertLevel = default!;
+    [Dependency] private readonly SharedAccessSystem _access = default!;
+    [Dependency] private readonly IPrototypeManager _prototypes = default!;
+    [Dependency] private readonly StationSystem _station = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SecurityBorgAlertLevelAccessComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<SecurityBorgAlertLevelAccessComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<SecurityBorgAlertLevelAccessComponent, EntParentChangedMessage>(OnParentChanged);
+        SubscribeLocalEvent<AlertLevelChangedEvent>(OnAlertLevelChanged);
+    }
+
+    private void OnStartup(Entity<SecurityBorgAlertLevelAccessComponent> ent, ref ComponentStartup args)
+    {
+        UpdateAccess(ent.Owner);
+    }
+
+    private void OnShutdown(Entity<SecurityBorgAlertLevelAccessComponent> ent, ref ComponentShutdown args)
+    {
+        ApplyFullAccess(ent.Owner);
+    }
+
+    private void OnParentChanged(Entity<SecurityBorgAlertLevelAccessComponent> ent, ref EntParentChangedMessage args)
+    {
+        UpdateAccess(ent.Owner);
+    }
+
+    private void OnAlertLevelChanged(AlertLevelChangedEvent args)
+    {
+        var query = EntityQueryEnumerator<SecurityBorgAlertLevelAccessComponent>();
+        while (query.MoveNext(out var uid, out _))
+        {
+            if (_station.GetOwningStation(uid) == args.Station)
+                ApplyAccess(uid, SecurityBorgAlertLevelPolicy.GetTier(args.AlertLevel));
+        }
+    }
+
+    private void UpdateAccess(EntityUid uid)
+    {
+        var alertLevel = _station.GetOwningStation(uid) is { } station
+            ? _alertLevel.GetLevel(station)
+            : null;
+
+        ApplyAccess(uid, SecurityBorgAlertLevelPolicy.GetTier(alertLevel));
+    }
+
+    private void ApplyAccess(EntityUid uid, SecurityBorgAlertLevelTier tier)
+    {
+        if (!HasComp<AccessComponent>(uid))
+            return;
+
+        if (tier == SecurityBorgAlertLevelTier.Full)
+        {
+            ApplyFullAccess(uid);
+            return;
+        }
+
+        var officer = _prototypes.Index(SecurityOfficerJob);
+        _access.SetAccessToJob(uid, officer, false);
+
+        var tags = _access.TryGetTags(uid)?.ToHashSet() ?? [];
+        tags.Add(BorgAccess);
+        if (tier == SecurityBorgAlertLevelTier.Green)
+            tags.Remove(MaintenanceAccess);
+
+        _access.TrySetTags(uid, tags);
+    }
+
+    private void ApplyFullAccess(EntityUid uid)
+    {
+        if (!HasComp<AccessComponent>(uid))
+            return;
+
+        var tags = _prototypes.Index(AllAccessGroup).Tags.ToHashSet();
+        tags.Add(BorgAccess);
+        _access.TrySetTags(uid, tags);
+    }
+}

--- a/Content.Pirate.Server/Silicons/Borgs/SecurityBorgAlertLevelPolicy.cs
+++ b/Content.Pirate.Server/Silicons/Borgs/SecurityBorgAlertLevelPolicy.cs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Pirate.Server.Silicons.Borgs;
+
+/// <summary>
+/// Shared alert-level policy for security cyborg access and lethal weapon modes.
+/// </summary>
+public static class SecurityBorgAlertLevelPolicy
+{
+    public static SecurityBorgAlertLevelTier GetTier(string? alertLevel)
+    {
+        return alertLevel?.ToLowerInvariant() switch
+        {
+            null or "" or "green" => SecurityBorgAlertLevelTier.Green,
+            "red" or "violet" or "gamma" or "delta" or "epsilon" or "amber" or "octarine" =>
+                SecurityBorgAlertLevelTier.Full,
+            _ => SecurityBorgAlertLevelTier.Officer,
+        };
+    }
+}
+
+public enum SecurityBorgAlertLevelTier
+{
+    Green,
+    Officer,
+    Full,
+}

--- a/Content.Pirate.Server/Silicons/Borgs/SecurityBorgLethalModeComponent.cs
+++ b/Content.Pirate.Server/Silicons/Borgs/SecurityBorgLethalModeComponent.cs
@@ -14,6 +14,4 @@ public sealed partial class SecurityBorgLethalModeComponent : Component
     [DataField]
     public int LethalMode = 1;
 
-    [DataField]
-    public HashSet<string> AllowedAlertLevels = new();
 }

--- a/Content.Pirate.Server/Silicons/Borgs/SecurityBorgLethalModeSystem.cs
+++ b/Content.Pirate.Server/Silicons/Borgs/SecurityBorgLethalModeSystem.cs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using System.Linq;
 using Content.Server.AlertLevel;
 using Content.Server.Station.Systems;
 using Content.Shared.Popups;
@@ -57,7 +56,7 @@ public sealed class SecurityBorgLethalModeSystem : EntitySystem
         while (query.MoveNext(out var uid, out var restriction, out var fireModes))
         {
             if (fireModes.CurrentFireMode != restriction.LethalMode ||
-                IsAlertLevelAllowed(restriction, args.AlertLevel) ||
+                IsLethalAllowedAtAlertLevel(args.AlertLevel) ||
                 _station.GetOwningStation(uid) != args.Station)
             {
                 continue;
@@ -70,12 +69,12 @@ public sealed class SecurityBorgLethalModeSystem : EntitySystem
     private bool IsLethalAllowed(Entity<SecurityBorgLethalModeComponent> ent)
     {
         return _station.GetOwningStation(ent.Owner) is { } station &&
-               IsAlertLevelAllowed(ent.Comp, _alertLevel.GetLevel(station));
+               IsLethalAllowedAtAlertLevel(_alertLevel.GetLevel(station));
     }
 
-    private static bool IsAlertLevelAllowed(SecurityBorgLethalModeComponent component, string alertLevel)
+    private static bool IsLethalAllowedAtAlertLevel(string alertLevel)
     {
-        return component.AllowedAlertLevels.Contains(alertLevel, StringComparer.OrdinalIgnoreCase);
+        return SecurityBorgAlertLevelPolicy.GetTier(alertLevel) == SecurityBorgAlertLevelTier.Full;
     }
 
     private void ResetToSafeMode(

--- a/Resources/Prototypes/_Pirate/Security/security_borg.yml
+++ b/Resources/Prototypes/_Pirate/Security/security_borg.yml
@@ -58,13 +58,6 @@
   - type: SecurityBorgLethalMode
     safeMode: 0
     lethalMode: 1
-    allowedAlertLevels:
-    - amber
-    - red
-    - gamma
-    - delta
-    - violet
-    - omicron
   - type: Unremoveable
   - type: GunExecutionBlacklist
 
@@ -291,6 +284,7 @@
   - Security
   addComponents:
   - type: FlashImmunity
+  - type: SecurityBorgAlertLevelAccess
   inventoryTemplateId: borgShort
   spriteBodyState: standard
   spriteHasMindState: standard_e


### PR DESCRIPTION
**Журнал змін**

:cl:
- tweak: сек борги мають доступ офіцерів у СК(також у Жовтий, Помаранчевий, Омікрон, Хонк, Білий), доступ офіцерів без техів у ЗК і повний у ЧК (також у Фіолетовий, Гамма, Дельта, Епсілон, Бурштин, Октарин)
- fix: сек борги мають летальну зброю в омікрон



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Додано динамічне керування доступом охоронних кіборгів відповідно до рівня тривоги станції.
  * На найвищих рівнях тривоги кіборги отримують розширений доступ, а на низьких — обмежений.
  * Доступ автоматично оновлюється під час зміни рівня тривоги або станції кіборга.
  * Обмеження летального режиму тепер узгоджуються із загальною політикою рівнів тривоги.
* **Зміни**
  * Налаштування рівнів тривоги перенесено з окремої зброї на рівень корпусу кіборга.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->