### PR TITLE
SecretTP tweak

### DIFF
--- a/Resources/Prototypes/_Goobstation/GangWars/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GangWars/GameRules/roundstart.yml
@@ -17,7 +17,7 @@
     definitions:
     - prefRoles: [ GangLeader ]
       max: 4
-      playerRatio: 15
+      playerRatio: 10 # Pirate edit - was 15
       jobBlacklist: [ Captain, HeadOfPersonnel, HeadOfSecurity, ChiefEngineer, ChiefMedicalOfficer, ResearchDirector, BlueshieldOfficer, NanotrasenRepresentative ] # QM / Det should be allowed
       blacklist:
         components:

--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -3,7 +3,7 @@
   id: Conspirators
   components:
   - type: GameRule
-    minPlayers: 24
+    minPlayers: 15 # Pirate edit - was 24
     chaosScore: 650
   - type: ConspiratorRule
   - type: AntagObjectives
@@ -15,7 +15,7 @@
     - prefRoles: [ Conspirator ]
       min: 3
       max: 5
-      playerRatio: 8
+      playerRatio: 4 # Pirate edit - was 8
       briefing:
         text: conspirator-role-greeting
         color: "#724F29"

--- a/Resources/Prototypes/_Pirate/GameRules/secret_tp.yml
+++ b/Resources/Prototypes/_Pirate/GameRules/secret_tp.yml
@@ -1,4 +1,4 @@
-﻿- type: entityTable
+- type: entityTable
   id: SecretTPTable
   table: !type:AllSelector
     children:
@@ -29,7 +29,6 @@
       - id: DragonSpawn
       - id: AsakimShuttle
       - id: SleeperAgents
-      - id: ReplicatorSpawn
       - id: ColossusSpawn
       - id: SkiaSpawn
       - id: Fugitive
@@ -38,15 +37,14 @@
       - id: BountyHunterSpawn
         conditions:
         - !type:BountyHunterTargetCondition
-      # - id: SyndicateDeadDrop # Pirate: syndicate drop console - replaced by the always-on SyndicateDropDispatcher
 
 - type: weightedRandom
   id: SecretTPPrimary
   weights:
+    Gangwars: 1.5
+    Revolutionary: 1.5
+    Nukeops: 1.5
     Conspirators: 1
-    BloodCult: 1
-    Revolutionary: 1
-    Nukeops: 1
     BlobGameMode: 1
     XenomorphsInfestationRoundstart: 1
 
@@ -55,11 +53,12 @@
   weights:
     Traitor: 1
     Thief: 1
-    BloodBrothers: 1
     Devil: 1
-    Vampire: 1
-    Changeling: 1
-    SiliconLiberation: 1
+    SiliconLiberation: 0.75
+    BloodBrothers: 0.75
+    Vampire: 0.5
+    Changeling: 0.5
+    Conspirators: 0.25
 
 - type: entity
   id: SecretTP
@@ -79,10 +78,9 @@
     roundStartAntagsWeightTable: SecretTPRoundstart
   - type: SecretTP
     jobPoints:
-      BlueshieldOfficer: 6
       HeadOfSecurity: 5
       Warden: 4
-      SecurityInstructor: 4
+      SecurityInstructor: 3
       Detective: 3
       SecurityOfficer: 3
       Brigmedic: 2
@@ -95,33 +93,36 @@
       Changeling: 4
       Hitman: 3
       Asakim: 3
+      SELFAgent: 3
       Traitor: 2
       TraitorSleeper: 2
-      SELFAgent: 2
       Fugitive: 2
+      Conspirator: 2
       BloodBrother: 1
     ruleMinimumAliveDepartments:
       Revolutionary:
-        Security: 4
+        Security: 3
         Command: 3
       BlobGameMode:
         Security: 5
         Command: 1
       TokenBlobMidround:
-        Security: 5
+        Security: 8
         Command: 1
-      Nukeops:
-        Security: 5
-      BloodCult:
+      TokenDragonSpawn:
+        Security: 8
+      DragonSpawn:
         Security: 5
       XenomorphsInfestationRoundstart:
         Security: 5
-      DragonSpawn:
+      Nukeops:
         Security: 4
-      TokenDragonSpawn:
+        Command: 1
+      Deserters:
         Security: 4
-      ReplicatorSpawn:
+      Gangwars:
         Security: 3
+        Command: 1
       Conspirators:
         Security: 2
     ruleBlacklist:
@@ -143,6 +144,8 @@
       - WraithMidround
       - SpacePirates
       - PiratesSpawn
+      - ReplicatorSpawn
+      - BloodCult
       ### Хрінь через яку раунд закінчеться в 95%
       - CosmicCult
       - TokenWizard

--- a/Resources/Prototypes/_Pirate/Objectives/bloodbrother_groups.yml
+++ b/Resources/Prototypes/_Pirate/Objectives/bloodbrother_groups.yml
@@ -3,7 +3,6 @@
   weights:
     BloodBrotherObjectiveGroupState: 1
     BloodBrotherObjectiveGroupSteal: 1
-    BloodBrotherObjectiveGroupKill: 1
 
 - type: weightedRandom
   id: BloodBrotherObjectiveGroupState
@@ -26,9 +25,3 @@
     BloodBrotherHandTeleporterStealObjective: 0.5
     BloodBrotherLawbringerStealObjective: 0.5
     BloodBrotherAccessConfiguratorStealObjective: 1
-
-- type: weightedRandom
-  id: BloodBrotherObjectiveGroupKill
-  weights:
-    BloodBrotherKillRandomPersonObjective: 0.85
-    BloodBrotherKillRandomHeadObjective: 0.25


### PR DESCRIPTION
**Журнал змін**
:cl:
- add: Раундстарт режим війни банд (антаг) (Вимоги: мінімум 3 СБ і 1 командування) [СекретТП]
- remove: Культ крові і репліктори [СекретТП]
- tweak: Кровні брати тепер не мають цілі на гіб
- tweak: ОБЩ більше не дає поінти для антагів [СекретТП]
- tweak: Конспіратори тепер можуть заспавнитися як сабмод [СекретТП]
- tweak: Конспіратори тепер мають дещо менші вимоги для спавну ніж раніше
- tweak: Вимога для ЯО змінена з 5 СБ до 4 СБ [СекретТП]
- tweak: Кожен конспіратор тепер забирає 2 поінта антагів [СекретТП]
- tweak: Збільшено шанс на спавн ЯО та революції (раундстарт) та зменшено шанс на спавн вампіра, генокрада і СЕЛФ агента (раундстарт сабмод) [СекретТП]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Зміни ігрового процесу**
  * Знижено вимоги до кількості гравців і співвідношення антагоністів для правил «Gang Wars» і «Conspirators», щоб ці події запускалися частіше.
  * Оновлено склад і ваги секретних режимів та раундових антагоністичних подій.
  * Скориговано вимоги до живих департаментів, очки посад служби безпеки та очки антагоністів.

* **Вилучення**
  * Подію появи Replicator прибрано з таблиці секретних подій.
  * Blood Cult вилучено з основного переліку режимів.
  * Прибрано групу цілей Blood Brother на знищення випадкових персонажів або керівників.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->