### PR TITLE
fix: слайми не чіпляються до активного особистого щита

### DIFF
--- a/Content.Goobstation.Server/Xenobiology/HTN/PickSlimeLatchTargetOperator.cs
+++ b/Content.Goobstation.Server/Xenobiology/HTN/PickSlimeLatchTargetOperator.cs
@@ -66,6 +66,7 @@ public sealed partial class PickSlimeLatchTargetOperator : HTNOperator
             if (_ent.HasComponent<BeingLatchedComponent>(entity)
             || _ent.HasComponent<SlimeDamageOvertimeComponent>(entity) // it's taken
             || _mobSystem.IsDead(entity)
+            || !_latch.CanLatch((owner, slimeComp), entity)
             || (growthComp.IsFirstStage && entity == slimeComp.Tamer) // no killing tamer
             || (entity == slimeComp.Tamer && _hunger.IsHungerAboveState(owner, HungerThreshold.Peckish)) // no killing tamer unless very hungry
             || (_ent.TryGetComponent<HumanoidAppearanceComponent>(entity, out var targetHumanoid) && targetHumanoid.Species == "SlimePerson")) // Pirate: slime kinship - slimes don't hunt their own kind

--- a/Content.Goobstation.Server/Xenobiology/SlimeLatchSystem.cs
+++ b/Content.Goobstation.Server/Xenobiology/SlimeLatchSystem.cs
@@ -76,7 +76,7 @@ public sealed partial class SlimeLatchSystem : EntitySystem
         if (_gameTiming.CurTime < ent.Comp.NextTickTime || _mobState.IsDead(ent))
             return;
 
-        // Active personal shield (ІПШ) — drop off instead of free growth with no damage.
+        // Active personal shield — drop off instead of free growth with no damage.
         if (_personalShield.HasActiveShield(ent) && ent.Comp.SourceEntityUid is { } latchedSlime
             && TryComp<SlimeComponent>(latchedSlime, out var slimeComp))
         {
@@ -283,7 +283,7 @@ public sealed partial class SlimeLatchSystem : EntitySystem
             || _mobState.IsDead(target) // target dead
             || !_actionBlocker.CanInteract(ent, target) // can't reach
             || !HasComp<MobStateComponent>(target) // make any mob work
-            || _personalShield.HasActiveShield(target) // ІПШ blocks latch (no free growth)
+            || _personalShield.HasActiveShield(target) // personal shield blocks latch (no free growth)
             || (TryComp<HumanoidAppearanceComponent>(target, out var humanoid) && humanoid.Species == "SlimePerson")); // Pirate: slime kinship - slimes don't hunt their own kind
     }
 

--- a/Content.Goobstation.Server/Xenobiology/SlimeLatchSystem.cs
+++ b/Content.Goobstation.Server/Xenobiology/SlimeLatchSystem.cs
@@ -25,6 +25,7 @@ using Content.Shared.Body.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Goobstation.Maths.FixedPoint;
 using Content.Shared.Chemistry.Components;
+using Content.Shared._Mono.PersonalShield;
 
 namespace Content.Goobstation.Server.Xenobiology;
 
@@ -43,6 +44,7 @@ public sealed partial class SlimeLatchSystem : EntitySystem
     [Dependency] private readonly SharedBodySystem _body = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
     [Dependency] private readonly StomachSystem _stomach = default!;
+    [Dependency] private readonly SharedPersonalShieldSystem _personalShield = default!;
 
     public override void Initialize()
     {
@@ -73,6 +75,14 @@ public sealed partial class SlimeLatchSystem : EntitySystem
     {
         if (_gameTiming.CurTime < ent.Comp.NextTickTime || _mobState.IsDead(ent))
             return;
+
+        // Active personal shield (ІПШ) — drop off instead of free growth with no damage.
+        if (_personalShield.HasActiveShield(ent) && ent.Comp.SourceEntityUid is { } latchedSlime
+            && TryComp<SlimeComponent>(latchedSlime, out var slimeComp))
+        {
+            Unlatch((latchedSlime, slimeComp));
+            return;
+        }
 
         ent.Comp.NextTickTime = _gameTiming.CurTime + ent.Comp.Interval;
         _damageable.TryChangeDamage(ent, ent.Comp.Damage, ignoreResistances: true, targetPart: TargetBodyPart.All);
@@ -175,6 +185,12 @@ public sealed partial class SlimeLatchSystem : EntitySystem
             return;
         }
 
+        if (_personalShield.HasActiveShield(args.Target))
+        {
+            _popup.PopupEntity(Loc.GetString("slime-latch-fail-personal-shield", ("ent", args.Target)), ent, ent);
+            return;
+        }
+
         if (CanLatch((args.Performer, slime), args.Target))
         {
             StartSlimeLatchDoAfter((args.Performer, slime), args.Target);
@@ -186,6 +202,12 @@ public sealed partial class SlimeLatchSystem : EntitySystem
 
     private bool StartSlimeLatchDoAfter(Entity<SlimeComponent> ent, EntityUid target)
     {
+        if (_personalShield.HasActiveShield(target))
+        {
+            _popup.PopupEntity(Loc.GetString("slime-latch-fail-personal-shield", ("ent", target)), ent, ent);
+            return false;
+        }
+
         if (_mobState.IsDead(target))
         {
             var targetDeadPopup = Loc.GetString("slime-latch-fail-target-dead", ("ent", target));
@@ -227,7 +249,8 @@ public sealed partial class SlimeLatchSystem : EntitySystem
 
     private void OnDoAfterAttempt(EntityUid uid, SlimeComponent comp, ref DoAfterAttemptEvent<SlimeLatchDoAfterEvent> args)
     {
-        if (HasComp<BeingLatchedComponent>(args.Event.Target))
+        if (args.Event.Target is { } target
+            && (HasComp<BeingLatchedComponent>(target) || _personalShield.HasActiveShield(target)))
             args.Cancel();
     }
 
@@ -260,6 +283,7 @@ public sealed partial class SlimeLatchSystem : EntitySystem
             || _mobState.IsDead(target) // target dead
             || !_actionBlocker.CanInteract(ent, target) // can't reach
             || !HasComp<MobStateComponent>(target) // make any mob work
+            || _personalShield.HasActiveShield(target) // ІПШ blocks latch (no free growth)
             || (TryComp<HumanoidAppearanceComponent>(target, out var humanoid) && humanoid.Species == "SlimePerson")); // Pirate: slime kinship - slimes don't hunt their own kind
     }
 

--- a/Content.IntegrationTests/Tests/_Pirate/Support/PortedSupportIntegrationTest.cs
+++ b/Content.IntegrationTests/Tests/_Pirate/Support/PortedSupportIntegrationTest.cs
@@ -453,8 +453,8 @@ public sealed class PortedSupportIntegrationTest
 
             Assert.That(buckleSystem.TryBuckle(victim, holder, cross, buckle, popup: false), Is.True);
             var strapLock = entMan.GetComponent<StrapLockComponent>(cross);
-            var damage = entMan.GetComponent<DamageableComponent>(victim).TotalDamage;
-            initialDamage = damage.Float();
+            var damageable = entMan.GetComponent<DamageableComponent>(victim);
+            initialDamage = damageable.Damage.DamageDict.GetValueOrDefault("Blunt").Float();
 
             var canDrag = new CanDragEvent();
             var frame = entMan.SpawnEntity("PowerArmorFrame", map.GridCoords);
@@ -497,7 +497,8 @@ public sealed class PortedSupportIntegrationTest
         await server.WaitAssertion(() =>
         {
             var buckle = entMan.GetComponent<BuckleComponent>(victim);
-            var damage = entMan.GetComponent<DamageableComponent>(victim).TotalDamage;
+            var blunt = entMan.GetComponent<DamageableComponent>(victim).Damage.DamageDict
+                .GetValueOrDefault("Blunt").Float();
             Assert.Multiple(() =>
             {
                 Assert.That(buckle.Buckled, Is.False);
@@ -505,7 +506,9 @@ public sealed class PortedSupportIntegrationTest
                 Assert.That(entMan.HasComponent<StrapLockHeldComponent>(victim), Is.False);
                 Assert.That(entMan.HasComponent<StrapLockHoldingComponent>(holder), Is.False);
                 Assert.That(server.System<SharedHandsSystem>().CountFreeHands(holder), Is.EqualTo(2));
-                Assert.That(damage.Float(), Is.EqualTo(initialDamage + 10f).Within(0.01f),
+                // CrucifixDropped is Blunt:10 — assert that type only so ambient tick damage
+                // (asphyxiation/bloodloss) does not flake TotalDamage.
+                Assert.That(blunt, Is.EqualTo(initialDamage + 10f).Within(0.01f),
                     "Leaving holding range must apply CrucifixDropped exactly once.");
             });
 

--- a/Content.Shared/_Mono/PersonalShield/SharedPersonalShieldSystem.cs
+++ b/Content.Shared/_Mono/PersonalShield/SharedPersonalShieldSystem.cs
@@ -167,7 +167,7 @@ public sealed partial class SharedPersonalShieldSystem : EntitySystem
     }
 
     /// <summary>
-    /// True if <paramref name="wearer"/> currently has a formed personal shield (ІПШ) from worn gear.
+    /// True if <paramref name="wearer"/> currently has a formed personal shield from worn gear.
     /// </summary>
     public bool HasActiveShield(EntityUid wearer)
     {

--- a/Content.Shared/_Mono/PersonalShield/SharedPersonalShieldSystem.cs
+++ b/Content.Shared/_Mono/PersonalShield/SharedPersonalShieldSystem.cs
@@ -166,6 +166,20 @@ public sealed partial class SharedPersonalShieldSystem : EntitySystem
         }
     }
 
+    /// <summary>
+    /// True if <paramref name="wearer"/> currently has a formed personal shield (ІПШ) from worn gear.
+    /// </summary>
+    public bool HasActiveShield(EntityUid wearer)
+    {
+        foreach (var item in _inventory.GetHandOrInventoryEntities(wearer))
+        {
+            if (TryComp(item, out PersonalShieldComponent? shield) && shield.IsUp)
+                return true;
+        }
+
+        return false;
+    }
+
     // Oops!
     public void Fracture(Entity<PersonalShieldComponent> ent)
     {

--- a/Resources/Locale/en-US/_Goobstation/xenobio/slime.ftl
+++ b/Resources/Locale/en-US/_Goobstation/xenobio/slime.ftl
@@ -8,6 +8,8 @@ slime-latch-fail-already-latched = You can't latch to the {$ent}, it latched by 
 
 slime-latch-fail-max-entities = You cannot consume the {$ent}, you are full!
 
+slime-latch-fail-personal-shield = You cannot latch onto {$ent} — their personal shield blocks you!
+
 slime-eat-corpse-success = {THE($eater)} is trying to tear something away from {THE($target)}!
 
 slime-eat-corpse-fail-not-eatable = {THE($target)} don't look eatable.

--- a/Resources/Locale/uk-UA/_Goobstation/xenobio/slime.ftl
+++ b/Resources/Locale/uk-UA/_Goobstation/xenobio/slime.ftl
@@ -7,7 +7,7 @@ slime-examined-tamer = [color=green]Схоже, воно радіє вас ба�
 slime-interaction-tame = Схоже, тепер ви йому подобаєтеся!
 slime-interaction-tame-fail = Схоже, воно вами не цікавиться.
 slime-latch-fail-already-latched = Ви не можете вчепитися в {$ent}, у нього вже вчепився хтось інший!
-slime-latch-fail-personal-shield = Ви не можете вчепитися в {$ent} — активний ІПШ відбиває вас!
+slime-latch-fail-personal-shield = Ви не можете вчепитися в {$ent} — активний особистий щит відбиває вас!
 slime-eat-corpse-success = {THE($eater)} намагається відірвати щось від {THE($target)}!
 slime-eat-corpse-fail-not-eatable = {THE($target)} не здається їстівним.
 slime-eat-corpse-fail-not-dead = {THE($target)} має бути мертвим!

--- a/Resources/Locale/uk-UA/_Goobstation/xenobio/slime.ftl
+++ b/Resources/Locale/uk-UA/_Goobstation/xenobio/slime.ftl
@@ -7,6 +7,7 @@ slime-examined-tamer = [color=green]Схоже, воно радіє вас ба�
 slime-interaction-tame = Схоже, тепер ви йому подобаєтеся!
 slime-interaction-tame-fail = Схоже, воно вами не цікавиться.
 slime-latch-fail-already-latched = Ви не можете вчепитися в {$ent}, у нього вже вчепився хтось інший!
+slime-latch-fail-personal-shield = Ви не можете вчепитися в {$ent} — активний ІПШ відбиває вас!
 slime-eat-corpse-success = {THE($eater)} намагається відірвати щось від {THE($target)}!
 slime-eat-corpse-fail-not-eatable = {THE($target)} не здається їстівним.
 slime-eat-corpse-fail-not-dead = {THE($target)} має бути мертвим!


### PR DESCRIPTION
## Про запит на злиття
Слайми могли вчепитися в ціль з **активним особистим щитом** (Mono PersonalShield) і рости (hunger), майже не завдаючи шкоди. Тепер latch блокується, поки щит піднятий; якщо щит увімкнули вже під час latch — слайм злітає.

Примітка: **ІПШ у нас = раса IPC**, не цей щит. Цей PR про personal shield на хардсьютах.

Також підкручено флейковий `StrapLockRequiresActorAndHands…` (assert на Blunt замість TotalDamage), бо Unmapped CI падав через ambient damage за 3 тіки.

## Медіа
- [x] цей запит не потребує медіа / логіка

## Вимоги
- [x] Я прочитав та дотримуюсь правил PR
- [x] Я додав медіа, **АБО** цей запит не потребує медіа

:cl:
- fix: Слайми більше не можуть вчепитися в ціль з активним особистим щитом (і злітають, якщо щит увімкнули під час latch).

Made with [Cursor](https://cursor.com)