### PR TITLE
fix: IPC (ІПШ) можуть передавати предмети (OfferItem)

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -220,6 +220,7 @@
         - DoorBumpOpener
         - IPCDrinkBlacklist # Goobstation - Energycrit: Don't let self antagging IPCs steal power from other battery powered species.
     - type: Hands
+    - type: OfferItem # Pirate - IPCs inherit silicon base, not BaseMobSpecies
     - type: Inventory
       templateId: human
     - type: InventorySlots


### PR DESCRIPTION
## Про запит на злиття
**ІПШ = раса IPC.** У них не було `OfferItem`, бо `MobIPC` наслідує `PlayerSiliconHumanoidBase`, а не `BaseMobSpecies` (де лежить OfferItem для органіків). Через це не можна ні пропонувати предмети IPC, ні приймати від них.

## Медіа
- [x] цей запит не потребує медіа / логіка

## Вимоги
- [x] Я прочитав та дотримуюсь правил PR
- [x] Я додав медіа, **АБО** цей запит не потребує медіа

:cl:
- fix: IPC (ІПШ) знову можуть передавати й отримувати предмети через OfferItem.

Made with [Cursor](https://cursor.com)