### PR TITLE
atmoslinks

### DIFF
--- a/Content.Pirate.Client/AtmosLinks/AtmosLinkOverlay.cs
+++ b/Content.Pirate.Client/AtmosLinks/AtmosLinkOverlay.cs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Numerics;
+using Content.Client.Resources;
+using Content.Pirate.Shared.AtmosLinks;
+using Robust.Client.Graphics;
+using Robust.Client.ResourceManagement;
+using Robust.Client.UserInterface;
+using Robust.Shared.Enums;
+using Robust.Shared.Map;
+
+namespace Content.Pirate.Client.AtmosLinks;
+
+public sealed class AtmosLinkOverlay : Overlay
+{
+    [Dependency] private readonly IEntityManager _entManager = default!;
+    [Dependency] private readonly IEyeManager _eye = default!;
+    [Dependency] private readonly IResourceCache _cache = default!;
+    [Dependency] private readonly IUserInterfaceManager _ui = default!;
+
+    private readonly AtmosLinkOverlaySystem _system;
+    private readonly SharedTransformSystem _transform;
+    private readonly Font _font;
+
+    private const float OrphanBoxSize = 0.8f;
+    private const float SourceMarkerRadius = 0.15f;
+
+    private static readonly Color OrphanColor = Color.Red;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace | OverlaySpace.ScreenSpace;
+
+    public AtmosLinkOverlay(AtmosLinkOverlaySystem system)
+    {
+        IoCManager.InjectDependencies(this);
+
+        _system = system;
+        _transform = _entManager.System<SharedTransformSystem>();
+        _font = _cache.GetFont("/Fonts/NotoSans/NotoSans-Regular.ttf", 10);
+
+        ZIndex = 200;
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        if (args.Space == OverlaySpace.ScreenSpace)
+        {
+            args.ScreenHandle.SetTransform(Matrix3x2.Identity);
+            DrawLabels(args);
+            return;
+        }
+
+        var handle = args.WorldHandle;
+
+        // The placement ghost (ZIndex 100) draws its sprite through SpriteSystem, which leaves the
+        // cursor-positioned transform on the world handle. We draw after it (ZIndex 200), so without this
+        // reset every line and marker slides around with the mouse while something is being placed.
+        handle.SetTransform(Matrix3x2.Identity);
+
+        foreach (var group in _system.Groups)
+        {
+            if (!TryGetWorldPos(group.Source, args.MapId, out var source))
+                continue;
+
+            var color = GetLinkColor(group.Source);
+
+            foreach (var target in group.Targets)
+            {
+                if (!TryGetWorldPos(target, args.MapId, out var targetPos))
+                    continue;
+
+                handle.DrawLine(source, targetPos, color);
+            }
+
+            handle.DrawCircle(source, SourceMarkerRadius, color);
+        }
+
+        foreach (var orphan in _system.Orphans)
+        {
+            if (!TryGetWorldPos(orphan.Position, args.MapId, out var pos))
+                continue;
+
+            if (!args.WorldAABB.Contains(pos))
+                continue;
+
+            var box = Box2.CenteredAround(pos, new Vector2(OrphanBoxSize, OrphanBoxSize));
+            handle.DrawRect(box, OrphanColor.WithAlpha(0.25f));
+            handle.DrawRect(box, OrphanColor, false);
+
+            handle.DrawLine(box.BottomLeft, box.TopRight, OrphanColor);
+            handle.DrawLine(box.TopLeft, box.BottomRight, OrphanColor);
+        }
+    }
+
+    private void DrawLabels(in OverlayDrawArgs args)
+    {
+        var uiScale = _ui.RootControl.UIScale;
+        var offset = new Vector2(-10f, -14f) * uiScale;
+
+        foreach (var orphan in _system.Orphans)
+        {
+            if (!TryGetWorldPos(orphan.Position, args.MapId, out var pos))
+                continue;
+
+            if (!args.WorldAABB.Contains(pos))
+                continue;
+
+            var screen = _eye.WorldToScreen(pos).Rounded();
+            args.ScreenHandle.DrawString(_font, screen + offset, GetLabel(orphan.Kind), uiScale, GetKindColor(orphan.Kind));
+        }
+    }
+
+    private bool TryGetWorldPos(NetCoordinates netCoords, MapId mapId, out Vector2 world)
+    {
+        world = default;
+
+        var coords = _entManager.GetCoordinates(netCoords);
+        if (!coords.IsValid(_entManager))
+            return false;
+
+        var mapCoords = _transform.ToMapCoordinates(coords);
+        if (mapCoords.MapId != mapId)
+            return false;
+
+        world = mapCoords.Position;
+        return true;
+    }
+
+    /// <summary>
+    ///     Stable per-device-list color so the same alarm keeps its color across snapshot refreshes.
+    /// </summary>
+    private static Color GetLinkColor(NetCoordinates source)
+    {
+        var hue = (uint) source.GetHashCode() % 360 / 360f;
+        return Color.FromHsv(new Vector4(hue, 0.7f, 1f, 0.8f));
+    }
+
+    private static Color GetKindColor(AtmosLinkDeviceKind kind)
+    {
+        return kind switch
+        {
+            AtmosLinkDeviceKind.AirAlarm => Color.Orange,
+            AtmosLinkDeviceKind.FireAlarm => Color.OrangeRed,
+            AtmosLinkDeviceKind.Sensor => Color.Aquamarine,
+            AtmosLinkDeviceKind.Vent => Color.SkyBlue,
+            AtmosLinkDeviceKind.Scrubber => Color.LightGreen,
+            AtmosLinkDeviceKind.Firelock => Color.Yellow,
+            _ => Color.White,
+        };
+    }
+
+    private static string GetLabel(AtmosLinkDeviceKind kind)
+    {
+        return kind switch
+        {
+            AtmosLinkDeviceKind.AirAlarm => "ALARM",
+            AtmosLinkDeviceKind.FireAlarm => "FIRE",
+            AtmosLinkDeviceKind.Sensor => "SENSOR",
+            AtmosLinkDeviceKind.Vent => "VENT",
+            AtmosLinkDeviceKind.Scrubber => "SCRUB",
+            AtmosLinkDeviceKind.Firelock => "FLOCK",
+            _ => "ATMOS",
+        };
+    }
+}

--- a/Content.Pirate.Client/AtmosLinks/AtmosLinkOverlaySystem.cs
+++ b/Content.Pirate.Client/AtmosLinks/AtmosLinkOverlaySystem.cs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Pirate.Shared.AtmosLinks;
+using Robust.Client.Graphics;
+
+namespace Content.Pirate.Client.AtmosLinks;
+
+public sealed class AtmosLinkOverlaySystem : EntitySystem
+{
+    [Dependency] private readonly IOverlayManager _overlay = default!;
+
+    public List<AtmosLinkGroup> Groups = new();
+    public List<AtmosLinkOrphan> Orphans = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeNetworkEvent<AtmosLinkOverlayDataEvent>(OnData);
+        SubscribeNetworkEvent<AtmosLinkOverlayDisableEvent>(OnDisable);
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+
+        Clear();
+    }
+
+    private void OnData(AtmosLinkOverlayDataEvent ev)
+    {
+        Groups = ev.Groups;
+        Orphans = ev.Orphans;
+
+        if (!_overlay.HasOverlay<AtmosLinkOverlay>())
+            _overlay.AddOverlay(new AtmosLinkOverlay(this));
+    }
+
+    private void OnDisable(AtmosLinkOverlayDisableEvent ev)
+    {
+        Clear();
+    }
+
+    private void Clear()
+    {
+        Groups = new List<AtmosLinkGroup>();
+        Orphans = new List<AtmosLinkOrphan>();
+        _overlay.RemoveOverlay<AtmosLinkOverlay>();
+    }
+}

--- a/Content.Pirate.Server/AtmosLinks/AtmosLinkOverlaySystem.cs
+++ b/Content.Pirate.Server/AtmosLinks/AtmosLinkOverlaySystem.cs
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Globalization;
+using Content.Server.Atmos.Monitor.Components;
+using Content.Server.Atmos.Piping.Unary.Components;
+using Content.Server.DeviceNetwork.Systems;
+using Content.Pirate.Shared.AtmosLinks;
+using Content.Shared.Atmos.Components;
+using Content.Shared.Doors.Components;
+using Content.Shared.DeviceNetwork.Components;
+using Robust.Server.Player;
+using Robust.Shared.Enums;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+
+namespace Content.Pirate.Server.AtmosLinks;
+
+public sealed class AtmosLinkOverlaySystem : EntitySystem
+{
+    [Dependency] private readonly IPlayerManager _players = default!;
+    [Dependency] private readonly DeviceListSystem _deviceList = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private const float UpdateInterval = 1f;
+
+    private float _accumulator;
+
+    private readonly Dictionary<ICommonSession, AtmosLinkOverlayOptions> _observers = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _players.PlayerStatusChanged += OnPlayerStatusChanged;
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+
+        _players.PlayerStatusChanged -= OnPlayerStatusChanged;
+        _observers.Clear();
+    }
+
+    private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs args)
+    {
+        if (args.NewStatus != SessionStatus.Disconnected)
+            return;
+
+        _observers.Remove(args.Session);
+    }
+
+    public bool IsEnabled(ICommonSession session)
+    {
+        return _observers.ContainsKey(session);
+    }
+
+    public AtmosLinkReport Enable(ICommonSession session, AtmosLinkOverlayOptions options)
+    {
+        _observers[session] = options;
+        return SendTo(session, options);
+    }
+
+    public void Disable(ICommonSession session)
+    {
+        if (_observers.Remove(session))
+            RaiseNetworkEvent(new AtmosLinkOverlayDisableEvent(), session.Channel);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_observers.Count == 0)
+            return;
+
+        _accumulator += frameTime;
+        if (_accumulator < UpdateInterval)
+            return;
+
+        _accumulator = 0f;
+
+        foreach (var (session, options) in _observers)
+        {
+            SendTo(session, options);
+        }
+    }
+
+    private AtmosLinkReport SendTo(ICommonSession session, AtmosLinkOverlayOptions options)
+    {
+        MapId? map = null;
+        if (!options.AllMaps)
+            map = GetSessionMap(session);
+
+        var report = BuildReport(map);
+        RaiseNetworkEvent(new AtmosLinkOverlayDataEvent(report.Groups, report.Orphans), session.Channel);
+        return report;
+    }
+
+    private MapId? GetSessionMap(ICommonSession session)
+    {
+        if (session.AttachedEntity is not { } player || !TryComp<TransformComponent>(player, out var xform))
+            return null;
+
+        return xform.MapID == MapId.Nullspace ? null : xform.MapID;
+    }
+
+    public AtmosLinkReport BuildReport(MapId? map)
+    {
+        var report = new AtmosLinkReport();
+
+        // Reverse index of every device list in the world, not just the ones on this map, so a device linked
+        // from another grid doesn't get reported as unlinked.
+        var linked = new HashSet<EntityUid>();
+        var listQuery = AllEntityQuery<DeviceListComponent>();
+        while (listQuery.MoveNext(out var listUid, out var listComp))
+        {
+            foreach (var device in _deviceList.GetAllDevices(listUid, listComp))
+            {
+                linked.Add(device);
+            }
+        }
+
+        var query = AllEntityQuery<DeviceNetworkComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var netComp, out var xform))
+        {
+            if (netComp.NetIdEnum != DeviceNetworkComponent.DeviceNetIdDefaults.AtmosDevices)
+                continue;
+
+            if (map != null && xform.MapID != map.Value)
+                continue;
+
+            if (xform.MapID == MapId.Nullspace)
+                continue;
+
+            var kind = GetKind(uid);
+
+            // Everything else on this net can't be linked to an alarm at all: SMES, thermomachines
+            // (freezer/heater/hellfire), volumetric pumps, pipe sensors, the TEG and the atmos monitoring
+            // console. Reporting those as "unlinked" would just bury the devices that matter.
+            if (kind == AtmosLinkDeviceKind.Other)
+                continue;
+
+            report.DeviceCount++;
+
+            var coords = GetNetCoordinates(xform.Coordinates);
+
+            if (TryComp<DeviceListComponent>(uid, out var list))
+            {
+                var targets = new List<NetCoordinates>();
+
+                foreach (var device in _deviceList.GetAllDevices(uid, list))
+                {
+                    if (Deleted(device) || !TryComp<TransformComponent>(device, out var deviceXform))
+                    {
+                        report.Dangling.Add($"{ToPrettyString(uid)} links to a deleted entity ({device})");
+                        continue;
+                    }
+
+                    targets.Add(GetNetCoordinates(deviceXform.Coordinates));
+
+                    // The state that "synchronizedevicelists" repairs: the list knows about the device but the
+                    // device doesn't know about the list, so it silently drops out on the next list update.
+                    if (!TryComp<DeviceNetworkComponent>(device, out var deviceNet)
+                        || !deviceNet.DeviceLists.Contains(uid))
+                    {
+                        report.Desynced.Add($"{ToPrettyString(device)} is in {ToPrettyString(uid)} but doesn't know it");
+                    }
+                }
+
+                report.LinkCount += targets.Count;
+
+                if (targets.Count > 0)
+                    report.Groups.Add(new AtmosLinkGroup(coords, kind, targets));
+                else
+                    AddOrphan(report, uid, xform, coords, kind);
+
+                continue;
+            }
+
+            if (!linked.Contains(uid))
+                AddOrphan(report, uid, xform, coords, kind);
+        }
+
+        return report;
+    }
+
+    private void AddOrphan(AtmosLinkReport report,
+        EntityUid uid,
+        TransformComponent xform,
+        NetCoordinates coords,
+        AtmosLinkDeviceKind kind)
+    {
+        report.Orphans.Add(new AtmosLinkOrphan(coords, kind));
+
+        var mapCoords = _transform.GetMapCoordinates(uid, xform);
+
+        // Invariant so the "tp" line stays copy-pasteable into the console on locales that would
+        // otherwise print "23,5".
+        var x = mapCoords.X.ToString("F1", CultureInfo.InvariantCulture);
+        var y = mapCoords.Y.ToString("F1", CultureInfo.InvariantCulture);
+
+        report.OrphanLines.Add($"{ToPrettyString(uid)} - tp {x} {y} {(int) mapCoords.MapId}");
+    }
+
+    private AtmosLinkDeviceKind GetKind(EntityUid uid)
+    {
+        if (HasComp<AirAlarmComponent>(uid))
+            return AtmosLinkDeviceKind.AirAlarm;
+
+        if (HasComp<FireAlarmComponent>(uid))
+            return AtmosLinkDeviceKind.FireAlarm;
+
+        if (HasComp<GasVentPumpComponent>(uid))
+            return AtmosLinkDeviceKind.Vent;
+
+        if (HasComp<GasVentScrubberComponent>(uid))
+            return AtmosLinkDeviceKind.Scrubber;
+
+        if (HasComp<FirelockComponent>(uid))
+            return AtmosLinkDeviceKind.Firelock;
+
+        // Pipe sensors carry an AtmosMonitor just like a room air sensor, but they feed the atmos
+        // monitoring console instead of an alarm, so they must not be mistaken for one.
+        if (HasComp<GasPipeSensorComponent>(uid))
+            return AtmosLinkDeviceKind.Other;
+
+        if (HasComp<AtmosMonitorComponent>(uid))
+            return AtmosLinkDeviceKind.Sensor;
+
+        return AtmosLinkDeviceKind.Other;
+    }
+}
+
+public sealed class AtmosLinkReport
+{
+    public readonly List<AtmosLinkGroup> Groups = new();
+    public readonly List<AtmosLinkOrphan> Orphans = new();
+
+    public readonly List<string> OrphanLines = new();
+
+    public readonly List<string> Dangling = new();
+
+    public readonly List<string> Desynced = new();
+
+    public int DeviceCount;
+    public int LinkCount;
+}
+
+public struct AtmosLinkOverlayOptions
+{
+    public bool AllMaps;
+}

--- a/Content.Pirate.Server/AtmosLinks/AtmosLinkOverlaySystem.cs
+++ b/Content.Pirate.Server/AtmosLinks/AtmosLinkOverlaySystem.cs
@@ -55,10 +55,15 @@ public sealed class AtmosLinkOverlaySystem : EntitySystem
         return _observers.ContainsKey(session);
     }
 
-    public AtmosLinkReport Enable(ICommonSession session, AtmosLinkOverlayOptions options)
+    // Null when the session isn't on a map and didn't ask for every map; the overlay stays off.
+    public AtmosLinkReport? Enable(ICommonSession session, AtmosLinkOverlayOptions options)
     {
+        var report = SendTo(session, options);
+        if (report == null)
+            return null;
+
         _observers[session] = options;
-        return SendTo(session, options);
+        return report;
     }
 
     public void Disable(ICommonSession session)
@@ -86,23 +91,33 @@ public sealed class AtmosLinkOverlaySystem : EntitySystem
         }
     }
 
-    private AtmosLinkReport SendTo(ICommonSession session, AtmosLinkOverlayOptions options)
+    private AtmosLinkReport? SendTo(ICommonSession session, AtmosLinkOverlayOptions options)
     {
         MapId? map = null;
         if (!options.AllMaps)
-            map = GetSessionMap(session);
+        {
+            // BuildReport reads a null map as "every map", so a mapless session is refused here instead of
+            // silently widening the scan to the whole server.
+            if (!TryGetSessionMap(session, out var sessionMap))
+                return null;
+
+            map = sessionMap;
+        }
 
         var report = BuildReport(map);
         RaiseNetworkEvent(new AtmosLinkOverlayDataEvent(report.Groups, report.Orphans), session.Channel);
         return report;
     }
 
-    private MapId? GetSessionMap(ICommonSession session)
+    private bool TryGetSessionMap(ICommonSession session, out MapId map)
     {
-        if (session.AttachedEntity is not { } player || !TryComp<TransformComponent>(player, out var xform))
-            return null;
+        map = MapId.Nullspace;
 
-        return xform.MapID == MapId.Nullspace ? null : xform.MapID;
+        if (session.AttachedEntity is not { } player || !TryComp<TransformComponent>(player, out var xform))
+            return false;
+
+        map = xform.MapID;
+        return map != MapId.Nullspace;
     }
 
     public AtmosLinkReport BuildReport(MapId? map)
@@ -112,12 +127,14 @@ public sealed class AtmosLinkOverlaySystem : EntitySystem
         // Reverse index of every device list in the world, not just the ones on this map, so a device linked
         // from another grid doesn't get reported as unlinked.
         var linked = new HashSet<EntityUid>();
+        var listed = new HashSet<(EntityUid List, EntityUid Device)>();
         var listQuery = AllEntityQuery<DeviceListComponent>();
         while (listQuery.MoveNext(out var listUid, out var listComp))
         {
             foreach (var device in _deviceList.GetAllDevices(listUid, listComp))
             {
                 linked.Add(device);
+                listed.Add((listUid, device));
             }
         }
 
@@ -144,6 +161,25 @@ public sealed class AtmosLinkOverlaySystem : EntitySystem
             report.DeviceCount++;
 
             var coords = GetNetCoordinates(xform.Coordinates);
+
+            // Mirror of the check further down: the device claims a list that doesn't hold it.
+            // "synchronizedevicelists" only fills in missing back-references, so this direction gets its own
+            // wording - it needs a re-link to clear.
+            foreach (var deviceList in netComp.DeviceLists)
+            {
+                if (Deleted(deviceList))
+                {
+                    report.Desynced.Add(
+                        $"{ToPrettyString(uid)} still points at a deleted device list ({deviceList})");
+                    continue;
+                }
+
+                if (!listed.Contains((deviceList, uid)))
+                {
+                    report.Desynced.Add(
+                        $"{ToPrettyString(uid)} thinks it is in {ToPrettyString(deviceList)}, which doesn't list it");
+                }
+            }
 
             if (TryComp<DeviceListComponent>(uid, out var list))
             {

--- a/Content.Pirate.Server/AtmosLinks/AtmosLinksCommand.cs
+++ b/Content.Pirate.Server/AtmosLinks/AtmosLinksCommand.cs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Pirate.Server.AtmosLinks;
+
+[AdminCommand(AdminFlags.Mapping)]
+public sealed class AtmosLinksCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly AtmosLinkOverlaySystem _atmosLinks = default!;
+
+    private const int MaxListed = 50;
+
+    public override string Command => "atmoslinks";
+
+    public override string Description =>
+        "Shows atmos device links (air alarms, fire alarms) and highlights atmos devices that are linked to nothing.";
+
+    public override string Help =>
+        "atmoslinks [on|off|toggle] [allmaps] - allmaps: every map instead of just the one you're on.";
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        return args.Length switch
+        {
+            1 => CompletionResult.FromHintOptions(["toggle", "on", "off"], "on/off/toggle"),
+            2 => CompletionResult.FromHintOptions(["allmaps"], "allmaps"),
+            _ => CompletionResult.Empty,
+        };
+    }
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (shell.Player is not { } player)
+        {
+            shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
+            return;
+        }
+
+        if (args.Length > 2)
+        {
+            shell.WriteLine(Help);
+            return;
+        }
+
+        var mode = args.Length > 0 ? args[0].ToLowerInvariant() : "toggle";
+        var options = new AtmosLinkOverlayOptions();
+
+        for (var i = 1; i < args.Length; i++)
+        {
+            switch (args[i].ToLowerInvariant())
+            {
+                case "allmaps":
+                case "all":
+                    options.AllMaps = true;
+                    break;
+                default:
+                    shell.WriteLine(Help);
+                    return;
+            }
+        }
+
+        bool enable;
+        switch (mode)
+        {
+            case "on":
+            case "true":
+            case "1":
+                enable = true;
+                break;
+            case "off":
+            case "false":
+            case "0":
+                enable = false;
+                break;
+            case "toggle":
+                enable = !_atmosLinks.IsEnabled(player);
+                break;
+            default:
+                shell.WriteLine(Help);
+                return;
+        }
+
+        if (!enable)
+        {
+            _atmosLinks.Disable(player);
+            shell.WriteLine("Atmos link overlay disabled.");
+            return;
+        }
+
+        var report = _atmosLinks.Enable(player, options);
+
+        shell.WriteLine(options.AllMaps
+            ? "Atmos link overlay enabled for all maps."
+            : "Atmos link overlay enabled for the map you're on.");
+        shell.WriteLine(
+            $"{report.DeviceCount} atmos devices, {report.Groups.Count} device lists, {report.LinkCount} links.");
+
+        if (report.Orphans.Count == 0)
+        {
+            shell.WriteLine("Every atmos device is linked.");
+        }
+        else
+        {
+            shell.WriteLine($"{report.Orphans.Count} device(s) linked to nothing (red boxes in game):");
+            WriteCapped(shell, report.OrphanLines);
+        }
+
+        if (report.Dangling.Count > 0)
+        {
+            shell.WriteError($"{report.Dangling.Count} link(s) point at deleted entities:");
+            WriteCapped(shell, report.Dangling);
+        }
+
+        if (report.Desynced.Count > 0)
+        {
+            shell.WriteError(
+                $"{report.Desynced.Count} device(s) are missing their back-reference, run \"synchronizedevicelists\" to fix:");
+            WriteCapped(shell, report.Desynced);
+        }
+    }
+
+    private void WriteCapped(IConsoleShell shell, List<string> lines)
+    {
+        for (var i = 0; i < lines.Count && i < MaxListed; i++)
+        {
+            shell.WriteLine($"  {lines[i]}");
+        }
+
+        if (lines.Count > MaxListed)
+            shell.WriteLine($"  ... and {lines.Count - MaxListed} more.");
+    }
+}

--- a/Content.Pirate.Server/AtmosLinks/AtmosLinksCommand.cs
+++ b/Content.Pirate.Server/AtmosLinks/AtmosLinksCommand.cs
@@ -25,7 +25,7 @@ public sealed class AtmosLinksCommand : LocalizedEntityCommands
     {
         return args.Length switch
         {
-            1 => CompletionResult.FromHintOptions(["toggle", "on", "off"], "on/off/toggle"),
+            1 => CompletionResult.FromHintOptions(["toggle", "on", "off", "allmaps"], "on/off/toggle, allmaps"),
             2 => CompletionResult.FromHintOptions(["allmaps"], "allmaps"),
             _ => CompletionResult.Empty,
         };
@@ -45,13 +45,27 @@ public sealed class AtmosLinksCommand : LocalizedEntityCommands
             return;
         }
 
-        var mode = args.Length > 0 ? args[0].ToLowerInvariant() : "toggle";
+        // Mode and flag may come in either order, and "atmoslinks allmaps" on its own still toggles.
+        var mode = AtmosLinksMode.Toggle;
         var options = new AtmosLinkOverlayOptions();
 
-        for (var i = 1; i < args.Length; i++)
+        foreach (var arg in args)
         {
-            switch (args[i].ToLowerInvariant())
+            switch (arg.ToLowerInvariant())
             {
+                case "on":
+                case "true":
+                case "1":
+                    mode = AtmosLinksMode.On;
+                    break;
+                case "off":
+                case "false":
+                case "0":
+                    mode = AtmosLinksMode.Off;
+                    break;
+                case "toggle":
+                    mode = AtmosLinksMode.Toggle;
+                    break;
                 case "allmaps":
                 case "all":
                     options.AllMaps = true;
@@ -62,26 +76,12 @@ public sealed class AtmosLinksCommand : LocalizedEntityCommands
             }
         }
 
-        bool enable;
-        switch (mode)
+        var enable = mode switch
         {
-            case "on":
-            case "true":
-            case "1":
-                enable = true;
-                break;
-            case "off":
-            case "false":
-            case "0":
-                enable = false;
-                break;
-            case "toggle":
-                enable = !_atmosLinks.IsEnabled(player);
-                break;
-            default:
-                shell.WriteLine(Help);
-                return;
-        }
+            AtmosLinksMode.On => true,
+            AtmosLinksMode.Off => false,
+            _ => !_atmosLinks.IsEnabled(player),
+        };
 
         if (!enable)
         {
@@ -91,6 +91,13 @@ public sealed class AtmosLinksCommand : LocalizedEntityCommands
         }
 
         var report = _atmosLinks.Enable(player, options);
+
+        if (report == null)
+        {
+            shell.WriteError("You aren't on a map, so there is nothing to scan. Teleport to one first, "
+                + "or use \"atmoslinks on allmaps\".");
+            return;
+        }
 
         shell.WriteLine(options.AllMaps
             ? "Atmos link overlay enabled for all maps."
@@ -116,10 +123,17 @@ public sealed class AtmosLinksCommand : LocalizedEntityCommands
 
         if (report.Desynced.Count > 0)
         {
-            shell.WriteError(
-                $"{report.Desynced.Count} device(s) are missing their back-reference, run \"synchronizedevicelists\" to fix:");
+            shell.WriteError($"{report.Desynced.Count} list/device mismatch(es) - \"synchronizedevicelists\" "
+                + "repairs missing back-references, the ones pointing the other way need a re-link:");
             WriteCapped(shell, report.Desynced);
         }
+    }
+
+    private enum AtmosLinksMode : byte
+    {
+        Toggle,
+        On,
+        Off,
     }
 
     private void WriteCapped(IConsoleShell shell, List<string> lines)


### PR DESCRIPTION
## Медіа
На прикладі БоксТП
<img width="1987" height="1346" alt="image" src="https://github.com/user-attachments/assets/acae72a6-10e8-4822-b7c8-95e3245a97da" />
На прикладі МетаТП
<img width="1498" height="1117" alt="image" src="https://github.com/user-attachments/assets/b67a4c1a-67d9-468c-bbbc-1fd054bcbcd3" />


**Журнал змін**

:cl:
- add: команда маперам atmoslinks для пошуку атмосферних пристроїв, які не підв'язані ні до чого, або підв'язані в односторонньому порядку (фікситься існуючою командою synchronizedevicelists), під час юзу в консолі виводиться список проблемних структур та їх координати


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Нові можливості**
  - Додано адміністративну команду `atmoslinks` для ввімкнення, вимкнення або перемикання оверлею атмосферних зв’язків.
  - Оверлей відображає зв’язки між атмосферними пристроями, джерела та непідключені пристрої з кольоровими позначками.
  - Доступний режим перегляду зв’язків на всіх картах.
  - Команда формує звіт із кількістю пристроїв і зв’язків, а також попередженнями про непідключені, видалені або розсинхронізовані елементи.

- **Виправлення**
  - Координати у звітах мають стабільний формат незалежно від локалі.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->