### PR TITLE
Fix turret LOS blocked by lockers and crates

### DIFF
--- a/Resources/Prototypes/NPCs/root.yml
+++ b/Resources/Prototypes/NPCs/root.yml
@@ -21,9 +21,12 @@
             - !type:TargetInLOSPrecondition
               targetKey: Target
               rangeKey: RangedRange
+              # Impassable walls still block; lockers/crates (Opaque/MachineLayer) do not.
+              opaqueKey: false
           operator: !type:GunOperator
             targetKey: Target
             requireLOS: true
+            opaqueKey: false
           services:
             - !type:UtilityService
               id: RangedService
@@ -53,10 +56,11 @@
             - !type:TargetInLOSPrecondition
               targetKey: Target
               rangeKey: RangedRange
-              opaqueKey: true
+              # Impassable walls still block; lockers/crates (Opaque/MachineLayer) do not.
+              opaqueKey: false
           operator: !type:GunOperator
             targetKey: Target
-            opaqueKey: true
+            opaqueKey: false
           services:
             - !type:UtilityService
               id: RangedService


### PR DESCRIPTION
## Summary
- Турелі перевіряли LOS через Opaque, тож шафи/ящики (`MachineLayer`) ховали гравця.
- Для `TurretCompound` і `EnergyTurretCompound` виставлено `opaqueKey: false` — стіни (Impassable) блокують, шафи/ящики ні.

## Test plan
- [ ] Заспавнити ballistic/energy турель і ворожого гравця
- [ ] Поставити шафу або ящик між ними — турель має бачити і атакувати
- [ ] Поставити стіну між ними — турель не повинна стріляти крізь стіну
- [ ] У PR лише `Resources/Prototypes/NPCs/root.yml`

**Журнал змін**
:cl:
- fix: Турелі знову бачать цілі крізь шафи та ящики


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Виправлення**
  - Турелі тепер можуть вести вогонь крізь непрозорі об’єкти, зокрема шафки та ящики.
  - Непрохідні стіни й надалі блокують лінію вогню.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->