### PR TITLE
Виправлено переломи кісток ентропійного колоса

### DIFF
--- a/Resources/Prototypes/_Goobstation/Body/Parts/colossus.yml
+++ b/Resources/Prototypes/_Goobstation/Body/Parts/colossus.yml
@@ -40,6 +40,7 @@
       collection: MetalThud
   - type: BodyPart
     partComposition: Inorganic
+  - type: Boneless # Colossi have an inorganic shell, not bones.
   - type: SurgeryTool # Shitmed Change
     startSound:
       path: /Audio/_Shitmed/Medical/Surgery/organ1.ogg


### PR DESCRIPTION
## Про запит на злиття
Виправляє переломи кісток в ентропійного колоса. Додано один компонент `Boneless` до базового прототипу `PartColossus`.

## Чому / Баланс
Колос має неорганічне тіло, але система ран створювала йому кістку за замовчуванням. Виправлення прибирає переломи для звичайного та самотнього колоса. Значення здоров'я, опору шкоді й лікування не змінюються.

## Технічні деталі
`ChestColossus` успадковує `PartColossus`; обидва варіанти колоса використовують `ColossusBody` із цією частиною тіла. Наявний компонент `Boneless` зупиняє створення кістки в `OnWoundableMapInit`. `Woundable` і `Damageable` залишаються без змін.

Зміна: один рядок в одному YAML-файлі. Сервер і тести не запускалися за вказівкою замовника; виправлення ґрунтується на прочитаній логіці системи ран.

## Медіа
Не потрібні: малий фікс без візуальних змін.

- [x] Я дозволяю переліцензувати мої зміни під [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), коли їх буде перенесено до [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged).

## Вимоги
- [x] Я прочитав та дотримуюсь [Правил запитів на злиття та журналу змін](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я додав медіа, **АБО** цей запит на злиття не потребує медіа.

## Зміни, що порушують сумісність
Немає.

**Журнал змін**
:cl:
- fix: Ентропійні колоси більше не отримують переломи кісток.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Нові можливості**
  * Для абстрактної частини тіла Colossus додано позначення відсутності кісткової структури.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->