### PR TITLE
Fix forged metal cooling in charcoal forge

### DIFF
--- a/Resources/Prototypes/_Pirate/Forging/Entities/Objects/metals.yml
+++ b/Resources/Prototypes/_Pirate/Forging/Entities/Objects/metals.yml
@@ -18,6 +18,7 @@
   - type: Temperature
     currentTemperature: 290
     specificHeat: 500
+    atmosTemperatureTransferEfficiency: 0.005 # Pirate: forged metal must retain heat in the forge
   # TODO: melting into a reagent puddle above extreme temperature
   # TODO: picking up a 1200C ingot should melt your hands off
 


### PR DESCRIPTION
Виправлено надто швидке охолодження металу під час нагрівання в ковальській печі.

:cl:
- fix: Сталева криця тепер може нагрітися до робочої температури в ковальській печі.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Покращення**
  - Налаштовано передачу тепла через атмосферу для металевих предметів.
  - Металеві об’єкти тепер точніше реагують на зміни температури навколишнього середовища.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->