### PR TITLE
Виправити видимість іконок антагоністів для привидів

### DIFF
--- a/Content.Client/StatusIcon/StatusIconSystem.cs
+++ b/Content.Client/StatusIcon/StatusIconSystem.cs
@@ -79,9 +79,6 @@ public sealed class StatusIconSystem : SharedStatusIconSystem
         if (data.VisibleToOwner && viewer == ent.Owner) // WD EDIT: not always show our icons to our entity
             return true;
 
-        if (data.VisibleToGhosts && HasComp<GhostComponent>(viewer))
-            return true;
-
         if (data.HideInContainer && (ent.Comp.Flags & MetaDataFlags.InContainer) != 0)
             return false;
 
@@ -93,6 +90,10 @@ public sealed class StatusIconSystem : SharedStatusIconSystem
 
         if (data.ShowTo != null && !_entityWhitelist.IsValid(data.ShowTo, viewer))
             return false;
+
+        // Pirate: apply the viewer whitelist before allowing ghost visibility.
+        if (HasComp<GhostComponent>(viewer))
+            return data.VisibleToGhosts;
 
         return true;
     }

--- a/Resources/Prototypes/_Goobstation/Blob/misc_blob.yml
+++ b/Resources/Prototypes/_Goobstation/Blob/misc_blob.yml
@@ -78,6 +78,7 @@
   priority: 10
   showTo:
     components:
+    - ShowAntagIcons # Pirate: expose to admin ghosts
     - BlobCarrier
     - BlobObserver
     - ZombieBlob

--- a/Resources/Prototypes/_Pirate/StatusIcon/faction.yml
+++ b/Resources/Prototypes/_Pirate/StatusIcon/faction.yml
@@ -16,6 +16,7 @@
   priority: 1
   showTo:
     components:
+      - ShowAntagIcons # Pirate: expose to admin ghosts
       - VampireThrall
       - Vampire
   isShaded: true


### PR DESCRIPTION
Виправлено видимість іконок антагоністів для звичайних привидів.

:cl:
- fix: звичайні привиди більше не бачать іконки антагоністів

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Виправлення**
  - Привиди більше не обходять перевірки видимості контейнерів, стелсу, спрайтів і списків доступу. Тепер фракційні значки відображаються їм лише за відповідних умов.
  - Адміністративні привиди можуть бачити піктограми антагоністів для фракцій Blob і Vampire Thrall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->