### PR TITLE
fix: кури їдять, ефекти яєць на того хто їсть

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
@@ -392,7 +392,9 @@ public sealed partial class IngestionSystem : EntitySystem
             return;
 
         // Tell the food that it's time to die.
-        var finishedEv = new FullyEatenEvent(args.User);
+        // User must be the eater (entity), not the DoAfter actor — force-feeding otherwise
+        // applies FullyEaten handlers (e.g. ranching egg triggers) to the feeder.
+        var finishedEv = new FullyEatenEvent(entity);
         RaiseLocalEvent(food, ref finishedEv);
 
         var afterEatingEv = new AfterEatingEvent(food);// goob moth eating

--- a/Resources/Prototypes/_Pirate/Ranching/Body/chicken.yml
+++ b/Resources/Prototypes/_Pirate/Ranching/Body/chicken.yml
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Ranch chickens need both wheat/rice (special digestion) and normal botany produce.
+# Default ruminant stomach is exclusive and only accepts Ruminant/Wheat/BananaPeel tags.
+
+- type: entity
+  parent: OrganAnimalRuminantStomach
+  id: OrganChickenRanchStomach
+  name: chicken stomach
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Stomach
+    isSpecialDigestibleExclusive: false
+    specialDigestible:
+      tags:
+      - Ruminant
+      - Wheat
+      - BananaPeel
+
+- type: entity
+  parent: OrganChickenRanchStomach
+  id: OrganChickenRanchStomach2
+  name: chicken stomach 2
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Organ
+    slotId: stomach2
+
+- type: body
+  id: AnimalChickenRanch
+  name: chicken
+  root: chest
+  slots:
+    chest:
+      part: ChestAnimal
+      connections:
+      - groin
+      organs:
+        lungs: OrganAnimalLungs
+        heart: OrganAnimalHeart
+    groin:
+      part: GroinAnimal
+      connections:
+      - legs
+      organs:
+        stomach: OrganChickenRanchStomach
+        stomach2: OrganChickenRanchStomach2
+        liver: OrganAnimalLiver
+        kidneys: OrganAnimalKidneys
+    legs:
+      part: LegsAnimal
+      connections:
+      - feet
+    feet:
+      part: FeetAnimal

--- a/Resources/Prototypes/_Pirate/Ranching/Eggs/eggs.yml
+++ b/Resources/Prototypes/_Pirate/Ranching/Eggs/eggs.yml
@@ -489,7 +489,7 @@
       type: Add
     - !type:ModifyStatusEffect
       effectProto: DreamsicleEggEffect
-      time: 60
+      time: 15 # was 60 — Quicksilver-tier speed for a full minute was too strong
       type: Add
 
 - type: entity

--- a/Resources/Prototypes/_Pirate/Ranching/Entities/Mobs/chickens.yml
+++ b/Resources/Prototypes/_Pirate/Ranching/Entities/Mobs/chickens.yml
@@ -36,7 +36,7 @@
     rootTask:
       task: RuminantCompound
   - type: Body
-    prototype: AnimalRuminant
+    prototype: AnimalChickenRanch
   - type: Fixtures
     fixtures:
       fix1:
@@ -76,15 +76,17 @@
   - type: Unrevivable
   - type: ExaminableHunger
   - type: Hunger
+    # Dead must be 0: hunger is clamped to Dead, so Dead>0 freezes them in permanent starvation damage.
     thresholds:
-      Overfed: 100
-      Okay: 50
-      Peckish: 35
-      Starving: 20
-      Dead: 15
+      Overfed: 200
+      Okay: 150
+      Peckish: 100
+      Starving: 50
+      Dead: 0
+    baseDecayRate: 0.03
     starvationDamage:
       types:
-        Asphyxiation: 1
+        Asphyxiation: 0.25
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_Pirate/Ranching/StatusEffects/effects.yml
+++ b/Resources/Prototypes/_Pirate/Ranching/StatusEffects/effects.yml
@@ -105,8 +105,8 @@
     effects:
     - !type:Jitter
     - !type:MovementSpeedModifier
-      walkSpeedModifier: 4
-      sprintSpeedModifier: 4
+      walkSpeedModifier: 2.5 # was 4 — still fast, not Quicksilver for a minute
+      sprintSpeedModifier: 2.5
 
 - type: entity
   parent: MobStatusEffectBase


### PR DESCRIPTION
## Про запит на злиття
Кури з ранчингу в ботаніці відмовлялись їсти і швидко дохли: шлунок ruminant був exclusive (тільки wheat/rice), а `Hunger.Dead: 15` + clamp тримав їх у постійному starvation damage.

Також при годуванні яйцем іншого гравця ефект застосовувався на того, хто годує (`FullyEatenEvent` брав DoAfter user замість eater).

Окремо нерф яйця sickle/dreamsicle («ртуть» / Quicksilver): 60с ×4 швидкості → 15с ×2.5.

## Медіа
- [x] цей запит не потребує медіа / логіка

## Вимоги
- [x] Я прочитав та дотримуюсь правил PR
- [x] Я додав медіа, **АБО** цей запит не потребує медіа

:cl:
- fix: Кури ранчингу знову можуть їсти звичайну їжу з ботаніки і не дохнуть від багнутого голоду.
- fix: Ефекти ranching-яєць застосовуються до того, кого годують, а не до того, хто годує.
- balance: Dreamsicle/Sickle яйце — коротший і слабший баф швидкості.

Made with [Cursor](https://cursor.com)