### PR TITLE
Додати дію для активації особистого щита

### DIFF
--- a/Resources/Locale/en-US/_Mono/personal-shield.ftl
+++ b/Resources/Locale/en-US/_Mono/personal-shield.ftl
@@ -6,3 +6,6 @@ personal-shield-examine-down = The shield is [color=darkgray]down[/color].
 personal-shield-toggle-fractured = Shield respooling. { $seconds } seconds remaining.
 personal-shield-toggle-up = Shield raised.
 personal-shield-toggle-down = Shield lowered.
+
+personal-shield-action-name = Toggle personal shield
+personal-shield-action-desc = Raise or lower your personal shield.

--- a/Resources/Locale/en-US/_Mono/personal-shield.ftl
+++ b/Resources/Locale/en-US/_Mono/personal-shield.ftl
@@ -7,5 +7,5 @@ personal-shield-toggle-fractured = Shield respooling. { $seconds } seconds remai
 personal-shield-toggle-up = Shield raised.
 personal-shield-toggle-down = Shield lowered.
 
-personal-shield-action-name = Toggle personal shield
-personal-shield-action-desc = Raise or lower your personal shield.
+ent-ActionTogglePersonalShield = Toggle personal shield
+    .desc = Raise or lower your personal shield.

--- a/Resources/Locale/uk-UA/_Mono/personal-shield.ftl
+++ b/Resources/Locale/uk-UA/_Mono/personal-shield.ftl
@@ -16,3 +16,6 @@ personal-shield-toggle-fractured = Перезаряджання щита. Зал
 }.
 personal-shield-toggle-up = Щит піднято.
 personal-shield-toggle-down = Щит опущено.
+
+personal-shield-action-name = Перемкнути особистий щит
+personal-shield-action-desc = Підняти або опустити особистий щит.

--- a/Resources/Locale/uk-UA/_Mono/personal-shield.ftl
+++ b/Resources/Locale/uk-UA/_Mono/personal-shield.ftl
@@ -17,5 +17,5 @@ personal-shield-toggle-fractured = Перезаряджання щита. Зал
 personal-shield-toggle-up = Щит піднято.
 personal-shield-toggle-down = Щит опущено.
 
-personal-shield-action-name = Перемкнути особистий щит
-personal-shield-action-desc = Підняти або опустити особистий щит.
+ent-ActionTogglePersonalShield = Перемкнути особистий щит
+    .desc = Підняти або опустити особистий щит.

--- a/Resources/Prototypes/_Mono/Actions/personal-shield.yml
+++ b/Resources/Prototypes/_Mono/Actions/personal-shield.yml
@@ -3,8 +3,6 @@
 - type: entity
   parent: BaseToggleAction
   id: ActionTogglePersonalShield
-  name: personal-shield-action-name
-  description: personal-shield-action-desc
   components:
   - type: Action
     icon: { sprite: Objects/Weapons/Melee/shields.rsi, state: teleriot-icon }

--- a/Resources/Prototypes/_Mono/Actions/personal-shield.yml
+++ b/Resources/Prototypes/_Mono/Actions/personal-shield.yml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: entity
+  parent: BaseToggleAction
+  id: ActionTogglePersonalShield
+  name: personal-shield-action-name
+  description: personal-shield-action-desc
+  components:
+  - type: Action
+    icon: { sprite: Objects/Weapons/Melee/shields.rsi, state: teleriot-icon }
+    iconOn: { sprite: Objects/Weapons/Melee/shields.rsi, state: teleriot-on }

--- a/Resources/Prototypes/_Mono/Entities/Clothing/base_shielding.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/base_shielding.yml
@@ -29,3 +29,5 @@
       path: /Audio/Machines/button.ogg
       params:
         variation: 0.250
+  - type: ToggleClothing
+    action: ActionTogglePersonalShield


### PR DESCRIPTION
Додає кнопку в меню дій для активації та деактивації особистих щитів на високорівневих костюмах.

:cl:
- add: Додано дію для активації особистого щита.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Нові функції**
  - Додано можливість перемикати особистий щит — піднімати або опускати його через окрему дію.
  - Для дії додано відповідну назву, опис та іконки в інтерфейсі.

- **Локалізація**
  - Додано переклади функції англійською та українською мовами.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->